### PR TITLE
Add a check for the bucket movement

### DIFF
--- a/soil_simulator/bucket_pos.cpp
+++ b/soil_simulator/bucket_pos.cpp
@@ -23,7 +23,7 @@ void soil_simulator::CalcBucketPos(
     SimOut* sim_out, std::vector<float> pos, std::vector<float> ori, Grid grid,
     Bucket* bucket, SimParam sim_param, float tol
 ) {
-    // Calculating position of the bucker corners
+    // Calculating position of the bucket corners
     auto [j_r_pos, j_l_pos, b_r_pos, b_l_pos, t_r_pos, t_l_pos] =
         soil_simulator::CalcBucketCornerPos(pos, ori, bucket);
 

--- a/soil_simulator/bucket_pos.cpp
+++ b/soil_simulator/bucket_pos.cpp
@@ -23,39 +23,11 @@ void soil_simulator::CalcBucketPos(
     SimOut* sim_out, std::vector<float> pos, std::vector<float> ori, Grid grid,
     Bucket* bucket, SimParam sim_param, float tol
 ) {
-    // Calculating position of the bucker vertices
-    auto j_pos = soil_simulator::CalcRotationQuaternion(
-        ori, bucket->j_pos_init_);
-    auto b_pos = soil_simulator::CalcRotationQuaternion(
-        ori, bucket->b_pos_init_);
-    auto t_pos = soil_simulator::CalcRotationQuaternion(
-        ori, bucket->t_pos_init_);
-
-    // Unit vector normal to the side of the bucket
-    auto normal_side = soil_simulator::CalcNormal(j_pos, b_pos, t_pos);
-
-    // Declaring vectors for each vertex of the bucket
-    std::vector<float> j_r_pos(3);
-    std::vector<float> j_l_pos(3);
-    std::vector<float> b_r_pos(3);
-    std::vector<float> b_l_pos(3);
-    std::vector<float> t_r_pos(3);
-    std::vector<float> t_l_pos(3);
+    // Calculating position of the bucker corners
+    auto [j_r_pos, j_l_pos, b_r_pos, b_l_pos, t_r_pos, t_l_pos] =
+        soil_simulator::CalcBucketCornerPos(pos, ori, bucket);
 
     for (auto ii = 0; ii < 3; ii++) {
-        // Adding position of the bucket origin
-        j_pos[ii] += pos[ii];
-        b_pos[ii] += pos[ii];
-        t_pos[ii] += pos[ii];
-
-        // Position of each vertex of the bucket
-        j_r_pos[ii] = j_pos[ii] + 0.5 * bucket->width_ * normal_side[ii];
-        j_l_pos[ii] = j_pos[ii] - 0.5 * bucket->width_ * normal_side[ii];
-        b_r_pos[ii] = b_pos[ii] + 0.5 * bucket->width_ * normal_side[ii];
-        b_l_pos[ii] = b_pos[ii] - 0.5 * bucket->width_ * normal_side[ii];
-        t_r_pos[ii] = t_pos[ii] + 0.5 * bucket->width_ * normal_side[ii];
-        t_l_pos[ii] = t_pos[ii] - 0.5 * bucket->width_ * normal_side[ii];
-
         // Adding a small increment to all vertices
         // This is to account for the edge case where one of the vertex is at
         // cell border. In that case, the increment would remove any ambiguity

--- a/soil_simulator/soil_dynamics.cpp
+++ b/soil_simulator/soil_dynamics.cpp
@@ -18,6 +18,15 @@ void soil_simulator::SoilDynamics::step(
     SimOut* sim_out, std::vector<float> pos, std::vector<float> ori,
     Grid grid, Bucket* bucket, SimParam sim_param, float tol
 ) {
+    // Checking movement made by the bucket
+    auto soil_update = soil_simulator::CheckBucketMovement(
+        pos, ori, grid, bucket);
+
+    if (!soil_update) {
+        // Bucket has not moved enough
+        return;
+    }
+
     // Updating bucket position
     soil_simulator::CalcBucketPos(
         sim_out, pos, ori, grid, bucket, sim_param, tol);

--- a/soil_simulator/soil_dynamics.cpp
+++ b/soil_simulator/soil_dynamics.cpp
@@ -14,7 +14,7 @@ Copyright, 2023, Vilella Kenny.
 #include "soil_simulator/relax.hpp"
 #include "soil_simulator/utils.hpp"
 
-void soil_simulator::SoilDynamics::step(
+bool soil_simulator::SoilDynamics::step(
     SimOut* sim_out, std::vector<float> pos, std::vector<float> ori,
     Grid grid, Bucket* bucket, SimParam sim_param, float tol
 ) {
@@ -24,7 +24,7 @@ void soil_simulator::SoilDynamics::step(
 
     if (!soil_update) {
         // Bucket has not moved enough
-        return;
+        return false;
     }
 
     // Updating bucket position
@@ -61,6 +61,7 @@ void soil_simulator::SoilDynamics::step(
         // Relaxing the soil resting on the bucket
         RelaxBodySoil(sim_out, grid, sim_param, tol);
     }
+    return true;
 }
 
 void soil_simulator::SoilDynamics::check(

--- a/soil_simulator/soil_dynamics.hpp
+++ b/soil_simulator/soil_dynamics.hpp
@@ -32,7 +32,9 @@ class SoilDynamics {
      /// \param sim_param: Class that stores information related to
      ///                   the simulation.
      /// \param tol: Small number used to handle numerical approximation errors.
-     void step(
+     ///
+     /// \return A boolean indicating whether soil update has been done.
+     bool step(
          SimOut* sim_out, std::vector<float> pos, std::vector<float> ori,
          Grid grid, Bucket* bucket, SimParam sim_param, float tol);
 

--- a/soil_simulator/utils.cpp
+++ b/soil_simulator/utils.cpp
@@ -57,6 +57,14 @@ soil_simulator::CalcBucketCornerPos(
     return {j_r_pos, j_l_pos, b_r_pos, b_l_pos, t_r_pos, t_l_pos};
 }
 
+/// This function calculates the maximum distance traveled by any part of the
+/// bucket since the last soil update. The position of the bucket during the
+/// last soil update is stored in the `bucket` class.
+///
+/// If the maximum distance traveled is lower than 10% of the cell size,
+/// the function returns `false` otherwise it returns `true`.
+/// Note that if the distance traveled exceeds twice the cell size, a warning is
+/// issued to indicate a potential problem with the soil update.
 bool soil_simulator::CheckBucketMovement(
     std::vector<float> pos, std::vector<float> ori, Grid grid, Bucket* bucket
 ) {

--- a/soil_simulator/utils.cpp
+++ b/soil_simulator/utils.cpp
@@ -20,7 +20,7 @@ std::tuple<
 soil_simulator::CalcBucketCornerPos(
     std::vector<float> pos, std::vector<float> ori, Bucket* bucket
 ) {
-    // Calculating position of the bucker vertices
+    // Calculating position of the bucket vertices
     auto j_pos = soil_simulator::CalcRotationQuaternion(
         ori, bucket->j_pos_init_);
     auto b_pos = soil_simulator::CalcRotationQuaternion(
@@ -76,7 +76,7 @@ bool soil_simulator::CheckBucketMovement(
     auto [j_r_pos_f, j_l_pos_f, b_r_pos_f, b_l_pos_f, t_r_pos_f, t_l_pos_f] =
         soil_simulator::CalcBucketCornerPos(bucket->pos_, bucket->ori_, bucket);
 
-    // Calculating distance travelled
+    // Calculating distance traveled
     float j_r_dist = std::sqrt(
         (j_r_pos_f[0] - j_r_pos_n[0]) * (j_r_pos_f[0] - j_r_pos_n[0]) +
         (j_r_pos_f[1] - j_r_pos_n[1]) * (j_r_pos_f[1] - j_r_pos_n[1])+
@@ -102,7 +102,7 @@ bool soil_simulator::CheckBucketMovement(
         (t_l_pos_f[1] - t_l_pos_n[1]) * (t_l_pos_f[1] - t_l_pos_n[1]) +
         (t_l_pos_f[2] - t_l_pos_n[2]) * (t_l_pos_f[2] - t_l_pos_n[2]));
 
-    // Calculating max distance travelled
+    // Calculating max distance traveled
     float max_dist = std::max(
         {j_r_dist, j_l_dist, b_r_dist, b_l_dist, t_r_dist, t_l_dist});
 
@@ -513,7 +513,7 @@ void soil_simulator::WriteSoil(
 void soil_simulator::WriteBucket(
     Bucket* bucket
 ) {
-    // Calculating position of the bucker points
+    // Calculating position of the bucket points
     auto j_pos = soil_simulator::CalcRotationQuaternion(
         bucket->ori_, bucket->j_pos_init_);
     auto b_pos = soil_simulator::CalcRotationQuaternion(

--- a/soil_simulator/utils.hpp
+++ b/soil_simulator/utils.hpp
@@ -11,12 +11,34 @@ Copyright, 2023, Vilella Kenny.
 
 namespace soil_simulator {
 
+/// \brief This function calculates the global position of the six corners of
+///        the bucket.
+///
+/// \param pos: Cartesian coordinates of the bucket origin. [m]
+/// \param ori: Orientation of the bucket. [Quaternion]
+/// \param bucket: Class that stores information related to the bucket object.
+///
+/// \return A tuple composed of six vectors giving the Cartesian coordinates
+///         of the bucket corners in that order: right side of the bucket joint,
+///         left side of the bucket joint, right side of the bucket base, left
+///         side of the bucket base, right side of the bucket teeth, left side
+///         of the bucket teeth. [m]
 std::tuple<
     std::vector<float>, std::vector<float>, std::vector<float>,
     std::vector<float>, std::vector<float>, std::vector<float>>
 CalcBucketCornerPos(
     std::vector<float> pos, std::vector<float> ori, Bucket* bucket);
 
+/// \brief This function calculates how far the bucket has traveled since the
+///        last soil update and checks whether it is necessary to update the
+///        soil.
+///
+/// \param pos: Cartesian coordinates of the bucket origin. [m]
+/// \param ori: Orientation of the bucket. [Quaternion]
+/// \param grid: Class that stores information related to the simulation grid.
+/// \param bucket: Class that stores information related to the bucket object.
+///
+/// \return A boolean indicating whether the soil should be updated.
 bool CheckBucketMovement(
     std::vector<float> pos, std::vector<float> ori, Grid grid, Bucket* bucket);
 
@@ -90,6 +112,6 @@ void WriteSoil(SimOut* sim_out, Grid grid);
 /// \brief This function writes the position of all bucket faces into a csv
 ///        located in the `results` directory.
 ///
-/// \param grid: Class that stores information related to the simulation grid.
+/// bucket: Class that stores information related to the bucket object.
 void WriteBucket(Bucket* bucket);
 }  // namespace soil_simulator

--- a/soil_simulator/utils.hpp
+++ b/soil_simulator/utils.hpp
@@ -5,11 +5,20 @@ Copyright, 2023, Vilella Kenny.
 */
 #pragma once
 
-#include <vector>
 #include <tuple>
+#include <vector>
 #include "soil_simulator/types.hpp"
 
 namespace soil_simulator {
+
+std::tuple<
+    std::vector<float>, std::vector<float>, std::vector<float>,
+    std::vector<float>, std::vector<float>, std::vector<float>>
+CalcBucketCornerPos(
+    std::vector<float> pos, std::vector<float> ori, Bucket* bucket);
+
+bool CheckBucketMovement(
+    std::vector<float> pos, std::vector<float> ori, Grid grid, Bucket* bucket);
 
 /// \brief This function calculates the unit normal vector of a plane formed by
 ///        three points using the right-hand rule.

--- a/test/example/soil_evolution.cpp
+++ b/test/example/soil_evolution.cpp
@@ -70,11 +70,11 @@ void soil_simulator::SoilEvolution(
 
         // Creating the trajectory
         std::tie(pos, ori) = soil_simulator::CalcTrajectory(
-            x_i, z_i, x_min, z_min, origin_angle, 100);
+            x_i, z_i, x_min, z_min, origin_angle, 1000);
     } else {
         // Default parabolic trajectory
         std::tie(pos, ori) = soil_simulator::CalcTrajectory(
-            -2.0, 1.5, 0.1, 0.25, origin_angle, 100);
+            -2.0, 1.5, 0.1, 0.25, origin_angle, 1000);
     }
 
     // Initializing bucket corner position vectors
@@ -113,20 +113,20 @@ void soil_simulator::SoilEvolution(
             j_pos[0] + half_width[0], j_pos[1] + half_width[1],
             j_pos[2] + half_width[2]});
         j_l_pos.push_back(std::vector<float> {
-            j_pos[0] + half_width[0], j_pos[1] - half_width[1],
-            j_pos[2] + half_width[2]});
+            j_pos[0] - half_width[0], j_pos[1] - half_width[1],
+            j_pos[2] - half_width[2]});
         b_r_pos.push_back(std::vector<float> {
             b_pos[0] + half_width[0], b_pos[1] + half_width[1],
             b_pos[2] + half_width[2]});
         b_l_pos.push_back(std::vector<float> {
-            b_pos[0] + half_width[0], b_pos[1] - half_width[1],
-            b_pos[2] + half_width[2]});
+            b_pos[0] - half_width[0], b_pos[1] - half_width[1],
+            b_pos[2] - half_width[2]});
         t_r_pos.push_back(std::vector<float> {
             t_pos[0] + half_width[0], t_pos[1] + half_width[1],
             t_pos[2] + half_width[2]});
         t_l_pos.push_back(std::vector<float> {
-            t_pos[0] + half_width[0], t_pos[1] - half_width[1],
-            t_pos[2] + half_width[2]});
+            t_pos[0] - half_width[0], t_pos[1] - half_width[1],
+            t_pos[2] - half_width[2]});
     }
 
     // Setting time
@@ -140,8 +140,8 @@ void soil_simulator::SoilEvolution(
     std::vector<std::vector<float>> pos_vec;
     std::vector<std::vector<float>> ori_vec;
     std::vector<float> time_vec;
-    float dt_i = dt;
-    float time = dt;
+    float dt_i = 0.1;
+    float time = 0.1;
     pos_vec.push_back(pos[0]);
     auto ori_i = soil_simulator::AngleToQuat(
             {ori[0][0], ori[0][1], ori[0][2]});
@@ -154,7 +154,7 @@ void soil_simulator::SoilEvolution(
 
        // Searching time that is closest to the time where pos and ori
        // were calculated
-       int kk = static_cast<int>(std::floor(time / dt_int));
+       int kk = static_cast<int>(std::ceil(time / dt_int));
 
        // Calculating linear interpolation of pos and ori at time
        float a = ((kk + 1) * dt_int - time) / dt_int;
@@ -171,7 +171,7 @@ void soil_simulator::SoilEvolution(
 
        // Calculating linear interpolation of bucket corners
        float time_plus = time + 0.5 * dt_i;
-       int kk_plus = static_cast<int>(std::floor(time_plus / dt_int));
+       int kk_plus = static_cast<int>(std::ceil(time_plus / dt_int));
        float a_plus = ((kk + 1) * dt_int - time_plus) / dt_int;
        float b_plus = (time_plus - kk * dt_int) / dt_int;
        std::vector<float> j_l_pos_plus = {
@@ -199,7 +199,7 @@ void soil_simulator::SoilEvolution(
            t_r_pos[kk_plus][1] * a + t_r_pos[kk_plus+1][1] * b,
            t_r_pos[kk_plus][2] * a + t_r_pos[kk_plus+1][2] * b};
        float time_minus = time - 0.5 * dt_i;
-       int kk_minus = static_cast<int>(std::floor(time_minus / dt_int));
+       int kk_minus = static_cast<int>(std::ceil(time_minus / dt_int));
        float a_minus = ((kk + 1) * dt_int - time_minus) / dt_int;
        float b_minus = (time_minus - kk * dt_int) / dt_int;
        std::vector<float> j_l_pos_minus = {
@@ -269,7 +269,7 @@ void soil_simulator::SoilEvolution(
            // Bucket is moving very slowly
            time += dt;
        } else {
-           // Bucket is mobing
+           // Bucket is moving
            time += dt_i;
        }
     }

--- a/test/unit_tests/CMakeLists.txt
+++ b/test/unit_tests/CMakeLists.txt
@@ -12,11 +12,11 @@ target_sources(unit_tests
     PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}/run_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test_types.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/test_utils.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test_bucket_pos.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test_body_soil.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test_intersecting_cells.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test_relax.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/test_utils.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../../soil_simulator/soil_dynamics.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../../soil_simulator/types.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../../soil_simulator/types.hpp

--- a/test/unit_tests/test_utils.cpp
+++ b/test/unit_tests/test_utils.cpp
@@ -71,6 +71,73 @@ TEST(UnitTestUtils, CalcBucketCornerPos) {
     EXPECT_TRUE((t_l_pos == std::vector<float> {-0.15, 0.6, -0.3}));
 }
 
+TEST(UnitTestUtils, CheckBucketMovement) {
+    // Setting up the environment
+    soil_simulator::Grid grid(1.0, 1.0, 1.0, 0.1, 0.1);
+    std::vector<float> o_pos = {0.0, 0.0, 0.0};
+    std::vector<float> j_pos = {0.0, 0.0, 0.0};
+    std::vector<float> b_pos = {0.0, 0.0, -0.5};
+    std::vector<float> t_pos = {0.7, 0.0, -0.5};
+    soil_simulator::Bucket *bucket = new soil_simulator::Bucket(
+        o_pos, j_pos, b_pos, t_pos, 0.5);
+    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
+    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+
+    // -- Testing for a one cell translation --
+    auto pos = std::vector<float> {0.1, 0.0, 0.0};
+    auto ori = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bool status = soil_simulator::CheckBucketMovement(pos, ori, grid, bucket);
+    EXPECT_TRUE(status);
+
+    // -- Testing for an arbitrary translation --
+    pos = std::vector<float> {0.05, 0.02, -0.05};
+    ori = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    status = soil_simulator::CheckBucketMovement(pos, ori, grid, bucket);
+    EXPECT_TRUE(status);
+
+    // -- Testing for a slight rotation --
+    pos = std::vector<float> {0.0, 0.0, 0.0};
+    ori = std::vector<float> {0.997, 0.0, 0.07, 0.0};
+    status = soil_simulator::CheckBucketMovement(pos, ori, grid, bucket);
+    EXPECT_TRUE(status);
+
+    // -- Testing for a slight rotation and translation --
+    pos = std::vector<float> {0.05, 0.0, 0.0};
+    ori = std::vector<float> {0.997, 0.0, 0.07, 0.0};
+    status = soil_simulator::CheckBucketMovement(pos, ori, grid, bucket);
+    EXPECT_TRUE(status);
+
+    // -- Testing for a short translation --
+    pos = std::vector<float> {0.005, 0.0, 0.0};
+    ori = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    status = soil_simulator::CheckBucketMovement(pos, ori, grid, bucket);
+    EXPECT_FALSE(status);
+
+    // -- Testing for a short arbitrary translation --
+    pos = std::vector<float> {0.001, 0.002, -0.003};
+    ori = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    status = soil_simulator::CheckBucketMovement(pos, ori, grid, bucket);
+    EXPECT_FALSE(status);
+
+    // -- Testing for a very slight rotation --
+    pos = std::vector<float> {0.0, 0.0, 0.0};
+    ori = std::vector<float> {0.999, 0.0, 0.0029, 0.0};
+    status = soil_simulator::CheckBucketMovement(pos, ori, grid, bucket);
+    EXPECT_FALSE(status);
+
+    // -- Testing for a very slight rotation and translation --
+    pos = std::vector<float> {0.001, 0.0, 0.0};
+    ori = std::vector<float> {0.999, 0.0, 0.0029, 0.0};
+    status = soil_simulator::CheckBucketMovement(pos, ori, grid, bucket);
+    EXPECT_FALSE(status);
+
+    // -- Testing for a three cell translation --
+    pos = std::vector<float> {0.005, 0.0, 0.0};
+    ori = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    status = soil_simulator::CheckBucketMovement(pos, ori, grid, bucket);
+    EXPECT_FALSE(status);
+}
+
 TEST(UnitTestUtils, CalcNormal) {
     // Setting dummy coordinates forming a triangle in the XY plane
     std::vector<float> a = {0.0, 0.0, 0.0};

--- a/test/unit_tests/test_utils.cpp
+++ b/test/unit_tests/test_utils.cpp
@@ -19,7 +19,7 @@ TEST(UnitTestUtils, CalcBucketCornerPos) {
     // -- Testing for a bucket in its reference pose --
     auto pos = std::vector<float> {0.0, 0.0, 0.0};
     auto ori = std::vector<float> {1.0, 0.0, 0.0, 0.0};
-    auto [j_r_pos, j_l_pos, b_r_pos, b_l_pos, t_r_pos, t_l_pos] = 
+    auto [j_r_pos, j_l_pos, b_r_pos, b_l_pos, t_r_pos, t_l_pos] =
         soil_simulator::CalcBucketCornerPos(pos, ori, bucket);
     EXPECT_TRUE((j_r_pos == std::vector<float> {0.0, -0.25, 0.0}));
     EXPECT_TRUE((j_l_pos == std::vector<float> {0.0, 0.25, 0.0}));
@@ -69,6 +69,8 @@ TEST(UnitTestUtils, CalcBucketCornerPos) {
     EXPECT_TRUE((b_l_pos == std::vector<float> {-0.15, -0.1, -0.3}));
     EXPECT_TRUE((t_r_pos == std::vector<float> {0.35, 0.6, -0.3}));
     EXPECT_TRUE((t_l_pos == std::vector<float> {-0.15, 0.6, -0.3}));
+
+    delete bucket;
 }
 
 TEST(UnitTestUtils, CheckBucketMovement) {
@@ -136,6 +138,8 @@ TEST(UnitTestUtils, CheckBucketMovement) {
     ori = std::vector<float> {1.0, 0.0, 0.0, 0.0};
     status = soil_simulator::CheckBucketMovement(pos, ori, grid, bucket);
     EXPECT_FALSE(status);
+
+    delete bucket;
 }
 
 TEST(UnitTestUtils, CalcNormal) {

--- a/test/unit_tests/test_utils.cpp
+++ b/test/unit_tests/test_utils.cpp
@@ -7,6 +7,70 @@ Copyright, 2023, Vilella Kenny.
 #include "gtest/gtest.h"
 #include "soil_simulator/utils.hpp"
 
+TEST(UnitTestUtils, CalcBucketCornerPos) {
+    // Setting up the environment
+    std::vector<float> o_pos = {0.0, 0.0, 0.0};
+    std::vector<float> j_pos = {0.0, 0.0, 0.0};
+    std::vector<float> b_pos = {0.0, 0.0, -0.5};
+    std::vector<float> t_pos = {0.7, 0.0, -0.5};
+    soil_simulator::Bucket *bucket = new soil_simulator::Bucket(
+        o_pos, j_pos, b_pos, t_pos, 0.5);
+
+    // -- Testing for a bucket in its reference pose --
+    auto pos = std::vector<float> {0.0, 0.0, 0.0};
+    auto ori = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    auto [j_r_pos, j_l_pos, b_r_pos, b_l_pos, t_r_pos, t_l_pos] = 
+        soil_simulator::CalcBucketCornerPos(pos, ori, bucket);
+    EXPECT_TRUE((j_r_pos == std::vector<float> {0.0, -0.25, 0.0}));
+    EXPECT_TRUE((j_l_pos == std::vector<float> {0.0, 0.25, 0.0}));
+    EXPECT_TRUE((b_r_pos == std::vector<float> {0.0, -0.25, -0.5}));
+    EXPECT_TRUE((b_l_pos == std::vector<float> {0.0, 0.25, -0.5}));
+    EXPECT_TRUE((t_r_pos == std::vector<float> {0.7, -0.25, -0.5}));
+    EXPECT_TRUE((t_l_pos == std::vector<float> {0.7, 0.25, -0.5}));
+
+    // -- Testing for a bucket translated compared to its reference pose --
+    pos = std::vector<float> {0.1, -0.1, 0.2};
+    ori = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    std::tie(j_r_pos, j_l_pos, b_r_pos, b_l_pos, t_r_pos, t_l_pos) =
+        soil_simulator::CalcBucketCornerPos(pos, ori, bucket);
+    EXPECT_TRUE((j_r_pos == std::vector<float> {0.1, -0.35, 0.2}));
+    EXPECT_TRUE((j_l_pos == std::vector<float> {0.1, 0.15, 0.2}));
+    EXPECT_TRUE((b_r_pos == std::vector<float> {0.1, -0.35, -0.3}));
+    EXPECT_TRUE((b_l_pos == std::vector<float> {0.1, 0.15, -0.3}));
+    EXPECT_TRUE((t_r_pos == std::vector<float> {0.8, -0.35, -0.3}));
+    EXPECT_TRUE((t_l_pos == std::vector<float> {0.8, 0.15, -0.3}));
+
+    // -- Testing for a bucket rotated compared to its reference pose --
+    pos = std::vector<float> {0.0, 0.0, 0.0};
+    ori = std::vector<float> {0.707107, 0.0, 0.0, -0.707107};
+    std::tie(j_r_pos, j_l_pos, b_r_pos, b_l_pos, t_r_pos, t_l_pos) =
+        soil_simulator::CalcBucketCornerPos(pos, ori, bucket);
+    EXPECT_TRUE((j_r_pos == std::vector<float> {0.25, 0.0, 0.0}));
+    EXPECT_TRUE((j_l_pos == std::vector<float> {-0.25, 0.0, 0.0}));
+    EXPECT_TRUE((b_r_pos == std::vector<float> {0.25, 0.0, -0.5}));
+    EXPECT_TRUE((b_l_pos == std::vector<float> {-0.25, 0.0, -0.5}));
+    // Following ones requires a different check due to numerical approximation
+    EXPECT_NEAR(t_r_pos[0], 0.25, 1e-5);
+    EXPECT_NEAR(t_r_pos[1], 0.7, 1e-5);
+    EXPECT_NEAR(t_r_pos[2], -0.5, 1e-5);
+    EXPECT_NEAR(t_l_pos[0], -0.25, 1e-5);
+    EXPECT_NEAR(t_l_pos[1], 0.7, 1e-5);
+    EXPECT_NEAR(t_l_pos[2], -0.5, 1e-5);
+
+    // -- Testing for a bucket rotated and translated compared to its --
+    // -- reference pose                                              --
+    pos = std::vector<float> {0.1, -0.1, 0.2};
+    ori = std::vector<float> {0.707107, 0.0, 0.0, -0.707107};
+    std::tie(j_r_pos, j_l_pos, b_r_pos, b_l_pos, t_r_pos, t_l_pos) =
+        soil_simulator::CalcBucketCornerPos(pos, ori, bucket);
+    EXPECT_TRUE((j_r_pos == std::vector<float> {0.35, -0.1, 0.2}));
+    EXPECT_TRUE((j_l_pos == std::vector<float> {-0.15, -0.1, 0.2}));
+    EXPECT_TRUE((b_r_pos == std::vector<float> {0.35, -0.1, -0.3}));
+    EXPECT_TRUE((b_l_pos == std::vector<float> {-0.15, -0.1, -0.3}));
+    EXPECT_TRUE((t_r_pos == std::vector<float> {0.35, 0.6, -0.3}));
+    EXPECT_TRUE((t_l_pos == std::vector<float> {-0.15, 0.6, -0.3}));
+}
+
 TEST(UnitTestUtils, CalcNormal) {
     // Setting dummy coordinates forming a triangle in the XY plane
     std::vector<float> a = {0.0, 0.0, 0.0};


### PR DESCRIPTION
# Description
- Created a function `CalcBucketCornerPos` to calculate position of the bucket corners
- Added a function `CheckBucketMovement`  to calculate the distance traveled since the last soil update.
- Added a check in  `step` function and conduct the soil update only if the bucket has moved sufficiently.
- Added  a return boolean for the `step` function indicating whether soil update has been made
- Added corresponding unit tests for the new functions
- Changed order of unit tests to run unit tests for utility functions before unit tests for features
- Debugged the soil evolution example script
- Fixed some typos