### PR TITLE
Bugfix: take into account for the trajectory that cell_size_z could be lower than cell_size_xy 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
 
       - name: Install Google test
         run: |
+          sudo apt-get update
           sudo apt-get install libgtest-dev
           cd /usr/src/gtest
           sudo cmake CMakeLists.txt

--- a/soil_simulator/utils.cpp
+++ b/soil_simulator/utils.cpp
@@ -106,10 +106,13 @@ bool soil_simulator::CheckBucketMovement(
     float max_dist = std::max(
         {j_r_dist, j_l_dist, b_r_dist, b_l_dist, t_r_dist, t_l_dist});
 
-    if (max_dist < 0.1 * grid.cell_size_xy_) {
+    // Calculating min cell size
+    float min_cell_size = std::min(grid.cell_size_xy_, grid.cell_size_z_);
+
+    if (max_dist < 0.5 * min_cell_size) {
         // Bucket has only slightly moved since last update
         return false;
-    } else if (max_dist > 2 * grid.cell_size_xy_) {
+    } else if (max_dist > 2 * min_cell_size) {
         LOG(WARNING) << "WARNING\nMovement made by the bucket is larger than "
             "two cell size.\nThe validity of the soil update cannot be ensured";
     }

--- a/test/example/soil_evolution.cpp
+++ b/test/example/soil_evolution.cpp
@@ -259,7 +259,8 @@ void soil_simulator::SoilEvolution(
 
        if (max_bucket_vel != 0.0) {
            // Bucket is moving
-           dt_i = grid.cell_size_xy_ / max_bucket_vel;
+           dt_i = std::min(grid.cell_size_xy_, grid.cell_size_z_) /
+               max_bucket_vel;
        } else {
            // No bucket movement
            dt_i = dt;


### PR DESCRIPTION
# Description
- Updated `CheckBucketMovement` to use the min of `cell_size_z` and `cell_size_xy`
-  Updated soil evolution example to step every time the bucket move by the min of `cell_size_z` and `cell_size_xy`