### PR TITLE
Add movement of intersecting soil cells from the terrain

### DIFF
--- a/docs/_api/intersecting_cells.rst
+++ b/docs/_api/intersecting_cells.rst
@@ -1,0 +1,5 @@
+intersecting_cells: Doxygen documentation
+=========================================
+
+.. autodoxygenfile:: intersecting_cells.hpp
+    :project: soil_simulator

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -13,4 +13,5 @@ A doxygen documentation is available for all the files of the simulator.
    types <_api/types>
    bucket_pos <_api/bucket_pos>
    body_soil <_api/body_soil>
+   intersecting_cells <_api/intersecting_cells>
    utils <_api/utils>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,10 @@ breathe_projects_source = {
         "types.cpp",
         "bucket_pos.hpp",
         "bucket_pos.cpp",
+        "body_soil.hpp",
+        "body_soil.cpp",
+        "intersecting_cells.hpp",
+        "intersecting_cells.cpp",
         "utils.hpp",
         "utils.cpp"])
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,8 @@ target_sources(soil_dynamics
         ${CMAKE_CURRENT_SOURCE_DIR}/bucket_pos.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/body_soil.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/body_soil.hpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/intersecting_cells.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/intersecting_cells.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/utils.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/utils.hpp
 )

--- a/src/intersecting_cells.cpp
+++ b/src/intersecting_cells.cpp
@@ -66,7 +66,13 @@ void soil_simulator::MoveIntersectingBody(SimOut* sim_out, float tol
         }
 
         // Randomizing direction to avoid asymmetry
-        std::random_shuffle(directions.begin(), directions.end());
+        // random_suffle is not used because it is machine dependent,
+        // which makes unit testing difficult
+        for (int ii = directions.size() - 1; ii > 0; ii--) {
+            std::uniform_int_distribution<int> dist(0, ii);
+            int jj = dist(rng);
+            std::swap(directions[ii], directions[jj]);
+        }
 
         // Calculating vertical extension of intersecting soil column
         float h_soil = sim_out->terrain_[ii][jj] - sim_out->body_[ind][ii][jj];

--- a/src/intersecting_cells.cpp
+++ b/src/intersecting_cells.cpp
@@ -7,6 +7,7 @@ Copyright, 2023, Vilella Kenny.
 #include <iostream>
 #include <random>
 #include <tuple>
+#include <utility>
 #include <vector>
 #include "src/types.hpp"
 #include "src/intersecting_cells.hpp"

--- a/src/intersecting_cells.cpp
+++ b/src/intersecting_cells.cpp
@@ -24,6 +24,20 @@ void soil_simulator::MoveIntersectingBodySoil(SimOut* sim_out, float tol
 ) {
 }
 
+/// This function checks the eight lateral directions surrounding the
+/// intersecting soil column and moves the soil to available spaces. If there is
+/// insufficient space for all the soil, it incrementally checks the eight
+/// directions farther from the intersecting soil column until all the soil has
+/// been moved. The process can be illustrated as follows
+///
+///                 ↖   ↑   ↗
+///                   ↖ ↑ ↗
+///                 ← ← O → →
+///                   ↙ ↓ ↘
+///                 ↙   ↓   ↘
+///
+/// Note that the order in which the directions are checked is randomized in
+/// order to avoid asymmetrical results.
 void soil_simulator::MoveIntersectingBody(SimOut* sim_out, float tol
 ) {
     // Locating soil cells intersecting with the bucket

--- a/src/intersecting_cells.cpp
+++ b/src/intersecting_cells.cpp
@@ -1,0 +1,39 @@
+/*
+This file implements the functions used to move the intersecting soil cells.
+
+Copyright, 2023, Vilella Kenny.
+*/
+#include <iostream>
+#include <tuple>
+#include <vector>
+#include "src/types.hpp"
+#include "src/intersecting_cells.hpp"
+
+void soil_simulator::MoveIntersectingCells(SimOut* sim_out, float tol) {
+    // Moving bucket soil intersecting with the bucket
+    soil_simulator::MoveIntersectingBodySoil!(sim_out, tol);
+
+    // Moving terrain intersecting with the bucket
+    soil_simulator::MoveIntersectingBody!(sim_out, tol);
+}
+
+void soil_simulator::MoveIntersectingBodySoil(SimOut* sim_out, float tol) {
+
+}
+
+void soil_simulator::MoveIntersectingBody(SimOut* sim_out, float tol) {
+
+}
+
+std::tuple<int, int, int, float, bool> soil_simulator::MoveBodySoil(
+    SimOut* sim_out, int ind_p, int ii_p, int jj_p, float max_h, int ii_n,
+    int jj_n, float h_soil, bool wall_presence, float tol) {
+
+}
+
+std::vector<std::vector<int>> soil_simulator::LocateIntersectingCells(
+    SimOut* sim_out, float tol) {
+
+}
+
+

--- a/src/intersecting_cells.cpp
+++ b/src/intersecting_cells.cpp
@@ -3,7 +3,9 @@ This file implements the functions used to move the intersecting soil cells.
 
 Copyright, 2023, Vilella Kenny.
 */
+#include <algorithm>
 #include <iostream>
+#include <random>
 #include <tuple>
 #include <vector>
 #include "src/types.hpp"
@@ -24,6 +26,97 @@ void soil_simulator::MoveIntersectingBodySoil(SimOut* sim_out, float tol
 
 void soil_simulator::MoveIntersectingBody(SimOut* sim_out, float tol
 ) {
+    // Locating soil cells intersecting with the bucket
+    auto intersecting_cells = soil_simulator::LocateIntersectingCells(
+        sim_out, tol);
+
+    if (intersecting_cells.size() == 0) {
+        // No intersecting cells
+        return;
+    }
+
+    // Storing all possible directions
+    std::vector<std::vector<int>> directions = {
+        {1, 0}, {-1, 0}, {0, 1}, {0, -1},
+        {1, 1}, {1, -1}, {-1, 1}, {-1, -1}};
+
+    // Iterating over intersecting cells
+    for (auto nn = 0; nn < intersecting_cells.size(); nn++) {
+        int ind = intersecting_cells[nn][0];
+        int ii = intersecting_cells[nn][1];
+        int jj = intersecting_cells[nn][2];
+
+        if (sim_out->terrain_[ii][jj] - tol < sim_out->body_[ind][ii][jj]) {
+            // Intersecting soil column has already been moved
+            continue;
+        }
+
+        // Randomizing direction to avoid asymmetry
+        std::random_shuffle(directions.begin(), directions.end());
+
+        // Calculating vertical extension of intersecting soil column
+        float h_soil = sim_out->terrain_[ii][jj] - sim_out->body_[ind][ii][jj];
+
+        int pp = 0;
+        // Investigating farther and farther until all the soil has been moved
+        while (h_soil > tol) {
+            pp += 1;
+            // Iterating over the eight lateral directions
+            for (auto xy = 0; xy < directions.size(); xy++) {
+                // Calculating considered position
+                int ii_p = ii + directions[xy][0] * pp;
+                int jj_p = jj + directions[xy][1] * pp;
+
+                // Determining presence of bucket
+                bool bucket_absence_1 = (
+                    (sim_out->body_[0][ii_p][jj_p] == 0.0) &&
+                    (sim_out->body_[1][ii_p][jj_p] == 0.0));
+                bool bucket_absence_3 = (
+                    (sim_out->body_[2][ii_p][jj_p] == 0.0) &&
+                    (sim_out->body_[3][ii_p][jj_p] == 0.0));
+
+                if (bucket_absence_1 && bucket_absence_3) {
+                    // No bucket
+                    sim_out->terrain_[ii_p][jj_p] += h_soil;
+                    h_soil = 0.0;
+                    break;
+                } else {
+                    // Bucket is present
+                    // Calculating minimum height of bucket
+                    float bucket_bot;
+                    if (bucket_absence_1)
+                        bucket_bot = sim_out->body_[2][ii_p][jj_p];
+                    else if (bucket_absence_3)
+                        bucket_bot = sim_out->body_[0][ii_p][jj_p];
+                    else
+                        bucket_bot = std::min(
+                            sim_out->body_[0][ii_p][jj_p],
+                            sim_out->body_[2][ii_p][jj_p]);
+
+                    if (sim_out->terrain_[ii_p][jj_p] + tol < bucket_bot) {
+                        // Space under the bucket
+                        // Calculating available space
+                        float delta_h = (
+                            bucket_bot - sim_out->terrain_[ii_p][jj_p]);
+
+                        if (delta_h < h_soil) {
+                            // Not enough space
+                            sim_out->terrain_[ii_p][jj_p] = bucket_bot;
+                            h_soil -= delta_h;
+                        } else {
+                            // More space than soil
+                            sim_out->terrain_[ii_p][jj_p] += h_soil;
+                            h_soil = 0.0;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Removing intersecting soil
+        sim_out->terrain_[ii][jj] = sim_out->body_[ind][ii][jj];
+    }
 }
 
 std::tuple<int, int, int, float, bool> soil_simulator::MoveBodySoil(
@@ -40,8 +133,12 @@ std::vector<std::vector<int>> soil_simulator::LocateIntersectingCells(
     std::vector<std::vector<int>> intersecting_cells;
 
     // Iterating over all bucket position
-    for (auto ii = sim_out->bucket_area_[0][0]; ii < sim_out->bucket_area_[0][1]; ii++)
-        for (auto jj = sim_out->bucket_area_[1][0]; jj < sim_out->bucket_area_[1][1]; jj++) {
+    for (auto ii = sim_out->bucket_area_[0][0];
+        ii < sim_out->bucket_area_[0][1]; ii++
+    )
+        for (auto jj = sim_out->bucket_area_[1][0];
+            jj < sim_out->bucket_area_[1][1]; jj++
+        ) {
             if (
                ((sim_out->body_[0][ii][jj] != 0.0) ||
                (sim_out->body_[1][ii][jj] != 0.0)) &&

--- a/src/intersecting_cells.cpp
+++ b/src/intersecting_cells.cpp
@@ -9,31 +9,54 @@ Copyright, 2023, Vilella Kenny.
 #include "src/types.hpp"
 #include "src/intersecting_cells.hpp"
 
-void soil_simulator::MoveIntersectingCells(SimOut* sim_out, float tol) {
+void soil_simulator::MoveIntersectingCells(SimOut* sim_out, float tol
+) {
     // Moving bucket soil intersecting with the bucket
-    soil_simulator::MoveIntersectingBodySoil!(sim_out, tol);
+    soil_simulator::MoveIntersectingBodySoil(sim_out, tol);
 
     // Moving terrain intersecting with the bucket
-    soil_simulator::MoveIntersectingBody!(sim_out, tol);
+    soil_simulator::MoveIntersectingBody(sim_out, tol);
 }
 
-void soil_simulator::MoveIntersectingBodySoil(SimOut* sim_out, float tol) {
-
+void soil_simulator::MoveIntersectingBodySoil(SimOut* sim_out, float tol
+) {
 }
 
-void soil_simulator::MoveIntersectingBody(SimOut* sim_out, float tol) {
-
+void soil_simulator::MoveIntersectingBody(SimOut* sim_out, float tol
+) {
 }
 
 std::tuple<int, int, int, float, bool> soil_simulator::MoveBodySoil(
     SimOut* sim_out, int ind_p, int ii_p, int jj_p, float max_h, int ii_n,
-    int jj_n, float h_soil, bool wall_presence, float tol) {
-
+    int jj_n, float h_soil, bool wall_presence, float tol
+) {
+    return {1, 1, 1, 0.0, true};
 }
 
 std::vector<std::vector<int>> soil_simulator::LocateIntersectingCells(
-    SimOut* sim_out, float tol) {
+    SimOut* sim_out, float tol
+) {
+    // Initializing
+    std::vector<std::vector<int>> intersecting_cells;
 
+    // Iterating over all bucket position
+    for (auto ii = sim_out->bucket_area_[0][0]; ii < sim_out->bucket_area_[0][1]; ii++)
+        for (auto jj = sim_out->bucket_area_[1][0]; jj < sim_out->bucket_area_[1][1]; jj++) {
+            if (
+               ((sim_out->body_[0][ii][jj] != 0.0) ||
+               (sim_out->body_[1][ii][jj] != 0.0)) &&
+               (sim_out->terrain_[ii][jj] - tol > sim_out->body_[0][ii][jj])) {
+                // Soil intersecting with the bucket
+                intersecting_cells.push_back(std::vector<int> {0, ii, jj});
+            }
+            if (
+               ((sim_out->body_[2][ii][jj] != 0.0) ||
+               (sim_out->body_[3][ii][jj] != 0.0)) &&
+                (sim_out->terrain_[ii][jj] - tol > sim_out->body_[2][ii][jj])) {
+                // Soil intersecting with the bucket
+                intersecting_cells.push_back(std::vector<int> {2, ii, jj});
+            }
+        }
+
+    return intersecting_cells;
 }
-
-

--- a/src/intersecting_cells.hpp
+++ b/src/intersecting_cells.hpp
@@ -1,0 +1,27 @@
+/*
+This file declares the functions used to move the intersecting soil cells.
+
+Copyright, 2023, Vilella Kenny.
+*/
+#pragma once
+
+#include <tuple>
+#include <vector>
+#include "src/types.hpp"
+
+namespace soil_simulator {
+
+void MoveIntersectingCells(SimOut* sim_out, float tol);
+
+void MoveIntersectingBodySoil(SimOut* sim_out, float tol);
+
+void MoveIntersectingBody(SimOut* sim_out, float tol);
+
+std::tuple<int, int, int, float, bool> MoveBodySoil(
+    SimOut* sim_out, int ind_p, int ii_p, int jj_p, float max_h, int ii_n,
+    int jj_n, float h_soil, bool wall_presence, float tol);
+
+std::vector<std::vector<int>> LocateIntersectingCells(
+    SimOut* sim_out, float tol);
+
+}  // namespace soil_simulator

--- a/src/intersecting_cells.hpp
+++ b/src/intersecting_cells.hpp
@@ -5,9 +5,13 @@ Copyright, 2023, Vilella Kenny.
 */
 #pragma once
 
+#include <random>
 #include <tuple>
 #include <vector>
 #include "src/types.hpp"
+
+// Setting RNG
+std::mt19937 rng;
 
 namespace soil_simulator {
 

--- a/src/intersecting_cells.hpp
+++ b/src/intersecting_cells.hpp
@@ -15,12 +15,22 @@ void MoveIntersectingCells(SimOut* sim_out, float tol);
 
 void MoveIntersectingBodySoil(SimOut* sim_out, float tol);
 
+/// \brief This function moves the soil cells in the `terrain_` that intersect
+///        with a bucket.
+///
+/// \param sim_out: Class that stores simulation outputs.
+/// \param tol: Small number used to handle numerical approximation errors.
 void MoveIntersectingBody(SimOut* sim_out, float tol);
 
 std::tuple<int, int, int, float, bool> MoveBodySoil(
     SimOut* sim_out, int ind_p, int ii_p, int jj_p, float max_h, int ii_n,
     int jj_n, float h_soil, bool wall_presence, float tol);
 
+/// \brief This function identifies all the soil cells in the `terrain_` that
+///        intersect with the bucket.
+///
+/// \param sim_out: Class that stores simulation outputs.
+/// \param tol: Small number used to handle numerical approximation errors.
 std::vector<std::vector<int>> LocateIntersectingCells(
     SimOut* sim_out, float tol);
 

--- a/test/unit_tests/CMakeLists.txt
+++ b/test/unit_tests/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(unit_tests
         ${CMAKE_CURRENT_SOURCE_DIR}/test_types.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test_bucket_pos.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test_body_soil.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/test_intersecting_cells.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test_utils.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../../src
 )

--- a/test/unit_tests/run_tests.cpp
+++ b/test/unit_tests/run_tests.cpp
@@ -3,16 +3,9 @@ This file runs all unit tests.
 
 Copyright, 2023, Vilella Kenny.
 */
-#include <random>
 #include "gtest/gtest.h"
 
-// Setting RNG
-std::mt19937 rng;
-
 int main(int argc, char **argv) {
-    // Set RNG seed
-    rng.seed(1234);
-
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }

--- a/test/unit_tests/run_tests.cpp
+++ b/test/unit_tests/run_tests.cpp
@@ -3,9 +3,16 @@ This file runs all unit tests.
 
 Copyright, 2023, Vilella Kenny.
 */
+#include <random>
 #include "gtest/gtest.h"
 
+// Setting RNG
+std::mt19937 rng;
+
 int main(int argc, char **argv) {
+    // Set RNG seed
+    rng.seed(1234);
+
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }

--- a/test/unit_tests/test_intersecting_cells.cpp
+++ b/test/unit_tests/test_intersecting_cells.cpp
@@ -6,9 +6,6 @@ Copyright, 2023, Vilella Kenny.
 #include "gtest/gtest.h"
 #include "src/intersecting_cells.cpp"
 
-// Setting RNG
-std::mt19937 rng;
-
 TEST(UnitTestIntersectingCells, MoveBodySoil) {
 }
 
@@ -397,7 +394,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
 
     // -- Testing when soil is moved by small amount (1) --
     // Soil is fitting under the bucket
-    rng.seed(1234);
     for (auto ii = 8; ii < 15; ii++)
         for (auto jj = 14; jj < 21; jj++) {
             sim_out->body_[0][ii][jj] = 0.0;
@@ -452,7 +448,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
 
     // -- Testing when soil is moved by small amount (2) --
     // Soil is going out of the bucket
-    rng.seed(1234);
     for (auto ii = 8; ii < 15; ii++)
         for (auto jj = 14; jj < 21; jj++) {
             sim_out->body_[0][ii][jj] = 0.0;
@@ -509,7 +504,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
 
     // -- Testing when soil is moved by small amount (3) --
     // Soil is just fitting under the bucket
-    rng.seed(1234);
     for (auto ii = 8; ii < 15; ii++)
         for (auto jj = 14; jj < 21; jj++) {
             sim_out->body_[0][ii][jj] = 0.0;

--- a/test/unit_tests/test_intersecting_cells.cpp
+++ b/test/unit_tests/test_intersecting_cells.cpp
@@ -6,6 +6,9 @@ Copyright, 2023, Vilella Kenny.
 #include "gtest/gtest.h"
 #include "src/intersecting_cells.cpp"
 
+// Setting RNG
+std::mt19937 rng;
+
 TEST(UnitTestIntersectingCells, MoveBodySoil) {
 }
 
@@ -394,6 +397,7 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
 
     // -- Testing when soil is moved by small amount (1) --
     // Soil is fitting under the bucket
+    rng.seed(1234);
     for (auto ii = 8; ii < 15; ii++)
         for (auto jj = 14; jj < 21; jj++) {
             sim_out->body_[0][ii][jj] = 0.0;
@@ -448,6 +452,7 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
 
     // -- Testing when soil is moved by small amount (2) --
     // Soil is going out of the bucket
+    rng.seed(1234);
     for (auto ii = 8; ii < 15; ii++)
         for (auto jj = 14; jj < 21; jj++) {
             sim_out->body_[0][ii][jj] = 0.0;
@@ -504,6 +509,7 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
 
     // -- Testing when soil is moved by small amount (3) --
     // Soil is just fitting under the bucket
+    rng.seed(1234);
     for (auto ii = 8; ii < 15; ii++)
         for (auto jj = 14; jj < 21; jj++) {
             sim_out->body_[0][ii][jj] = 0.0;

--- a/test/unit_tests/test_intersecting_cells.cpp
+++ b/test/unit_tests/test_intersecting_cells.cpp
@@ -75,4 +75,502 @@ TEST(UnitTestIntersectingCells, LocateIntersectingCells) {
 }
 
 TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
+    // Setting up the environment
+    soil_simulator::Grid grid(1.0, 1.0, 1.0, 0.1, 0.1);
+    soil_simulator::SimOut *sim_out = new soil_simulator::SimOut(grid);
+    sim_out->bucket_area_[0][0] = 1;
+    sim_out->bucket_area_[0][1] = 20;
+    sim_out->bucket_area_[1][0] = 1;
+    sim_out->bucket_area_[1][1] = 20;
+
+    // -- Testing for a single intersecting cells in the -X direction --
+    for (auto ii = 11; ii < 13; ii++)
+        for (auto jj = 16; jj < 19; jj++) {
+            sim_out->body_[0][ii][jj] = 0.0;
+            sim_out->body_[1][ii][jj] = 0.5;
+        }
+    sim_out->body_[0][10][16] = 0.0;
+    sim_out->body_[1][10][16] = 0.5;
+    sim_out->body_[0][10][18] = 0.0;
+    sim_out->body_[1][10][18] = 0.5;
+    sim_out->terrain_[11][17] = 0.1;
+    soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[11][17], 0.0, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[10][17], 0.1, 1e-5);
+    sim_out->terrain_[10][17] = 0.0;
+    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
+        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
+            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
+    for (auto ii = 10; ii < 13; ii++)
+        for (auto jj = 16; jj < 19; jj++) {
+            sim_out->body_[0][ii][jj] = 0.0;
+            sim_out->body_[1][ii][jj] = 0.0;
+        }
+
+    // -- Testing for a single intersecting cells in the +X direction --
+    for (auto ii = 10; ii < 12; ii++)
+        for (auto jj = 16; jj < 19; jj++) {
+            sim_out->body_[0][ii][jj] = 0.0;
+            sim_out->body_[1][ii][jj] = 0.5;
+        }
+    sim_out->body_[0][12][16] = 0.0;
+    sim_out->body_[1][12][16] = 0.5;
+    sim_out->body_[0][12][18] = 0.0;
+    sim_out->body_[1][12][18] = 0.5;
+    sim_out->terrain_[11][17] = 0.2;
+    soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[11][17], 0.0, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[12][17], 0.2, 1e-5);
+    sim_out->terrain_[12][17] = 0.0;
+    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
+        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
+            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
+    for (auto ii = 10; ii < 13; ii++)
+        for (auto jj = 16; jj < 19; jj++) {
+            sim_out->body_[0][ii][jj] = 0.0;
+            sim_out->body_[1][ii][jj] = 0.0;
+        }
+
+    // -- Testing for a single intersecting cells in the -Y direction --
+    for (auto ii = 10; ii < 13; ii++)
+        for (auto jj = 17; jj < 19; jj++) {
+            sim_out->body_[0][ii][jj] = 0.0;
+            sim_out->body_[1][ii][jj] = 0.5;
+        }
+    sim_out->body_[0][10][16] = 0.0;
+    sim_out->body_[1][10][16] = 0.5;
+    sim_out->body_[0][12][16] = 0.0;
+    sim_out->body_[1][12][16] = 0.5;
+    sim_out->terrain_[11][17] = 0.05;
+    soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[11][17], 0.0, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[11][16], 0.05, 1e-5);
+    sim_out->terrain_[11][16] = 0.0;
+    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
+        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
+            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
+    for (auto ii = 10; ii < 13; ii++)
+        for (auto jj = 16; jj < 19; jj++) {
+            sim_out->body_[0][ii][jj] = 0.0;
+            sim_out->body_[1][ii][jj] = 0.0;
+        }
+
+    // -- Testing for a single intersecting cells in the +Y direction --
+    for (auto ii = 10; ii < 13; ii++)
+        for (auto jj = 16; jj < 18; jj++) {
+            sim_out->body_[0][ii][jj] = 0.0;
+            sim_out->body_[1][ii][jj] = 0.5;
+        }
+    sim_out->body_[0][10][18] = 0.0;
+    sim_out->body_[1][10][18] = 0.5;
+    sim_out->body_[0][12][18] = 0.0;
+    sim_out->body_[1][12][18] = 0.5;
+    sim_out->terrain_[11][17] = 0.25;
+    soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[11][17], 0.0, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[11][18], 0.25, 1e-5);
+    sim_out->terrain_[11][18] = 0.0;
+    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
+        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
+            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
+    for (auto ii = 10; ii < 13; ii++)
+        for (auto jj = 16; jj < 19; jj++) {
+            sim_out->body_[0][ii][jj] = 0.0;
+            sim_out->body_[1][ii][jj] = 0.0;
+        }
+
+    // -- Testing for a single intersecting cells in the -X-Y direction --
+    for (auto ii = 10; ii < 13; ii++)
+        for (auto jj = 17; jj < 19; jj++) {
+            sim_out->body_[0][ii][jj] = 0.0;
+            sim_out->body_[1][ii][jj] = 0.5;
+        }
+    sim_out->body_[0][11][16] = 0.0;
+    sim_out->body_[1][11][16] = 0.5;
+    sim_out->body_[0][12][16] = 0.0;
+    sim_out->body_[1][12][16] = 0.5;
+    sim_out->terrain_[11][17] = 0.4;
+    soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[11][17], 0.0, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[10][16], 0.4, 1e-5);
+    sim_out->terrain_[10][16] = 0.0;
+    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
+        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
+            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
+    for (auto ii = 10; ii < 13; ii++)
+        for (auto jj = 16; jj < 19; jj++) {
+            sim_out->body_[0][ii][jj] = 0.0;
+            sim_out->body_[1][ii][jj] = 0.0;
+        }
+
+    // -- Testing for a single intersecting cells in the +X-Y direction --
+    for (auto ii = 10; ii < 13; ii++)
+        for (auto jj = 17; jj < 19; jj++) {
+            sim_out->body_[0][ii][jj] = 0.0;
+            sim_out->body_[1][ii][jj] = 0.5;
+        }
+    sim_out->body_[0][10][16] = 0.0;
+    sim_out->body_[1][10][16] = 0.5;
+    sim_out->body_[0][11][16] = 0.0;
+    sim_out->body_[1][11][16] = 0.5;
+    sim_out->terrain_[11][17] = 0.1;
+    soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[11][17], 0.0, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[12][16], 0.1, 1e-5);
+    sim_out->terrain_[12][16] = 0.0;
+    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
+        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
+            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
+    for (auto ii = 10; ii < 13; ii++)
+        for (auto jj = 16; jj < 19; jj++) {
+            sim_out->body_[0][ii][jj] = 0.0;
+            sim_out->body_[1][ii][jj] = 0.0;
+        }
+
+    // -- Testing for a single intersecting cells in the -X+Y direction --
+    for (auto ii = 10; ii < 13; ii++)
+        for (auto jj = 16; jj < 18; jj++) {
+            sim_out->body_[0][ii][jj] = 0.0;
+            sim_out->body_[1][ii][jj] = 0.5;
+        }
+    sim_out->body_[0][11][18] = 0.0;
+    sim_out->body_[1][11][18] = 0.5;
+    sim_out->body_[0][12][18] = 0.0;
+    sim_out->body_[1][12][18] = 0.5;
+    sim_out->terrain_[11][17] = 0.5;
+    soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[11][17], 0.0, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[10][18], 0.5, 1e-5);
+    sim_out->terrain_[10][18] = 0.0;
+    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
+        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
+            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
+    for (auto ii = 10; ii < 13; ii++)
+        for (auto jj = 16; jj < 19; jj++) {
+            sim_out->body_[0][ii][jj] = 0.0;
+            sim_out->body_[1][ii][jj] = 0.0;
+        }
+
+    // -- Testing for a single intersecting cells in the +X+Y direction --
+    for (auto ii = 10; ii < 13; ii++)
+        for (auto jj = 16; jj < 18; jj++) {
+            sim_out->body_[0][ii][jj] = 0.0;
+            sim_out->body_[1][ii][jj] = 0.5;
+        }
+    sim_out->body_[0][10][18] = 0.0;
+    sim_out->body_[1][10][18] = 0.5;
+    sim_out->body_[0][11][18] = 0.0;
+    sim_out->body_[1][11][18] = 0.5;
+    sim_out->terrain_[11][17] = 0.8;
+    soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[11][17], 0.0, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[12][18], 0.8, 1e-5);
+    sim_out->terrain_[12][18] = 0.0;
+    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
+        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
+            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
+    for (auto ii = 10; ii < 13; ii++)
+        for (auto jj = 16; jj < 19; jj++) {
+            sim_out->body_[0][ii][jj] = 0.0;
+            sim_out->body_[1][ii][jj] = 0.0;
+        }
+
+    // -- Testing for a single intersecting cells in the second bucket layer --
+    for (auto ii = 10; ii < 13; ii++)
+        for (auto jj = 16; jj < 18; jj++) {
+            sim_out->body_[2][ii][jj] = 0.0;
+            sim_out->body_[3][ii][jj] = 0.5;
+        }
+    sim_out->body_[2][11][18] = 0.0;
+    sim_out->body_[3][11][18] = 0.5;
+    sim_out->body_[2][12][18] = 0.0;
+    sim_out->body_[3][12][18] = 0.5;
+    sim_out->terrain_[11][17] = 0.5;
+    soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[11][17], 0.0, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[10][18], 0.5, 1e-5);
+    sim_out->terrain_[10][18] = 0.0;
+    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
+        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
+            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
+    for (auto ii = 10; ii < 13; ii++)
+        for (auto jj = 16; jj < 19; jj++) {
+            sim_out->body_[2][ii][jj] = 0.0;
+            sim_out->body_[3][ii][jj] = 0.0;
+        }
+
+    // -- Testing for a single intersecting cells with various bucket layer --
+    sim_out->body_[2][10][16] = 0.0;
+    sim_out->body_[3][10][16] = 0.5;
+    sim_out->body_[2][10][17] = 0.0;
+    sim_out->body_[3][10][17] = 0.5;
+    sim_out->body_[0][11][16] = 0.0;
+    sim_out->body_[1][11][16] = 0.5;
+    sim_out->body_[0][11][17] = 0.0;
+    sim_out->body_[1][11][17] = 0.5;
+    sim_out->body_[0][12][16] = 0.0;
+    sim_out->body_[1][12][16] = 0.5;
+    sim_out->body_[0][12][17] = 0.0;
+    sim_out->body_[1][12][17] = 0.5;
+    sim_out->body_[2][12][16] = 0.6;
+    sim_out->body_[3][12][16] = 0.8;
+    sim_out->body_[2][12][17] = 0.6;
+    sim_out->body_[3][12][17] = 0.8;
+    sim_out->body_[0][11][18] = 0.0;
+    sim_out->body_[1][11][18] = 0.5;
+    sim_out->body_[2][12][18] = 0.0;
+    sim_out->body_[3][12][18] = 0.5;
+    sim_out->terrain_[11][17] = 0.5;
+    soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[11][17], 0.0, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[10][18], 0.5, 1e-5);
+    sim_out->terrain_[10][18] = 0.0;
+    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
+        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
+            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
+    for (auto ii = 10; ii < 13; ii++)
+        for (auto jj = 16; jj < 19; jj++) {
+            sim_out->body_[0][ii][jj] = 0.0;
+            sim_out->body_[1][ii][jj] = 0.0;
+            sim_out->body_[2][ii][jj] = 0.0;
+            sim_out->body_[3][ii][jj] = 0.0;
+        }
+
+    // -- Testing for single intersecting cells with all bucket under terrain --
+    for (auto ii = 10; ii < 13; ii++)
+        for (auto jj = 16; jj < 18; jj++) {
+            sim_out->body_[0][ii][jj] = 0.0;
+            sim_out->body_[1][ii][jj] = 0.2;
+        }
+    sim_out->body_[0][10][18] = 0.0;
+    sim_out->body_[1][10][18] = 0.5;
+    sim_out->body_[0][11][18] = 0.0;
+    sim_out->body_[1][11][18] = 0.5;
+    sim_out->body_[0][11][17] = 0.5;
+    sim_out->body_[1][11][17] = 0.6;
+    sim_out->body_[2][11][17] = -0.2;
+    sim_out->body_[3][11][17] = 0.3;
+    sim_out->terrain_[11][17] = 0.8;
+    soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[11][17], -0.2, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[12][18], 1.0, 1e-5);
+    sim_out->terrain_[12][18] = 0.0;
+    sim_out->terrain_[11][17] = 0.0;
+    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
+        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
+            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
+    for (auto ii = 10; ii < 13; ii++)
+        for (auto jj = 16; jj < 19; jj++) {
+            sim_out->body_[0][ii][jj] = 0.0;
+            sim_out->body_[1][ii][jj] = 0.0;
+        }
+    sim_out->body_[2][11][17] = 0.0;
+    sim_out->body_[3][11][17] = 0.0;
+
+    // -- Testing for a single intersecting cells under a large bucket --
+    for (auto ii = 8; ii < 15; ii++)
+        for (auto jj = 14; jj < 21; jj++) {
+            sim_out->body_[0][ii][jj] = 0.0;
+            sim_out->body_[1][ii][jj] = 0.2;
+        }
+    sim_out->body_[0][11][17] = -0.4;
+    sim_out->body_[1][11][17] = 0.6;
+    sim_out->body_[0][8][17] = 0.0;
+    sim_out->body_[1][8][17] = 0.0;
+    sim_out->terrain_[11][17] = 0.5;
+    soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[11][17], -0.4, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[8][17], 0.9, 1e-5);
+    sim_out->terrain_[8][17] = 0.0;
+    sim_out->terrain_[11][17] = 0.0;
+    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
+        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
+            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
+    for (auto ii = 8; ii < 15; ii++)
+        for (auto jj = 14; jj < 21; jj++) {
+            sim_out->body_[0][ii][jj] = 0.0;
+            sim_out->body_[1][ii][jj] = 0.0;
+        }
+
+    // -- Testing when soil is moved by small amount (1) --
+    // Soil is fitting under the bucket
+    for (auto ii = 8; ii < 15; ii++)
+        for (auto jj = 14; jj < 21; jj++) {
+            sim_out->body_[0][ii][jj] = 0.0;
+            sim_out->body_[1][ii][jj] = 0.2;
+        }
+    sim_out->body_[0][11][17] = -0.5;
+    sim_out->body_[1][11][17] = 0.6;
+    sim_out->body_[0][10][17] = 0.1;
+    sim_out->body_[1][10][17] = 0.2;
+    sim_out->body_[0][8][17] = 0.25;
+    sim_out->body_[1][8][17] = 0.4;
+    sim_out->body_[0][12][17] = 0.2;
+    sim_out->body_[1][12][17] = 0.3;
+    sim_out->body_[0][13][17] = 0.05;
+    sim_out->body_[1][13][17] = 0.4;
+    sim_out->body_[2][13][17] = 0.6;
+    sim_out->body_[3][13][17] = 0.7;
+    sim_out->body_[0][13][19] = 0.3;
+    sim_out->body_[1][13][19] = 0.5;
+    sim_out->body_[0][14][20] = 0.0;
+    sim_out->body_[1][14][20] = 0.0;
+    sim_out->body_[2][14][20] = 0.2;
+    sim_out->body_[3][14][20] = 0.4;
+    sim_out->terrain_[11][17] = 0.5;
+    soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[11][17], -0.5, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[10][17], 0.1, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[8][17], 0.25, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[12][17], 0.2, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[13][17], 0.05, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[13][19], 0.3, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[14][20], 0.1, 1e-5);
+    sim_out->terrain_[11][17] = 0.0;
+    sim_out->terrain_[10][17] = 0.0;
+    sim_out->terrain_[8][17] = 0.0;
+    sim_out->terrain_[12][17] = 0.0;
+    sim_out->terrain_[13][17] = 0.0;
+    sim_out->terrain_[13][19] = 0.0;
+    sim_out->terrain_[14][20] = 0.0;
+    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
+        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
+            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
+    for (auto ii = 8; ii < 15; ii++)
+        for (auto jj = 14; jj < 21; jj++) {
+            sim_out->body_[0][ii][jj] = 0.0;
+            sim_out->body_[1][ii][jj] = 0.0;
+        }
+    sim_out->body_[2][13][17] = 0.0;
+    sim_out->body_[3][13][17] = 0.0;
+    sim_out->body_[2][14][20] = 0.0;
+    sim_out->body_[3][14][20] = 0.0;
+
+    // -- Testing when soil is moved by small amount (2) --
+    // Soil is going out of the bucket
+    for (auto ii = 8; ii < 15; ii++)
+        for (auto jj = 14; jj < 21; jj++) {
+            sim_out->body_[0][ii][jj] = 0.0;
+            sim_out->body_[1][ii][jj] = 0.2;
+        }
+    sim_out->body_[0][11][17] = -0.5;
+    sim_out->body_[1][11][17] = 0.6;
+    sim_out->body_[0][10][17] = 0.1;
+    sim_out->body_[1][10][17] = 0.2;
+    sim_out->body_[0][8][17] = 0.25;
+    sim_out->body_[1][8][17] = 0.4;
+    sim_out->body_[0][12][17] = 0.2;
+    sim_out->body_[1][12][17] = 0.3;
+    sim_out->body_[0][13][17] = 0.05;
+    sim_out->body_[1][13][17] = 0.4;
+    sim_out->body_[2][13][17] = 0.6;
+    sim_out->body_[3][13][17] = 0.7;
+    sim_out->body_[0][13][19] = 0.3;
+    sim_out->body_[1][13][19] = 0.5;
+    sim_out->body_[0][14][20] = 0.0;
+    sim_out->body_[1][14][20] = 0.0;
+    sim_out->body_[2][14][20] = 0.2;
+    sim_out->body_[3][14][20] = 0.4;
+    sim_out->terrain_[11][17] = 0.8;
+    soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[11][17], -0.5, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[10][17], 0.1, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[8][17], 0.25, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[12][17], 0.2, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[13][17], 0.05, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[13][19], 0.3, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[14][20], 0.2, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[7][21], 0.2, 1e-5);
+    sim_out->terrain_[11][17] = 0.0;
+    sim_out->terrain_[10][17] = 0.0;
+    sim_out->terrain_[8][17] = 0.0;
+    sim_out->terrain_[12][17] = 0.0;
+    sim_out->terrain_[13][17] = 0.0;
+    sim_out->terrain_[13][19] = 0.0;
+    sim_out->terrain_[14][20] = 0.0;
+    sim_out->terrain_[7][21] = 0.0;
+    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
+        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
+            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
+    for (auto ii = 8; ii < 15; ii++)
+        for (auto jj = 14; jj < 21; jj++) {
+            sim_out->body_[0][ii][jj] = 0.0;
+            sim_out->body_[1][ii][jj] = 0.0;
+        }
+    sim_out->body_[2][13][17] = 0.0;
+    sim_out->body_[3][13][17] = 0.0;
+    sim_out->body_[2][14][20] = 0.0;
+    sim_out->body_[3][14][20] = 0.0;
+
+    // -- Testing when soil is moved by small amount (3) --
+    // Soil is just fitting under the bucket
+    for (auto ii = 8; ii < 15; ii++)
+        for (auto jj = 14; jj < 21; jj++) {
+            sim_out->body_[0][ii][jj] = 0.0;
+            sim_out->body_[1][ii][jj] = 0.2;
+        }
+    sim_out->body_[0][11][17] = -0.5;
+    sim_out->body_[1][11][17] = 0.6;
+    sim_out->body_[0][10][17] = 0.1;
+    sim_out->body_[1][10][17] = 0.2;
+    sim_out->body_[0][8][17] = 0.25;
+    sim_out->body_[1][8][17] = 0.4;
+    sim_out->body_[0][12][17] = 0.2;
+    sim_out->body_[1][12][17] = 0.3;
+    sim_out->body_[0][13][17] = 0.05;
+    sim_out->body_[1][13][17] = 0.4;
+    sim_out->body_[2][13][17] = 0.6;
+    sim_out->body_[3][13][17] = 0.7;
+    sim_out->body_[0][13][19] = 0.3;
+    sim_out->body_[1][13][19] = 0.5;
+    sim_out->body_[0][14][20] = 0.0;
+    sim_out->body_[1][14][20] = 0.0;
+    sim_out->body_[2][14][20] = 0.2;
+    sim_out->body_[3][14][20] = 0.4;
+    sim_out->terrain_[11][17] = 0.6;
+    soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[11][17], -0.5, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[10][17], 0.1, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[8][17], 0.25, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[12][17], 0.2, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[13][17], 0.05, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[13][19], 0.3, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[14][20], 0.2, 1e-5);
+    sim_out->terrain_[11][17] = 0.0;
+    sim_out->terrain_[10][17] = 0.0;
+    sim_out->terrain_[8][17] = 0.0;
+    sim_out->terrain_[12][17] = 0.0;
+    sim_out->terrain_[13][17] = 0.0;
+    sim_out->terrain_[13][19] = 0.0;
+    sim_out->terrain_[14][20] = 0.0;
+    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
+        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
+            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
+    for (auto ii = 8; ii < 15; ii++)
+        for (auto jj = 14; jj < 21; jj++) {
+            sim_out->body_[0][ii][jj] = 0.0;
+            sim_out->body_[1][ii][jj] = 0.0;
+        }
+    sim_out->body_[2][13][17] = 0.0;
+    sim_out->body_[3][13][17] = 0.0;
+    sim_out->body_[2][14][20] = 0.0;
+    sim_out->body_[3][14][20] = 0.0;
+
+    // -- Testing when there is nothing to move --
+    for (auto ii = 8; ii < 15; ii++)
+        for (auto jj = 14; jj < 21; jj++) {
+            sim_out->body_[0][ii][jj] = 0.0;
+            sim_out->body_[1][ii][jj] = 0.2;
+        }
+    soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
+    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
+        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
+            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
+    for (auto ii = 8; ii < 15; ii++)
+        for (auto jj = 14; jj < 21; jj++) {
+            sim_out->body_[0][ii][jj] = 0.0;
+            sim_out->body_[1][ii][jj] = 0.0;
+        }
+
+    delete sim_out;
 }

--- a/test/unit_tests/test_intersecting_cells.cpp
+++ b/test/unit_tests/test_intersecting_cells.cpp
@@ -394,6 +394,7 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
 
     // -- Testing when soil is moved by small amount (1) --
     // Soil is fitting under the bucket
+    rng.seed(1234);
     for (auto ii = 8; ii < 15; ii++)
         for (auto jj = 14; jj < 21; jj++) {
             sim_out->body_[0][ii][jj] = 0.0;
@@ -421,11 +422,11 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
     soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][17], -0.5, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[10][17], 0.1, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[8][17], 0.25, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[8][17], 0.15, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][17], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[13][17], 0.05, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[13][19], 0.3, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[14][20], 0.1, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[14][20], 0.2, 1e-5);
     sim_out->terrain_[11][17] = 0.0;
     sim_out->terrain_[10][17] = 0.0;
     sim_out->terrain_[8][17] = 0.0;
@@ -448,6 +449,7 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
 
     // -- Testing when soil is moved by small amount (2) --
     // Soil is going out of the bucket
+    rng.seed(1234);
     for (auto ii = 8; ii < 15; ii++)
         for (auto jj = 14; jj < 21; jj++) {
             sim_out->body_[0][ii][jj] = 0.0;
@@ -480,7 +482,7 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
     EXPECT_NEAR(sim_out->terrain_[13][17], 0.05, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[13][19], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[14][20], 0.2, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[7][21], 0.2, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[15][17], 0.2, 1e-5);
     sim_out->terrain_[11][17] = 0.0;
     sim_out->terrain_[10][17] = 0.0;
     sim_out->terrain_[8][17] = 0.0;
@@ -488,7 +490,7 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
     sim_out->terrain_[13][17] = 0.0;
     sim_out->terrain_[13][19] = 0.0;
     sim_out->terrain_[14][20] = 0.0;
-    sim_out->terrain_[7][21] = 0.0;
+    sim_out->terrain_[15][17] = 0.0;
     for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
         for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
             EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
@@ -504,6 +506,7 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
 
     // -- Testing when soil is moved by small amount (3) --
     // Soil is just fitting under the bucket
+    rng.seed(1234);
     for (auto ii = 8; ii < 15; ii++)
         for (auto jj = 14; jj < 21; jj++) {
             sim_out->body_[0][ii][jj] = 0.0;

--- a/test/unit_tests/test_intersecting_cells.cpp
+++ b/test/unit_tests/test_intersecting_cells.cpp
@@ -1,0 +1,19 @@
+/*
+This file implements unit tests for the functions in intersecting_cells.cpp.
+
+Copyright, 2023, Vilella Kenny.
+*/
+#include "gtest/gtest.h"
+#include "src/intersecting_cells.cpp"
+
+TEST(UnitTestIntersectingCells, MoveBodySoil) {
+}
+
+TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
+}
+
+TEST(UnitTestIntersectingCells, LocateIntersectingCells) {
+}
+
+TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
+}

--- a/test/unit_tests/test_intersecting_cells.cpp
+++ b/test/unit_tests/test_intersecting_cells.cpp
@@ -13,6 +13,65 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
 }
 
 TEST(UnitTestIntersectingCells, LocateIntersectingCells) {
+    // Setting up the environment
+    soil_simulator::Grid grid(1.0, 1.0, 1.0, 0.1, 0.1);
+    soil_simulator::SimOut *sim_out = new soil_simulator::SimOut(grid);
+    sim_out->bucket_area_[0][0] = 4;
+    sim_out->bucket_area_[0][1] = 12;
+    sim_out->bucket_area_[1][0] = 8;
+    sim_out->bucket_area_[1][1] = 17;
+    sim_out->terrain_[10][11] = 0.1;
+    sim_out->terrain_[10][12] = 0.1;
+    sim_out->terrain_[10][13] = 0.1;
+    sim_out->terrain_[10][14] = 0.1;
+    sim_out->terrain_[10][15] = 0.1;
+    sim_out->terrain_[10][16] = 0.1;
+    sim_out->terrain_[11][11] = -0.1;
+    sim_out->body_[0][5][10] = 0.0;
+    sim_out->body_[1][5][10] = 0.1;
+    sim_out->body_[2][6][10] = 0.0;
+    sim_out->body_[3][6][10] = 0.1;
+    sim_out->body_[0][7][10] = 0.0;
+    sim_out->body_[1][7][10] = 0.1;
+    sim_out->body_[2][7][10] = 0.2;
+    sim_out->body_[3][7][10] = 0.3;
+    sim_out->body_[0][11][11] = -0.1;
+    sim_out->body_[1][11][11] = 0.0;
+    sim_out->body_[0][10][11] = 0.0;
+    sim_out->body_[1][10][11] = 0.1;
+    sim_out->body_[2][10][12] = -0.1;
+    sim_out->body_[3][10][12] = 0.0;
+    sim_out->body_[0][10][13] = -0.2;
+    sim_out->body_[1][10][13] = 0.0;
+    sim_out->body_[2][10][13] = 0.0;
+    sim_out->body_[3][10][13] = 0.3;
+    sim_out->body_[0][10][14] = 0.2;
+    sim_out->body_[1][10][14] = 0.3;
+    sim_out->body_[2][10][14] = -0.1;
+    sim_out->body_[3][10][14] = 0.0;
+    sim_out->body_[0][10][15] = -0.3;
+    sim_out->body_[1][10][15] = -0.2;
+    sim_out->body_[2][10][15] = 0.5;
+    sim_out->body_[3][10][15] = 0.6;
+    sim_out->body_[0][10][16] = -0.3;
+    sim_out->body_[1][10][16] = -0.2;
+    sim_out->body_[2][10][16] = -0.6;
+    sim_out->body_[3][10][16] = -0.4;
+
+    // -- Testing that intersecting cells are properly located --
+    auto intersecting_cells = soil_simulator::LocateIntersectingCells(
+        sim_out, 1e-5);
+    EXPECT_TRUE((intersecting_cells[0] == std::vector<int> {0, 10, 11}));
+    EXPECT_TRUE((intersecting_cells[1] == std::vector<int> {2, 10, 12}));
+    EXPECT_TRUE((intersecting_cells[2] == std::vector<int> {0, 10, 13}));
+    EXPECT_TRUE((intersecting_cells[3] == std::vector<int> {2, 10, 13}));
+    EXPECT_TRUE((intersecting_cells[4] == std::vector<int> {2, 10, 14}));
+    EXPECT_TRUE((intersecting_cells[5] == std::vector<int> {0, 10, 15}));
+    EXPECT_TRUE((intersecting_cells[6] == std::vector<int> {0, 10, 16}));
+    EXPECT_TRUE((intersecting_cells[7] == std::vector<int> {2, 10, 16}));
+    EXPECT_EQ(intersecting_cells.size(), 8);
+
+    delete sim_out;
 }
 
 TEST(UnitTestIntersectingCells, MoveIntersectingBody) {


### PR DESCRIPTION
# Description
- Added skeleton for the movement of intersecting cells
- Added implementation of `MoveIntersectingBody`
- Added doxygen documentation
- Added corresponding unit tests