### PR TITLE
Add step function and example script for simulator

### DIFF
--- a/src/body_soil.cpp
+++ b/src/body_soil.cpp
@@ -6,6 +6,7 @@ Copyright, 2023, Vilella Kenny.
 */
 #include <algorithm>
 #include <cmath>
+#include <iostream>
 #include <vector>
 #include "src/body_soil.hpp"
 #include "src/types.hpp"

--- a/src/bucket_pos.cpp
+++ b/src/bucket_pos.cpp
@@ -21,15 +21,15 @@ Copyright, 2023, Vilella Kenny.
 /// using the quaternion definition.
 void soil_simulator::CalcBucketPos(
     SimOut* sim_out, std::vector<float> pos, std::vector<float> ori, Grid grid,
-    Bucket bucket, SimParam sim_param, float tol
+    Bucket* bucket, SimParam sim_param, float tol
 ) {
     // Calculating position of the bucker vertices
     auto j_pos = soil_simulator::CalcRotationQuaternion(
-        ori, bucket.j_pos_init_);
+        ori, bucket->j_pos_init_);
     auto b_pos = soil_simulator::CalcRotationQuaternion(
-        ori, bucket.b_pos_init_);
+        ori, bucket->b_pos_init_);
     auto t_pos = soil_simulator::CalcRotationQuaternion(
-        ori, bucket.t_pos_init_);
+        ori, bucket->t_pos_init_);
 
     // Unit vector normal to the side of the bucket
     auto normal_side = soil_simulator::CalcNormal(j_pos, b_pos, t_pos);
@@ -49,12 +49,12 @@ void soil_simulator::CalcBucketPos(
         t_pos[ii] += pos[ii];
 
         // Position of each vertex of the bucket
-        j_r_pos[ii] = j_pos[ii] + 0.5 * bucket.width_ * normal_side[ii];
-        j_l_pos[ii] = j_pos[ii] - 0.5 * bucket.width_ * normal_side[ii];
-        b_r_pos[ii] = b_pos[ii] + 0.5 * bucket.width_ * normal_side[ii];
-        b_l_pos[ii] = b_pos[ii] - 0.5 * bucket.width_ * normal_side[ii];
-        t_r_pos[ii] = t_pos[ii] + 0.5 * bucket.width_ * normal_side[ii];
-        t_l_pos[ii] = t_pos[ii] - 0.5 * bucket.width_ * normal_side[ii];
+        j_r_pos[ii] = j_pos[ii] + 0.5 * bucket->width_ * normal_side[ii];
+        j_l_pos[ii] = j_pos[ii] - 0.5 * bucket->width_ * normal_side[ii];
+        b_r_pos[ii] = b_pos[ii] + 0.5 * bucket->width_ * normal_side[ii];
+        b_l_pos[ii] = b_pos[ii] - 0.5 * bucket->width_ * normal_side[ii];
+        t_r_pos[ii] = t_pos[ii] + 0.5 * bucket->width_ * normal_side[ii];
+        t_l_pos[ii] = t_pos[ii] - 0.5 * bucket->width_ * normal_side[ii];
 
         // Adding a small increment to all vertices
         // This is to account for the edge case where one of the vertex is at

--- a/src/bucket_pos.hpp
+++ b/src/bucket_pos.hpp
@@ -22,7 +22,7 @@ namespace soil_simulator {
 /// \param tol: Small number used to handle numerical approximation errors.
 void CalcBucketPos(
     SimOut* sim_out, std::vector<float> pos, std::vector<float> ori, Grid grid,
-    Bucket bucket, SimParam sim_param, float tol);
+    Bucket* bucket, SimParam sim_param, float tol);
 
 /// \brief This function determines the cells where a rectangle surface is
 ///        located.

--- a/src/soil_dynamics.cpp
+++ b/src/soil_dynamics.cpp
@@ -33,6 +33,28 @@ void soil_simulator::SoilDynamics::step(
 
     // Assuming that the terrain is not at equilibrium
     sim_out->equilibrium_ = false;
+
+    // Iterating until equilibrium or maximum number of iterations is reached
+    int it = 0;
+    while (!sim_out->equilibrium_ && it < sim_param.max_iterations_) {
+        it++;
+
+        // Updating impact_area
+        sim_out->impact_area_[0][0] = std::min(
+            sim_out->bucket_area_[0][0], sim_out->relax_area_[0][0]);
+        sim_out->impact_area_[1][0] = std::min(
+            sim_out->bucket_area_[1][0], sim_out->relax_area_[1][0]);
+        sim_out->impact_area_[0][1] = std::max(
+            sim_out->bucket_area_[0][1], sim_out->relax_area_[0][1]);
+        sim_out->impact_area_[1][1] = std::max(
+            sim_out->bucket_area_[1][1], sim_out->relax_area_[1][1]);
+
+        // Relaxing the terrain
+        RelaxTerrain(sim_out, grid, sim_param, tol);
+
+        // Relaxing the soil resting on the bucket
+        RelaxBodySoil(sim_out, grid, sim_param, tol);
+    }
 }
 
 void soil_simulator::SoilDynamics::check() {

--- a/src/soil_dynamics.cpp
+++ b/src/soil_dynamics.cpp
@@ -140,9 +140,9 @@ int main() {
         // Calculating lateral vector of the bucket
         auto normal_side = soil_simulator::CalcNormal(j_pos, b_pos, t_pos);
         std::vector<float> half_width = {
-            0.5 * bucket_width * normal_side[0],
-            0.5 * bucket_width * normal_side[1],
-            0.5 * bucket_width * normal_side[2]};
+            bucket_width * normal_side[0] / 2,
+            bucket_width * normal_side[1] / 2,
+            bucket_width * normal_side[2] / 2};
 
         // Populating position of the bucket corners
         j_r_pos.push_back(std::vector<float> {

--- a/src/soil_dynamics.cpp
+++ b/src/soil_dynamics.cpp
@@ -3,6 +3,7 @@ This file implements the main functions of the simulator.
 
 Copyright, 2023, Vilella Kenny.
 */
+#include <algorithm>
 #include <iostream>
 #include <random>
 #include <vector>
@@ -64,8 +65,268 @@ void soil_simulator::SoilDynamics::WriteOutputs() {
 }
 
 int main() {
+    // Flags for the simulation
+    bool set_rng = true;
+    bool random_trajectory = true;
+
+    // Initalizing the simulator
     soil_simulator::SoilDynamics sim;
+
+    // Initalizing the simulation grid
     soil_simulator::Grid grid(4.0, 4.0, 4.0, 0.05, 0.05);
-    std::cout << grid.vect_x_[0];
+
+    // Initalizing the simulated bucket
+    std::vector<float> o_pos_init = {0.0, 0.0, 0.0};
+    std::vector<float> j_pos_init = {0.0, 0.0, 0.0};
+    std::vector<float> b_pos_init = {0.0, 0.0, -0.5};
+    std::vector<float> t_pos_init = {0.7, 0.0, -0.5};
+    float bucket_width = 0.5;
+    soil_simulator::Bucket *bucket = new soil_simulator::Bucket(
+        o_pos_init, j_pos_init, b_pos_init, t_pos_init, bucket_width);
+
+    // Initalizing the simulation parameter
+    soil_simulator::SimParam sim_param(0.85, 10, 4);
+
+    // Initalizing the simulation outputs class
+    soil_simulator::SimOut *sim_out = new soil_simulator::SimOut(grid);
+
+    if (set_rng)
+        soil_simulator::rng.seed(1234);
+
+    std::vector<std::vector<float>> pos;
+    std::vector<std::vector<float>> ori;
+    if (random_trajectory) {
+        // Random parabolic trajectory
+        // Calculating random parameters within a certain range
+        std::uniform_real_distribution<float> dist(0.0, 1.0);
+        float x_i = -3.0 + 2.0 * dist(soil_simulator::rng);
+        float z_i = 0.5 + 1.5 * dist(soil_simulator::rng);
+        float x_min = -0.5 * dist(soil_simulator::rng);
+        float z_min = -0.25 + 0.5 * dist(soil_simulator::rng);
+
+        // Creating the trajectory
+        std::tie(pos, ori) = soil_simulator::CalcTrajectory(
+            x_i, z_i, x_min, z_min, 100);
+    } else {
+        // Default parabolic trajectory
+        std::tie(pos, ori) = soil_simulator::CalcTrajectory(
+            -2.0, 1.5, 0.1, 0.25, 100);
+    }
+
+    // Initializing bucket corner position vectors
+    std::vector<std::vector<float>> j_r_pos;
+    std::vector<std::vector<float>> j_l_pos;
+    std::vector<std::vector<float>> b_r_pos;
+    std::vector<std::vector<float>> b_l_pos;
+    std::vector<std::vector<float>> t_r_pos;
+    std::vector<std::vector<float>> t_l_pos;
+
+    // Iterating over bucket trajectory
+    for (auto ii = 0; ii < pos.size(); ii++) {
+        // Converting orientation to quaternion
+        auto ori_i = soil_simulator::AngleToQuat(
+            {-ori[ii][0], -ori[ii][1], -ori[ii][2]});
+
+        // Calculating position of bucket points
+        auto j_pos = soil_simulator::CalcRotationQuaternion(ori_i, j_pos_init);
+        auto b_pos = soil_simulator::CalcRotationQuaternion(ori_i, b_pos_init);
+        auto t_pos = soil_simulator::CalcRotationQuaternion(ori_i, t_pos_init);
+        for (auto jj = 0; jj < 3; jj++) {
+            j_pos[jj] += pos[ii][jj];
+            b_pos[jj] += pos[ii][jj];
+            t_pos[jj] += pos[ii][jj];
+        }
+
+        // Calculating lateral vector of the bucket
+        auto normal_side = soil_simulator::CalcNormal(j_pos, b_pos, t_pos);
+        std::vector<float> half_width = {
+            0.5 * bucket_width * normal_side[0],
+            0.5 * bucket_width * normal_side[1],
+            0.5 * bucket_width * normal_side[2]};
+
+        // Populating position of the bucket corners
+        j_r_pos.push_back(std::vector<float> {
+            j_pos[0] + half_width[0], j_pos[1] + half_width[1],
+            j_pos[2] + half_width[2]});
+        j_l_pos.push_back(std::vector<float> {
+            j_pos[0] + half_width[0], j_pos[1] - half_width[1],
+            j_pos[2] + half_width[2]});
+        b_r_pos.push_back(std::vector<float> {
+            b_pos[0] + half_width[0], b_pos[1] + half_width[1],
+            b_pos[2] + half_width[2]});
+        b_l_pos.push_back(std::vector<float> {
+            b_pos[0] + half_width[0], b_pos[1] - half_width[1],
+            b_pos[2] + half_width[2]});
+        t_r_pos.push_back(std::vector<float> {
+            t_pos[0] + half_width[0], t_pos[1] + half_width[1],
+            t_pos[2] + half_width[2]});
+        t_l_pos.push_back(std::vector<float> {
+            t_pos[0] + half_width[0], t_pos[1] - half_width[1],
+            t_pos[2] + half_width[2]});
+    }
+
+    // Setting time
+    float total_time = 8.0;
+    float dt = 0.2;
+
+    // Calculating time step for pos and ori vector
+    float dt_int = total_time / (pos.size() - 1);
+
+    // Initializing
+    std::vector<std::vector<float>> pos_vec;
+    std::vector<std::vector<float>> ori_vec;
+    std::vector<float> time_vec;
+    float dt_i = dt;
+    float time = dt;
+    pos_vec.push_back(pos[0]);
+    auto ori_i = soil_simulator::AngleToQuat(
+            {-ori[0][0], -ori[0][1], -ori[0][2]});
+    ori_vec.push_back(ori_i);
+
+    // Creating time evolution
+    while (time + dt_i < total_time) {
+       // Adding time to time vector
+       time_vec.push_back(time);
+
+       // Searching time that is closest to the time where pos and ori
+       // were calculated
+       int kk = static_cast<int>(std::floor(time / dt_int));
+
+       // Calculating linear interpolation of pos and ori at time
+       float a = ((kk + 1) * dt_int - time) / dt_int;
+       float b = (time - kk * dt_int) / dt_int;
+       pos_vec.push_back(std::vector<float> {
+           pos[kk][0] * a + pos[kk+1][0] * b,
+           pos[kk][1] * a + pos[kk+1][1] * b,
+           pos[kk][2] * a + pos[kk+1][5] * b});
+       ori_vec.push_back(soil_simulator::AngleToQuat({
+            -(ori[kk][0] * a + ori[kk+1][0] * b),
+            -(ori[kk][1] * a + ori[kk+1][1] * b),
+            -(ori[kk][2] * a + ori[kk+1][2] * b)}));
+
+       // Calculating linear interpolation of bucket corners
+       float time_plus = time + 0.5 * dt_i;
+       int kk_plus = static_cast<int>(std::floor(time_plus / dt_int));
+       float a_plus = ((kk + 1) * dt_int - time_plus) / dt_int;
+       float b_plus = (time_plus - kk * dt_int) / dt_int;
+       std::vector<float> j_l_pos_plus = {
+           j_l_pos[kk_plus][0] * a + j_l_pos[kk_plus+1][0] * b,
+           j_l_pos[kk_plus][1] * a + j_l_pos[kk_plus+1][1] * b,
+           j_l_pos[kk_plus][2] * a + j_l_pos[kk_plus+1][2] * b};
+       std::vector<float> j_r_pos_plus = {
+           j_r_pos[kk_plus][0] * a + j_r_pos[kk_plus+1][0] * b,
+           j_r_pos[kk_plus][1] * a + j_r_pos[kk_plus+1][1] * b,
+           j_r_pos[kk_plus][2] * a + j_r_pos[kk_plus+1][2] * b};
+       std::vector<float> b_l_pos_plus = {
+           b_l_pos[kk_plus][0] * a + b_l_pos[kk_plus+1][0] * b,
+           b_l_pos[kk_plus][1] * a + b_l_pos[kk_plus+1][1] * b,
+           b_l_pos[kk_plus][2] * a + b_l_pos[kk_plus+1][2] * b};
+       std::vector<float> b_r_pos_plus = {
+           b_r_pos[kk_plus][0] * a + b_r_pos[kk_plus+1][0] * b,
+           b_r_pos[kk_plus][1] * a + b_r_pos[kk_plus+1][1] * b,
+           b_r_pos[kk_plus][2] * a + b_r_pos[kk_plus+1][2] * b};
+       std::vector<float> t_l_pos_plus = {
+           t_l_pos[kk_plus][0] * a + t_l_pos[kk_plus+1][0] * b,
+           t_l_pos[kk_plus][1] * a + t_l_pos[kk_plus+1][1] * b,
+           t_l_pos[kk_plus][2] * a + t_l_pos[kk_plus+1][2] * b};
+       std::vector<float> t_r_pos_plus = {
+           t_r_pos[kk_plus][0] * a + t_r_pos[kk_plus+1][0] * b,
+           t_r_pos[kk_plus][1] * a + t_r_pos[kk_plus+1][1] * b,
+           t_r_pos[kk_plus][2] * a + t_r_pos[kk_plus+1][2] * b};
+       float time_minus = time - 0.5 * dt_i;
+       int kk_minus = static_cast<int>(std::floor(time_minus / dt_int));
+       float a_minus = ((kk + 1) * dt_int - time_minus) / dt_int;
+       float b_minus = (time_minus - kk * dt_int) / dt_int;
+       std::vector<float> j_l_pos_minus = {
+           j_l_pos[kk_minus][0] * a + j_l_pos[kk_minus+1][0] * b,
+           j_l_pos[kk_minus][1] * a + j_l_pos[kk_minus+1][1] * b,
+           j_l_pos[kk_minus][2] * a + j_l_pos[kk_minus+1][2] * b};
+       std::vector<float> j_r_pos_minus = {
+           j_r_pos[kk_minus][0] * a + j_r_pos[kk_minus+1][0] * b,
+           j_r_pos[kk_minus][1] * a + j_r_pos[kk_minus+1][1] * b,
+           j_r_pos[kk_minus][2] * a + j_r_pos[kk_minus+1][2] * b};
+       std::vector<float> b_l_pos_minus = {
+           b_l_pos[kk_minus][0] * a + b_l_pos[kk_minus+1][0] * b,
+           b_l_pos[kk_minus][1] * a + b_l_pos[kk_minus+1][1] * b,
+           b_l_pos[kk_minus][2] * a + b_l_pos[kk_minus+1][2] * b};
+       std::vector<float> b_r_pos_minus = {
+           b_r_pos[kk_minus][0] * a + b_r_pos[kk_minus+1][0] * b,
+           b_r_pos[kk_minus][1] * a + b_r_pos[kk_minus+1][1] * b,
+           b_r_pos[kk_minus][2] * a + b_r_pos[kk_minus+1][2] * b};
+       std::vector<float> t_l_pos_minus = {
+           t_l_pos[kk_minus][0] * a + t_l_pos[kk_minus+1][0] * b,
+           t_l_pos[kk_minus][1] * a + t_l_pos[kk_minus+1][1] * b,
+           t_l_pos[kk_minus][2] * a + t_l_pos[kk_minus+1][2] * b};
+       std::vector<float> t_r_pos_minus = {
+           t_r_pos[kk_minus][0] * a + t_r_pos[kk_minus+1][0] * b,
+           t_r_pos[kk_minus][1] * a + t_r_pos[kk_minus+1][1] * b,
+           t_r_pos[kk_minus][2] * a + t_r_pos[kk_minus+1][2] * b};
+
+       // Calculating velocity of bucket corners
+       float j_l_vel = std::sqrt(
+           std::pow(j_l_pos_plus[0] - j_l_pos_minus[0], 2) +
+           std::pow(j_l_pos_plus[1] - j_l_pos_minus[1], 2) +
+           std::pow(j_l_pos_plus[2] - j_l_pos_minus[2], 2)) / dt_i;
+       float j_r_vel = std::sqrt(
+           std::pow(j_r_pos_plus[0] - j_r_pos_minus[0], 2) +
+           std::pow(j_r_pos_plus[1] - j_r_pos_minus[1], 2) +
+           std::pow(j_r_pos_plus[2] - j_r_pos_minus[2], 2)) / dt_i;
+       float b_l_vel = std::sqrt(
+           std::pow(b_l_pos_plus[0] - b_l_pos_minus[0], 2) +
+           std::pow(b_l_pos_plus[1] - b_l_pos_minus[1], 2) +
+           std::pow(b_l_pos_plus[2] - b_l_pos_minus[2], 2)) / dt_i;
+       float b_r_vel = std::sqrt(
+           std::pow(b_r_pos_plus[0] - b_r_pos_minus[0], 2) +
+           std::pow(b_r_pos_plus[1] - b_r_pos_minus[1], 2) +
+           std::pow(b_r_pos_plus[2] - b_r_pos_minus[2], 2)) / dt_i;
+       float t_l_vel = std::sqrt(
+           std::pow(t_l_pos_plus[0] - t_l_pos_minus[0], 2) +
+           std::pow(t_l_pos_plus[1] - t_l_pos_minus[1], 2) +
+           std::pow(t_l_pos_plus[2] - t_l_pos_minus[2], 2)) / dt_i;
+       float t_r_vel = std::sqrt(
+           std::pow(t_r_pos_plus[0] - t_r_pos_minus[0], 2) +
+           std::pow(t_r_pos_plus[1] - t_r_pos_minus[1], 2) +
+           std::pow(t_r_pos_plus[2] - t_r_pos_minus[2], 2)) / dt_i;
+
+       // Calculating the maximum velocity of the bucket
+       float max_bucket_vel = std::max({
+           j_l_vel, j_r_vel, b_l_vel, b_r_vel, t_l_vel, t_r_vel});
+
+       if (max_bucket_vel != 0.0) {
+           // Bucket is moving
+           dt_i = grid.cell_size_xy_ / max_bucket_vel;
+       } else {
+           // No bucket movement
+           dt_i = dt;
+       }
+
+       if (dt_i > dt) {
+           // Bucket is moving very slowly
+           time += dt;
+       } else {
+           // Bucket is mobing
+           time += dt_i;
+       }
+    }
+
+    // Adding final step
+    int nn = pos.size() - 1;
+    time_vec.push_back(total_time);
+    pos_vec.push_back(pos[nn]);
+    ori_vec.push_back(soil_simulator::AngleToQuat(
+        {-ori[nn][0], -ori[nn][1], -ori[nn][2]}));
+
+    // Simulation loop
+    for (auto ii = 0; ii < time_vec.size(); ii++) {
+        std::cout << "Step " << ii << " / " << time_vec.size() << "\n";
+
+        // Stepping the soil dynamics
+        sim.step(
+            sim_out, pos_vec[ii], ori_vec[ii], grid, bucket, sim_param, 1e-5);
+    }
+
+    delete bucket;
+    delete sim_out;
+
     return 0;
 }

--- a/src/soil_dynamics.cpp
+++ b/src/soil_dynamics.cpp
@@ -5,13 +5,34 @@ Copyright, 2023, Vilella Kenny.
 */
 #include <iostream>
 #include <random>
+#include <vector>
 #include "src/soil_dynamics.hpp"
 #include "src/types.hpp"
+#include "src/bucket_pos.hpp"
+#include "src/body_soil.hpp"
+#include "src/intersecting_cells.hpp"
+#include "src/relax.hpp"
+#include "src/utils.hpp"
 
 // Defining RNG
 std::mt19937 soil_simulator::rng;
 
-void soil_simulator::SoilDynamics::step() {
+void soil_simulator::SoilDynamics::step(
+    SimOut* sim_out, std::vector<float> pos, std::vector<float> ori,
+    Grid grid, Bucket* bucket, SimParam sim_param, float tol
+) {
+    // Updating bucket position
+    soil_simulator::CalcBucketPos(
+        sim_out, pos, ori, grid, bucket, sim_param, tol);
+
+    // Updating position of soil resting on the bucket
+    soil_simulator::UpdateBodySoil(sim_out, pos, ori, grid, bucket, tol);
+
+    // Moving intersecting soil cells
+    soil_simulator::MoveIntersectingCells(sim_out, tol);
+
+    // Assuming that the terrain is not at equilibrium
+    sim_out->equilibrium_ = false;
 }
 
 void soil_simulator::SoilDynamics::check() {

--- a/src/soil_dynamics.cpp
+++ b/src/soil_dynamics.cpp
@@ -198,7 +198,8 @@ int main() {
        pos_vec.push_back(std::vector<float> {
            pos[kk][0] * a + pos[kk+1][0] * b,
            pos[kk][1] * a + pos[kk+1][1] * b,
-           pos[kk][2] * a + pos[kk+1][5] * b});
+           pos[kk][2] * a + pos[kk+1][2] * b});
+
        ori_vec.push_back(soil_simulator::AngleToQuat({
             -(ori[kk][0] * a + ori[kk+1][0] * b),
             -(ori[kk][1] * a + ori[kk+1][1] * b),
@@ -318,7 +319,7 @@ int main() {
 
     // Simulation loop
     for (auto ii = 0; ii < time_vec.size(); ii++) {
-        std::cout << "Step " << ii << " / " << time_vec.size() << "\n";
+        std::cout << "Step " << ii << " / " << time_vec.size()-1 << "\n";
 
         // Stepping the soil dynamics
         sim.step(

--- a/src/soil_dynamics.hpp
+++ b/src/soil_dynamics.hpp
@@ -6,6 +6,8 @@ Copyright, 2023, Vilella Kenny.
 #pragma once
 
 #include <random>
+#include <vector>
+#include "src/types.hpp"
 
 namespace soil_simulator {
 
@@ -19,7 +21,9 @@ class SoilDynamics {
      void init();
 
      /// \brief Step the simulation.
-     void step();
+     void step(
+         SimOut* sim_out, std::vector<float> pos, std::vector<float> ori,
+         Grid grid, Bucket* bucket, SimParam sim_param, float tol);
 
      /// \brief Check the validity of the simulation outputs.
      void check();

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -161,12 +161,16 @@ soil_simulator::SimOut::SimOut(
         4, std::vector<std::vector<float>>(2*grid.half_length_x_+1,
         std::vector<float>(2*grid.half_length_y_+1, 0.0)));
 
-    body_soil_pos_.resize(1);
-
-    for (auto ii = 0 ; ii < 2 ; ii++)
-        for (auto jj = 0 ; jj < 2 ; jj++) {
-            bucket_area_[ii][jj] = 0.0;
-            relax_area_[ii][jj] = 0.0;
-            impact_area_[ii][jj] = 0.0;
-        }
+    bucket_area_[0][0] = 1;
+    relax_area_[0][0] = 1;
+    impact_area_[0][0] = 1;
+    bucket_area_[1][0] = 1;
+    relax_area_[1][0] = 1;
+    impact_area_[1][0] = 1;
+    bucket_area_[0][1] = 2 * grid.half_length_x_;
+    relax_area_[0][1] = 2 * grid.half_length_x_;
+    impact_area_[0][1] = 2 * grid.half_length_x_;
+    bucket_area_[1][1] = 2 * grid.half_length_y_;
+    relax_area_[1][1] = 2 * grid.half_length_y_;
+    impact_area_[1][1] = 2 * grid.half_length_y_;
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -146,18 +146,19 @@ std::tuple<
     // Initializing trajectory vector
     std::vector<std::vector<float>> pos;
     std::vector<std::vector<float>> ori;
-    pos.push_back(std::vector<float> {x_i, 0.0, z_i});
-    ori.push_back(
-        std::vector<float> {0.0, std::atan((2 * a * x_i) / x_i), 0.0});
 
     // Creating trajectory
-    for (auto ii = 1; ii < nn; ii++) {
+    for (auto ii = 0; ii < nn; ii++) {
         // Calculating the trajectory following a parabole
         float x = x_vec[ii];
         pos.push_back(std::vector<float> {x, 0.0, a * x * x + b * x + c});
 
         // Calculating orientation following the gradient of the trajectory
-        ori.push_back(std::vector<float> {0.0, std::atan((2 * a * x) / x), 0});
+        if (x == 0)
+            ori.push_back(std::vector<float> {0.0, 0.0, 0.0});
+        else
+            ori.push_back(std::vector<float> {
+                0.0, std::atan(2 * a * x + b), 0.0});
     }
 
     return {pos, ori};

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -8,12 +8,12 @@ Copyright, 2023, Vilella Kenny.
 #include <vector>
 #include "src/utils.hpp"
 
-std::vector <float> soil_simulator::CalcNormal(
-    std::vector <float> a, std::vector <float> b, std::vector <float> c
+std::vector<float> soil_simulator::CalcNormal(
+    std::vector<float> a, std::vector<float> b, std::vector<float> c
 ) {
     // Declaring vectors
-    std::vector <float> normal(3);
-    std::vector <float> cross(3);
+    std::vector<float> normal(3);
+    std::vector<float> cross(3);
 
     // Calculating cross product
     cross[0] = (b[1] - a[1]) * (c[2] - a[2]) - (b[2] - a[2]) * (c[1] - a[1]);
@@ -32,18 +32,18 @@ std::vector <float> soil_simulator::CalcNormal(
 
 /// The mathematical reasoning behind this implementation can be easily found
 /// in the Wiki page of Quaternion or elsewhere.
-std::vector <float> soil_simulator::CalcRotationQuaternion(
-    std::vector <float> ori, std::vector <float> pos
+std::vector<float> soil_simulator::CalcRotationQuaternion(
+    std::vector<float> ori, std::vector<float> pos
 ) {
     // Declaring vectors
     float norm_ori = (
         ori[0] * ori[0] + ori[1] * ori[1] + ori[2] * ori[2] + ori[3] * ori[3]);
-    std::vector <float> conj_ori = {
+    std::vector<float> conj_ori = {
         ori[0] / norm_ori,
         -ori[1] / norm_ori,
         -ori[2] / norm_ori,
         -ori[3] / norm_ori};
-    std::vector <float> temp_pos = {0.0, pos[0], pos[1], pos[2]};
+    std::vector<float> temp_pos = {0.0, pos[0], pos[1], pos[2]};
 
     // Calculating rotation
     auto temp_quat = soil_simulator::MultiplyQuaternion(conj_ori, temp_pos);
@@ -53,11 +53,11 @@ std::vector <float> soil_simulator::CalcRotationQuaternion(
 
 /// The mathematical reasoning behind this implementation can be easily found
 /// in the Wiki page of Quaternion or elsewhere.
-std::vector <float> soil_simulator::MultiplyQuaternion(
-    std::vector <float> q1, std::vector <float> q2
+std::vector<float> soil_simulator::MultiplyQuaternion(
+    std::vector<float> q1, std::vector<float> q2
 ) {
     // Declaring vectors
-    std::vector <float> quat(4);
+    std::vector<float> quat(4);
 
     // Calculating quaternion multiplication
     quat[0] = q1[0] * q2[0] - q1[1] * q2[1] - q1[2] * q2[2] - q1[3] * q2[3];
@@ -66,4 +66,49 @@ std::vector <float> soil_simulator::MultiplyQuaternion(
     quat[3] = q1[0] * q2[3] + q1[1] * q2[2] - q1[2] * q2[1] + q1[3] * q2[0];
 
     return quat;
+}
+
+std::tuple<
+    std::vector<std::vector<float>>, std::vector<std::vector<float>>
+> soil_simulator::CalcTrajectory(
+    float x_i, float z_i, float x_min, float z_min, int nn
+) {
+    // Calculating X vector of the trajectory
+    std::vector<float> x_vec(nn);
+    float delta_x = 2.0 * (x_min - x_i) / (nn - 1);
+    for (auto ii = 0; ii < nn; ii++)
+        x_vec[ii] = x_i + ii * delta_x;
+
+    // Calculating factor of the parabolic function
+    float a;
+    float b;
+    float c;
+    if (x_min == 0) {
+        a = (z_i - z_min) / (x_i * x_i);
+        b = 0.0;
+        c = z_min;
+    } else {
+        b = 2 * x_min * (z_min - z_i) / ((x_i - x_min) * (x_i - x_min));
+        a = -b / (2 * x_min);
+        c = z_min + b * b / (4 * a);
+    }
+
+    // Initializing trajectory vector
+    std::vector<std::vector<float>> pos;
+    std::vector<std::vector<float>> ori;
+    pos.push_back(std::vector<float> {x_i, 0.0, z_i});
+    ori.push_back(
+        std::vector<float> {0.0, std::atan((2 * a * x_i) / x_i), 0.0});
+
+    // Creating trajectory
+    for (auto ii = 1; ii < nn; ii++) {
+        // Calculating the trajectory following a parabole
+        float x = x_vec[ii];
+        pos.push_back(std::vector<float> {x, 0.0, a * x * x + b * x + c});
+
+        // Calculating orientation following the gradient of the trajectory
+        ori.push_back(std::vector<float> {0.0, std::atan((2 * a * x) / x), 0.0});
+    }
+
+    return {pos, ori};
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -51,6 +51,34 @@ std::vector<float> soil_simulator::CalcRotationQuaternion(
     return {quat[1], quat[2], quat[3]};
 }
 
+std::vector<float> soil_simulator::AngleToQuat(
+    std::vector<float> ori
+) {
+    // Compute the sines and cosines of half angle.
+    float sin_0 = std::sin(ori[0] / 2.0);
+    float sin_1 = std::sin(ori[1] / 2.0);
+    float sin_2 = std::sin(ori[2] / 2.0);
+    float cos_0 = std::cos(ori[0] / 2.0);
+    float cos_1 = std::cos(ori[1] / 2.0);
+    float cos_2 = std::cos(ori[2] / 2.0);
+
+    float q_0 = cos_0 * cos_1 * cos_2 + sin_0 * sin_1 * sin_2;
+    std::vector<float> quat(4);
+    if (q_0 > 0) {
+        quat[0] = q_0;
+        quat[1] = cos_0 * cos_1 * sin_2 - sin_0 * sin_1 * cos_2;
+        quat[2] = cos_0 * sin_1 * cos_2 + sin_0 * cos_1 * sin_2;
+        quat[3] = sin_0 * cos_1 * cos_2 - cos_0 * sin_1 * sin_2;
+    } else {
+        quat[0] = -q_0;
+        quat[1] = -cos_0 * cos_1 * sin_2 + sin_0 * sin_1 * cos_2;
+        quat[2] = -cos_0 * sin_1 * cos_2 - sin_0 * cos_1 * sin_2;
+        quat[3] = -sin_0 * cos_1 * cos_2 + cos_0 * sin_1 * sin_2;
+    }
+
+    return quat;
+}
+
 /// The mathematical reasoning behind this implementation can be easily found
 /// in the Wiki page of Quaternion or elsewhere.
 std::vector<float> soil_simulator::MultiplyQuaternion(
@@ -107,7 +135,7 @@ std::tuple<
         pos.push_back(std::vector<float> {x, 0.0, a * x * x + b * x + c});
 
         // Calculating orientation following the gradient of the trajectory
-        ori.push_back(std::vector<float> {0.0, std::atan((2 * a * x) / x), 0.0});
+        ori.push_back(std::vector<float> {0.0, std::atan((2 * a * x) / x), 0});
     }
 
     return {pos, ori};

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -51,6 +51,11 @@ std::vector<float> soil_simulator::CalcRotationQuaternion(
     return {quat[1], quat[2], quat[3]};
 }
 
+/// The mathematical reasoning behind this implementation can be easily found
+/// in the Wiki page of Quaternion or elsewhere.
+///
+/// Note that this function only works if the Euler angles follow the
+/// ZYX convention.
 std::vector<float> soil_simulator::AngleToQuat(
     std::vector<float> ori
 ) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -154,11 +154,7 @@ std::tuple<
         pos.push_back(std::vector<float> {x, 0.0, a * x * x + b * x + c});
 
         // Calculating orientation following the gradient of the trajectory
-        if (x == 0)
-            ori.push_back(std::vector<float> {0.0, 0.0, 0.0});
-        else
-            ori.push_back(std::vector<float> {
-                0.0, std::atan(2 * a * x + b), 0.0});
+        ori.push_back(std::vector<float> {0.0, std::atan(2 * a * x + b), 0.0});
     }
 
     return {pos, ori};

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -96,6 +96,23 @@ std::vector<float> soil_simulator::MultiplyQuaternion(
     return quat;
 }
 
+/// The parabolic trajectory is described by
+///
+///    z(x) = a * x * x + b * x + c.
+///
+/// Knowing that at the starting position
+///
+///    z(x_i) = z_i
+///
+/// and that at the deepest point of the trajectory
+///
+///    dz(x_min) / dx = 0.0
+///    z(x_min) = z_min,
+///
+/// it is possible to calculate the three parameters (a, b, c) of the parabolic
+/// equation. The orientation is assumed to be equal to the gradient of the
+/// trajectory. This implies that the bucket teeth would follow the movement, so
+/// that it can somewhat replicate an actual digging scoop.
 std::tuple<
     std::vector<std::vector<float>>, std::vector<std::vector<float>>
 > soil_simulator::CalcTrajectory(

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -35,6 +35,8 @@ std::vector<float> CalcNormal(
 std::vector<float> CalcRotationQuaternion(
     std::vector<float> ori, std::vector<float> pos);
 
+std::vector<float> AngleToQuat(std::vector<float> ori);
+
 /// \brief This function calculates the product of two Quaternions.
 ///
 /// \param q1: First quaternion. [Quaternion]

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -6,6 +6,7 @@ Copyright, 2023, Vilella Kenny.
 #pragma once
 
 #include <vector>
+#include <tuple>
 
 namespace soil_simulator {
 
@@ -17,8 +18,8 @@ namespace soil_simulator {
 /// \param c: Cartesian coordinates of the third point of the plane. [m]
 ///
 /// \return Unit normal vector of the provided plane. [m]
-std::vector <float> CalcNormal(
-    std::vector <float> a, std::vector <float> b, std::vector <float> c);
+std::vector<float> CalcNormal(
+    std::vector<float> a, std::vector<float> b, std::vector<float> c);
 
 /// \brief This function applies a rotation `ori` to the Cartesian
 ///        coordinates `pos`.
@@ -31,8 +32,8 @@ std::vector <float> CalcNormal(
 ///
 /// \return Rotated Cartesian coordinates of the input `pos` relative to the
 ///         bucket origin. [m]
-std::vector <float> CalcRotationQuaternion(
-    std::vector <float> ori, std::vector <float> pos);
+std::vector<float> CalcRotationQuaternion(
+    std::vector<float> ori, std::vector<float> pos);
 
 /// \brief This function calculates the product of two Quaternions.
 ///
@@ -40,6 +41,10 @@ std::vector <float> CalcRotationQuaternion(
 /// \param q2: Second quaternion. [Quaternion]
 ///
 /// \return Product of the two inputs quaternions. [Quaternion]
-std::vector <float> MultiplyQuaternion(
-    std::vector <float> q1, std::vector <float> q2);
+std::vector<float> MultiplyQuaternion(
+    std::vector<float> q1, std::vector<float> q2);
+
+std::tuple<
+    std::vector<std::vector<float>>, std::vector<std::vector<float>>
+> CalcTrajectory(float x_i, float z_i, float x_min, float z_min, int nn);
 }  // namespace soil_simulator

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -46,6 +46,19 @@ std::vector<float> AngleToQuat(std::vector<float> ori);
 std::vector<float> MultiplyQuaternion(
     std::vector<float> q1, std::vector<float> q2);
 
+/// \brief This function calculates a parabolic trajectory given the starting
+///        position (`x_i`, `z_i`) and the deepest position (`x_min`, `z_min`)
+///        of the trajectory.
+///
+/// \param x_i: X coordinate of the starting position of the trajectory. [m]
+/// \param z_i: Z coordinate of the starting position of the trajectory. [m]
+/// \param x_min: X coordinate of the deepest position of the trajectory. [m]
+/// \param z_min: Z coordinate of the deepest position of the trajectory. [m]
+/// \param nn: Number of increments in the trajectory.
+///
+/// \return A tuple composed of a vector aggregating the position of the bucket
+///         with time in meter, and a vector aggregating the orientation of the
+///         bucket with time following the quaternion convention.
 std::tuple<
     std::vector<std::vector<float>>, std::vector<std::vector<float>>
 > CalcTrajectory(float x_i, float z_i, float x_min, float z_min, int nn);

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -35,6 +35,12 @@ std::vector<float> CalcNormal(
 std::vector<float> CalcRotationQuaternion(
     std::vector<float> ori, std::vector<float> pos);
 
+/// \brief This function converts Euler angles following the ZYX convention to
+///        a quaternion.
+///
+/// \param ori: Orientation of the bucket. [Euler angles, ZYX sequence]
+///
+/// \return Orientation of the bucket. [Quaternion]
 std::vector<float> AngleToQuat(std::vector<float> ori);
 
 /// \brief This function calculates the product of two Quaternions.

--- a/test/unit_tests/test_bucket_pos.cpp
+++ b/test/unit_tests/test_bucket_pos.cpp
@@ -1666,7 +1666,8 @@ TEST(UnitTestBucketPos, CalcBucketPos) {
     std::vector<float> j_pos = {0.0, 0.0, 0.0};
     std::vector<float> b_pos = {0.5, 0.01, 0.0};
     std::vector<float> t_pos = {0.5, 0.0, 0.0};
-    soil_simulator::Bucket bucket(o_pos, j_pos, b_pos, t_pos, 0.5);
+    soil_simulator::Bucket *bucket = new soil_simulator::Bucket(
+        o_pos, j_pos, b_pos, t_pos, 0.5);
     std::vector<float> ori = {1.0, 0.0, 0.0, 0.0};
     std::vector<float> pos = {0.0, 0.0, 0.0};
     soil_simulator::CalcBucketPos(
@@ -1695,12 +1696,13 @@ TEST(UnitTestBucketPos, CalcBucketPos) {
                     (kk == 10) && (jj < 16) && (jj > 9)))
                     EXPECT_NEAR(sim_out->body_[ii][jj][kk], 0.0, 1.e-5);
             }
+
     // -- Testing for a bucket in the XY plane --
     b_pos = {0.5, 0.0, -0.01};
     t_pos = {0.5, 0.0, 0.0};
-    soil_simulator::Bucket bucket_2(o_pos, j_pos, b_pos, t_pos, 0.5);
+    *bucket = soil_simulator::Bucket(o_pos, j_pos, b_pos, t_pos, 0.5);
     soil_simulator::CalcBucketPos(
-        sim_out, pos, ori, grid, bucket_2, sim_param, 1.e-5);
+        sim_out, pos, ori, grid, bucket, sim_param, 1.e-5);
     for (auto ii = 0; ii < sim_out->body_.size(); ii++)
         for (auto jj = 0; jj < sim_out->body_[0].size(); jj++)
             for (auto kk = 0; kk < sim_out->body_[0][0].size(); kk++)
@@ -1721,11 +1723,11 @@ TEST(UnitTestBucketPos, CalcBucketPos) {
     // -- Testing for a bucket in a dummy position --
     b_pos = {0.0, 0.0, -0.5};
     t_pos = {0.5, 0.0, -0.5};
-    soil_simulator::Bucket bucket_3(o_pos, j_pos, b_pos, t_pos, 0.5);
+    *bucket = soil_simulator::Bucket(o_pos, j_pos, b_pos, t_pos, 0.5);
     ori = {0.707107, 0.0, -0.707107, 0.0};  // -pi/2 rotation around the Y axis
     pos = {0.0, 0.0, -0.1};
     soil_simulator::CalcBucketPos(
-        sim_out, pos, ori, grid, bucket_3, sim_param, 1.e-5);
+        sim_out, pos, ori, grid, bucket, sim_param, 1.e-5);
     for (auto jj = 5; jj < 11; jj++)
         for (auto kk = 8; kk < 13; kk++)
             EXPECT_NEAR(sim_out->body_[1][jj][kk], -0.1, 1.e-5);
@@ -1756,5 +1758,6 @@ TEST(UnitTestBucketPos, CalcBucketPos) {
                     EXPECT_NEAR(sim_out->body_[ii][jj][kk], 0.0, 1.e-5);
             }
 
+    delete bucket;
     delete sim_out;
 }

--- a/test/unit_tests/test_types.cpp
+++ b/test/unit_tests/test_types.cpp
@@ -184,10 +184,16 @@ TEST(UnitTestTypes, SimOut) {
     EXPECT_EQ(sim_out.body_soil_.size(), 4);
     EXPECT_EQ(sim_out.body_soil_[0].size(), 5);
     EXPECT_EQ(sim_out.body_soil_[0][0].size(), 5);
-    for (auto ii = 0 ; ii < 2 ; ii++)
-        for (auto jj = 0 ; jj < 2 ; jj++) {
-            EXPECT_NEAR(sim_out.bucket_area_[ii][jj], 0.0, 1e-8);
-            EXPECT_NEAR(sim_out.relax_area_[ii][jj], 0.0, 1e-8);
-            EXPECT_NEAR(sim_out.impact_area_[ii][jj], 0.0, 1e-8);
-        }
+    EXPECT_EQ(sim_out.bucket_area_[0][0], 1);
+    EXPECT_EQ(sim_out.relax_area_[0][0], 1);
+    EXPECT_EQ(sim_out.impact_area_[0][0], 1);
+    EXPECT_EQ(sim_out.bucket_area_[0][1], 4);
+    EXPECT_EQ(sim_out.relax_area_[0][1], 4);
+    EXPECT_EQ(sim_out.impact_area_[0][1], 4);
+    EXPECT_EQ(sim_out.bucket_area_[1][0], 1);
+    EXPECT_EQ(sim_out.relax_area_[1][0], 1);
+    EXPECT_EQ(sim_out.impact_area_[1][0], 1);
+    EXPECT_EQ(sim_out.bucket_area_[1][1], 4);
+    EXPECT_EQ(sim_out.relax_area_[1][1], 4);
+    EXPECT_EQ(sim_out.impact_area_[1][1], 4);
 }

--- a/test/unit_tests/test_utils.cpp
+++ b/test/unit_tests/test_utils.cpp
@@ -114,7 +114,7 @@ TEST(UnitTestUtils, CalcRotationQuaternion) {
     EXPECT_NEAR(new_pos[1], 0.5, 1e-5);
     EXPECT_NEAR(new_pos[2], -0.1, 1e-5);
 
-    // -- Testing applying a pi/2 rotation around the Y axis --
+    // -- Testing applying a pi/2 rotation around the X axis --
     ori = {0.707107, -0.707107, 0.0, 0.0};
     pos = {-0.1, 0.3, -0.5};
     new_pos = soil_simulator::CalcRotationQuaternion(ori, pos);
@@ -130,4 +130,42 @@ TEST(UnitTestUtils, CalcRotationQuaternion) {
     EXPECT_NEAR(new_pos[0], -0.380155, 1e-5);
     EXPECT_NEAR(new_pos[1], 0.504297, 1e-5);
     EXPECT_NEAR(new_pos[2], -0.29490, 1e-5);
+}
+
+TEST(UnitTestUtils, AngleToQuat) {
+    // -- Testing applying a pi/2 rotation around the Z axis --
+    std::vector<float> ori = {-1.570796327, 0.0, 0.0};
+    auto quat = soil_simulator::AngleToQuat(ori);
+    EXPECT_NEAR(quat[0], 0.707107, 1e-5);
+    EXPECT_NEAR(quat[1], 0.0, 1e-5);
+    EXPECT_NEAR(quat[2], 0.0, 1e-5);
+    EXPECT_NEAR(quat[3], -0.707107, 1e-5);
+
+    // -- Testing applying a pi/2 rotation around the Y axis --
+    ori = {0.0, -1.570796327, 0.0};
+    quat = soil_simulator::AngleToQuat(ori);
+    EXPECT_NEAR(quat[0], 0.707107, 1e-5);
+    EXPECT_NEAR(quat[1], 0.0, 1e-5);
+    EXPECT_NEAR(quat[2], -0.707107, 1e-5);
+    EXPECT_NEAR(quat[3], 0.0, 1e-5);
+
+    // -- Testing applying a pi/2 rotation around the X axis --
+    ori = {0.0, 0.0, -1.570796327};
+    quat = soil_simulator::AngleToQuat(ori);
+    EXPECT_NEAR(quat[0], 0.707107, 1e-5);
+    EXPECT_NEAR(quat[1], -0.707107, 1e-5);
+    EXPECT_NEAR(quat[2], 0.0, 1e-5);
+    EXPECT_NEAR(quat[3], 0.0, 1e-5);
+
+    // -- Testing applying an arbitrary rotation --
+    // Results checked against ReferenceFrameRotations library in Julia
+    ori = {0.53, 1.2, -0.3};
+    quat = soil_simulator::AngleToQuat(ori);
+    EXPECT_NEAR(quat[0], 0.765481, 1e-5);
+    EXPECT_NEAR(quat[1], -0.265256, 1e-5);
+    EXPECT_NEAR(quat[2], 0.50651, 1e-5);
+    EXPECT_NEAR(quat[3], 0.295169, 1e-5);
+}
+
+TEST(UnitTestUtils, CalcTrajectory) {
 }

--- a/test/unit_tests/test_utils.cpp
+++ b/test/unit_tests/test_utils.cpp
@@ -168,4 +168,76 @@ TEST(UnitTestUtils, AngleToQuat) {
 }
 
 TEST(UnitTestUtils, CalcTrajectory) {
+    // -- Testing for a simple flat trajectory --
+    auto [pos, ori] = soil_simulator::CalcTrajectory(-1.0, 0.0, 0.0, 0.0, 3);
+    EXPECT_EQ(pos.size(), 3);
+    EXPECT_EQ(ori.size(), 3);
+    EXPECT_TRUE((pos[0] == std::vector<float> {-1.0, 0.0, 0.0}));
+    EXPECT_TRUE((pos[1] == std::vector<float> {0.0, 0.0, 0.0}));
+    EXPECT_TRUE((pos[2] == std::vector<float> {1.0, 0.0, 0.0}));
+    EXPECT_TRUE((ori[0] == std::vector<float> {0.0, 0.0, 0.0}));
+    EXPECT_TRUE((ori[1] == std::vector<float> {0.0, 0.0, 0.0}));
+    EXPECT_TRUE((ori[2] == std::vector<float> {0.0, 0.0, 0.0}));
+
+    // -- Testing for a simple trajectory --
+    std::tie(pos, ori) = soil_simulator::CalcTrajectory(-1.0, 0.0, 0.0, -1.0, 3);
+    EXPECT_EQ(pos.size(), 3);
+    EXPECT_EQ(ori.size(), 3);
+    EXPECT_TRUE((pos[0] == std::vector<float> {-1.0, 0.0, 0.0}));
+    EXPECT_TRUE((pos[1] == std::vector<float> {0.0, 0.0, -1.0}));
+    EXPECT_TRUE((pos[2] == std::vector<float> {1.0, 0.0, 0.0}));
+    for (auto ii = 0; ii < 3; ii++) {
+        EXPECT_NEAR(ori[ii][0], 0.0, 1e-5);
+        EXPECT_NEAR(ori[ii][2], 0.0, 1e-5);
+    }
+    EXPECT_NEAR(ori[0][1], -1.10715, 1e-5);
+    EXPECT_NEAR(ori[1][1], 0.0, 1e-5);
+    EXPECT_NEAR(ori[2][1], 1.10715, 1e-5);
+
+    // -- Testing for a simple trajectory translated in the Z axis --
+    std::tie(pos, ori) = soil_simulator::CalcTrajectory(-1.0, 2.5, 0.0, 1.5, 3);
+    EXPECT_EQ(pos.size(), 3);
+    EXPECT_EQ(ori.size(), 3);
+    EXPECT_TRUE((pos[0] == std::vector<float> {-1.0, 0.0, 2.5}));
+    EXPECT_TRUE((pos[1] == std::vector<float> {0.0, 0.0, 1.5}));
+    EXPECT_TRUE((pos[2] == std::vector<float> {1.0, 0.0, 2.5}));
+    for (auto ii = 0; ii < 3; ii++) {
+        EXPECT_NEAR(ori[ii][0], 0.0, 1e-5);
+        EXPECT_NEAR(ori[ii][2], 0.0, 1e-5);
+    }
+    EXPECT_NEAR(ori[0][1], -1.10715, 1e-5);
+    EXPECT_NEAR(ori[1][1], 0.0, 1e-5);
+    EXPECT_NEAR(ori[2][1], 1.10715, 1e-5);
+
+    // -- Testing for a simple trajectory translated in the X axis --
+    std::tie(pos, ori) = soil_simulator::CalcTrajectory(2.0, 0.0, 3.0, -1.0, 3);
+    EXPECT_EQ(pos.size(), 3);
+    EXPECT_EQ(ori.size(), 3);
+    EXPECT_TRUE((pos[0] == std::vector<float> {2.0, 0.0, 0.0}));
+    EXPECT_TRUE((pos[1] == std::vector<float> {3.0, 0.0, -1.0}));
+    EXPECT_TRUE((pos[2] == std::vector<float> {4.0, 0.0, 0.0}));
+    for (auto ii = 0; ii < 3; ii++) {
+        EXPECT_NEAR(ori[ii][0], 0.0, 1e-5);
+        EXPECT_NEAR(ori[ii][2], 0.0, 1e-5);
+    }
+    EXPECT_NEAR(ori[0][1], -1.10715, 1e-5);
+    EXPECT_NEAR(ori[1][1], 0.0, 1e-5);
+    EXPECT_NEAR(ori[2][1], 1.10715, 1e-5);
+
+    // -- Testing for a simple trajectory with more points --
+    std::tie(pos, ori) = soil_simulator::CalcTrajectory(-1.0, 0.0, 0.0, -1.0, 5);
+    EXPECT_EQ(pos.size(), 5);
+    EXPECT_EQ(ori.size(), 5);
+    EXPECT_TRUE((pos[0] == std::vector<float> {-1.0, 0.0, 0.0}));
+    EXPECT_TRUE((pos[1] == std::vector<float> {-0.5, 0.0, -0.75}));
+    EXPECT_TRUE((pos[2] == std::vector<float> {0.0, 0.0, -1.0}));
+    EXPECT_TRUE((pos[3] == std::vector<float> {0.5, 0.0, -0.75}));
+    EXPECT_TRUE((pos[4] == std::vector<float> {1.0, 0.0, 0.0}));
+    for (auto ii = 0; ii < 5; ii++) {
+        EXPECT_NEAR(ori[ii][0], 0.0, 1e-5);
+        EXPECT_NEAR(ori[ii][2], 0.0, 1e-5);
+    }
+    EXPECT_NEAR(ori[0][1], -1.10715, 1e-5);
+    EXPECT_NEAR(ori[2][1], 0.0, 1e-5);
+    EXPECT_NEAR(ori[4][1], 1.10715, 1e-5);
 }

--- a/test/unit_tests/test_utils.cpp
+++ b/test/unit_tests/test_utils.cpp
@@ -180,7 +180,8 @@ TEST(UnitTestUtils, CalcTrajectory) {
     EXPECT_TRUE((ori[2] == std::vector<float> {0.0, 0.0, 0.0}));
 
     // -- Testing for a simple trajectory --
-    std::tie(pos, ori) = soil_simulator::CalcTrajectory(-1.0, 0.0, 0.0, -1.0, 3);
+    std::tie(pos, ori) = soil_simulator::CalcTrajectory(
+        -1.0, 0.0, 0.0, -1.0, 3);
     EXPECT_EQ(pos.size(), 3);
     EXPECT_EQ(ori.size(), 3);
     EXPECT_TRUE((pos[0] == std::vector<float> {-1.0, 0.0, 0.0}));
@@ -225,7 +226,8 @@ TEST(UnitTestUtils, CalcTrajectory) {
     EXPECT_NEAR(ori[2][1], 1.10715, 1e-5);
 
     // -- Testing for a simple trajectory with more points --
-    std::tie(pos, ori) = soil_simulator::CalcTrajectory(-1.0, 0.0, 0.0, -1.0, 5);
+    std::tie(pos, ori) = soil_simulator::CalcTrajectory(
+        -1.0, 0.0, 0.0, -1.0, 5);
     EXPECT_EQ(pos.size(), 5);
     EXPECT_EQ(ori.size(), 5);
     EXPECT_TRUE((pos[0] == std::vector<float> {-1.0, 0.0, 0.0}));


### PR DESCRIPTION
# Description
- Changed `Bucket` class to a pointer
- Added implementation for the `step` function
- Added implementation of an example script for the simulator in the `main` function
- Improved initialization of `bucket_area_`, `impact_area_` and `relax_area_`
- Improved formatting in `utils.cpp` and `utils.hpp`
- Added implementation for the `AngleToQuat` function
- Added unit tests for the `AngleToQuat` function
- Added implementation for the `CalcTrajectory` function
- Added unit tests for the `CalcTrajectory` function
- Changed all unit tests accordingly to changes
- Added some unit tests when necessary

# Note
The example script may not be entirely working.
Checking and verification will be done in a later PR.