### PR TITLE
Added default constructor for SimOut

### DIFF
--- a/soil_simulator/types.hpp
+++ b/soil_simulator/types.hpp
@@ -355,7 +355,7 @@ class SimOut {
      ///
      /// \param grid: Class that stores information related to the simulation
      ///              grid.
-     SimOut(Grid grid = Grid());
+     explicit SimOut(Grid grid = Grid());
 
      /// \brief Destructor
     ~SimOut() {}

--- a/soil_simulator/types.hpp
+++ b/soil_simulator/types.hpp
@@ -355,7 +355,7 @@ class SimOut {
      ///
      /// \param grid: Class that stores information related to the simulation
      ///              grid.
-     explicit SimOut(Grid grid);
+     SimOut(Grid grid = Grid());
 
      /// \brief Destructor
     ~SimOut() {}


### PR DESCRIPTION
# Description
- Added a default constructor for the `SimOut` class, this is to make its sue easier for third-party.