### PR TITLE
Refactor UpdateBodySoil: preliminary implementation (1)

### DIFF
--- a/soil_simulator/body_soil.cpp
+++ b/soil_simulator/body_soil.cpp
@@ -15,7 +15,7 @@ Copyright, 2023, Vilella Kenny.
 
 /// In this function, the movement applied to the base of the soil column is
 /// calculated and the soil is moved to this new location. The original
-/// position of the soil column in the bucket frame is stored in the 
+/// position of the soil column in the bucket frame is stored in the
 /// `body_soil_pos_` member of the `SimOut` class.
 ///
 /// It is difficult to track accurately each bucket wall. This is currently done
@@ -94,8 +94,8 @@ void soil_simulator::UpdateBodySoil(
             sim_out->body_soil_[0][ii_n][jj_n] = sim_out->body_[1][ii_n][jj_n];
 
             // Adding position to body_soil_pos
-            sim_out->body_soil_pos_.push_back(
-                soil_simulator::body_soil {0, ii_n, jj_n, x_b, y_b, z_b, h_soil});
+            sim_out->body_soil_pos_.push_back(soil_simulator::body_soil
+                {0, ii_n, jj_n, x_b, y_b, z_b, h_soil});
         } else if (
             ((sim_out->body_[2][ii_n][jj_n] != 0.0) ||
             (sim_out->body_[3][ii_n][jj_n] != 0.0)) &&
@@ -110,8 +110,8 @@ void soil_simulator::UpdateBodySoil(
             sim_out->body_soil_[2][ii_n][jj_n] = sim_out->body_[3][ii_n][jj_n];
 
             // Adding position to body_soil_pos
-            sim_out->body_soil_pos_.push_back(
-                soil_simulator::body_soil {2, ii_n, jj_n, x_b, y_b, z_b, h_soil});
+            sim_out->body_soil_pos_.push_back(soil_simulator::body_soil
+                 {2, ii_n, jj_n, x_b, y_b, z_b, h_soil});
         } else {
             // Bucket is not present
             // This should normally not happen, it is only for safety

--- a/soil_simulator/body_soil.cpp
+++ b/soil_simulator/body_soil.cpp
@@ -117,13 +117,9 @@ void soil_simulator::UpdateBodySoil(
                 sim_out->body_soil_[0][ii_t][jj_t] = (
                     sim_out->body_[1][ii_t][jj_t]);
 
-                // Calculating pos of cell in bucket frame
-                auto pos = soil_simulator::CalcBucketFramePos(
-                    ii_t, jj_t, sim_out->body_[1][ii_t][jj_t], grid, bucket);
-
                 // Adding position to body_soil_pos
                 sim_out->body_soil_pos_.push_back(soil_simulator::body_soil
-                    {0, ii_t, jj_t, pos[0], pos[1], pos[2], h_soil});
+                    {0, ii_t, jj_t, x_b, y_b, z_b, h_soil});
                 soil_moved = true;
                 break;
             } else if (
@@ -140,13 +136,9 @@ void soil_simulator::UpdateBodySoil(
                 sim_out->body_soil_[2][ii_t][jj_t] = (
                     sim_out->body_[3][ii_t][jj_t]);
 
-                // Calculating pos of cell in bucket frame
-                auto pos = soil_simulator::CalcBucketFramePos(
-                    ii_t, jj_t, sim_out->body_[3][ii_t][jj_t], grid, bucket);
-
                 // Adding position to body_soil_pos
                 sim_out->body_soil_pos_.push_back(soil_simulator::body_soil
-                     {2, ii_t, jj_t, pos[0], pos[1], pos[2], h_soil});
+                     {2, ii_t, jj_t, x_b, y_b, z_b, h_soil});
                 soil_moved = true;
                 break;
             }

--- a/soil_simulator/body_soil.cpp
+++ b/soil_simulator/body_soil.cpp
@@ -48,7 +48,7 @@ void soil_simulator::UpdateBodySoil(
         sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // Iterating over all XY positions where body_soil is present
-    float min_cell_height_diff = 2 * std::min(
+    float min_cell_height_diff = 3 * std::min(
         grid.cell_size_z_, grid.cell_size_xy_);
     for (auto nn = 0; nn < old_body_soil_pos.size(); nn++) {
         int ind = old_body_soil_pos[nn].ind;
@@ -143,11 +143,11 @@ void soil_simulator::UpdateBodySoil(
                 break;
             }
         }
+
         if (!soil_moved) {
             // This should normally not happen, it is only for safety
             // Moving body_soil to terrain
-            sim_out->terrain_[ii_n][jj_n] += (
-                old_body_soil[ind+1][ii][jj] - old_body_soil[ind][ii][jj]);
+            sim_out->terrain_[ii_n][jj_n] += h_soil;
             LOG(WARNING) << "WARNING\nBucket soil could not be updated.\n "
                 "Soil is moved to the terrain to maintain mass conservation";
         }

--- a/soil_simulator/intersecting_cells.hpp
+++ b/soil_simulator/intersecting_cells.hpp
@@ -18,6 +18,8 @@ extern std::mt19937 rng;
 ///        that intersect with the bucket or with another soil cell.
 ///
 /// \param sim_out: Class that stores simulation outputs.
+/// \param grid: Class that stores information related to the simulation grid.
+/// \param bucket: Class that stores information related to the bucket object.
 /// \param tol: Small number used to handle numerical approximation errors.
 void MoveIntersectingCells(
     SimOut* sim_out, Grid grid, Bucket* bucket, float tol);
@@ -26,6 +28,8 @@ void MoveIntersectingCells(
 ///        intersect with another bucket layer.
 ///
 /// \param sim_out: Class that stores simulation outputs.
+/// \param grid: Class that stores information related to the simulation grid.
+/// \param bucket: Class that stores information related to the bucket object.
 /// \param tol: Small number used to handle numerical approximation errors.
 void MoveIntersectingBodySoil(
     SimOut* sim_out, Grid grid, Bucket* bucket, float tol);
@@ -50,6 +54,7 @@ void MoveIntersectingBody(SimOut* sim_out, float tol);
 /// \param jj_n: Index of the new considered position in the Y direction.
 /// \param h_soil: Height of the soil column left to be moved. [m]
 /// \param wall_presence: Indicates whether a wall is blocking the movement.
+/// \param bucket: Class that stores information related to the bucket object.
 /// \param tol: Small number used to handle numerical approximation errors.
 ///
 /// \return A tuple composed of the index of the new considered bucket layer,

--- a/soil_simulator/intersecting_cells.hpp
+++ b/soil_simulator/intersecting_cells.hpp
@@ -19,14 +19,16 @@ extern std::mt19937 rng;
 ///
 /// \param sim_out: Class that stores simulation outputs.
 /// \param tol: Small number used to handle numerical approximation errors.
-void MoveIntersectingCells(SimOut* sim_out, float tol);
+void MoveIntersectingCells(
+    SimOut* sim_out, Grid grid, Bucket* bucket, float tol);
 
 /// \brief This function moves the soil cells resting on the bucket that
 ///        intersect with another bucket layer.
 ///
 /// \param sim_out: Class that stores simulation outputs.
 /// \param tol: Small number used to handle numerical approximation errors.
-void MoveIntersectingBodySoil(SimOut* sim_out, float tol);
+void MoveIntersectingBodySoil(
+    SimOut* sim_out, Grid grid, Bucket* bucket, float tol);
 
 /// \brief This function moves the soil cells in the `terrain_` that intersect
 ///        with a bucket.
@@ -57,7 +59,8 @@ void MoveIntersectingBody(SimOut* sim_out, float tol);
 ///         whether a bucket wall is blocking the movement.
 std::tuple<int, int, int, float, bool> MoveBodySoil(
     SimOut* sim_out, int ind_p, int ii_p, int jj_p, float max_h, int ii_n,
-    int jj_n, float h_soil, bool wall_presence, float tol);
+    int jj_n, float h_soil, bool wall_presence, Grid grid, Bucket* bucket,
+    float tol);
 
 /// \brief This function identifies all the soil cells in the `terrain_` that
 ///        intersect with the bucket.

--- a/soil_simulator/relax.cpp
+++ b/soil_simulator/relax.cpp
@@ -176,7 +176,7 @@ void soil_simulator::RelaxBodySoil(
         int ii = sim_out->body_soil_pos_[nn].ii;
         int jj = sim_out->body_soil_pos_[nn].jj;
         int ind = sim_out->body_soil_pos_[nn].ind;
-        int h_soil = sim_out->body_soil_pos_[nn].h_soil;
+        float h_soil = sim_out->body_soil_pos_[nn].h_soil;
 
         // Checking if soil is present
         if (h_soil < tol) {

--- a/soil_simulator/relax.cpp
+++ b/soil_simulator/relax.cpp
@@ -1105,13 +1105,15 @@ void soil_simulator::RelaxUnstableBodyCell(
                     sim_out->body_soil_pos_[nn].h_soil = 0.0;
                 }
             }
-            // Calculating pos of cell in bucket frame
-            auto pos = soil_simulator::CalcBucketFramePos(
-                ii_c, jj_c, sim_out->body_[3][ii_c][jj_c], grid, bucket);
+            if (h_soil > tol) {
+                // Calculating pos of cell in bucket frame
+                auto pos = soil_simulator::CalcBucketFramePos(
+                    ii_c, jj_c, sim_out->body_[3][ii_c][jj_c], grid, bucket);
 
-            // Adding new bucket soil position to body_soil_pos
-            body_soil_pos->push_back(soil_simulator::body_soil
-                {2, ii_c, jj_c, pos[0], pos[1], pos[2], h_soil});
+                // Adding new bucket soil position to body_soil_pos
+                body_soil_pos->push_back(soil_simulator::body_soil
+                    {2, ii_c, jj_c, pos[0], pos[1], pos[2], h_soil});
+            }
         } else if (st[1] == '2') {
             // Soil should avalanche on the second bucket layer
             h_new = 0.5 * (
@@ -1262,13 +1264,15 @@ void soil_simulator::RelaxUnstableBodyCell(
                     sim_out->body_soil_pos_[nn].h_soil = 0.0;
                 }
             }
-            // Calculating pos of cell in bucket frame
-            auto pos = soil_simulator::CalcBucketFramePos(
-                ii_c, jj_c, sim_out->body_[1][ii_c][jj_c], grid, bucket);
+            if (h_soil > tol) {
+                // Calculating pos of cell in bucket frame
+                auto pos = soil_simulator::CalcBucketFramePos(
+                    ii_c, jj_c, sim_out->body_[1][ii_c][jj_c], grid, bucket);
 
-            // Adding new bucket soil position to body_soil_pos
-            body_soil_pos->push_back(soil_simulator::body_soil
-                {0, ii_c, jj_c, pos[0], pos[1], pos[2], h_soil});
+                // Adding new bucket soil position to body_soil_pos
+                body_soil_pos->push_back(soil_simulator::body_soil
+                    {0, ii_c, jj_c, pos[0], pos[1], pos[2], h_soil});
+            }
         } else if (st[1] == '4') {
             // Soil should avalanche on the first bucket layer
             h_new = 0.5 * (

--- a/soil_simulator/relax.cpp
+++ b/soil_simulator/relax.cpp
@@ -12,6 +12,7 @@ Copyright, 2023, Vilella Kenny.
 #include <vector>
 #include "soil_simulator/relax.hpp"
 #include "soil_simulator/types.hpp"
+#include "soil_simulator/utils.hpp"
 
 /// The soil stability is determined by the `repose_angle_`. If the slope formed
 /// by two neighboring soil columns exceeds the `repose_angle_`, it is
@@ -39,7 +40,7 @@ Copyright, 2023, Vilella Kenny.
 /// In case (2a), the soil will avalanche on the `terrain_`, while in case (2b),
 /// the soil will avalanche on the bucket.
 void soil_simulator::RelaxTerrain(
-    SimOut* sim_out, Grid grid, SimParam sim_param, float tol
+    SimOut* sim_out, Grid grid, Bucket* bucket, SimParam sim_param, float tol
 ) {
     // Assuming that the terrain is at equilibrium
     sim_out->equilibrium_ = true;
@@ -120,7 +121,7 @@ void soil_simulator::RelaxTerrain(
 
             // Relaxing the soil cell
             RelaxUnstableTerrainCell(
-                sim_out, status, dh_max, ii, jj, ii_c, jj_c, grid, tol);
+                sim_out, status, dh_max, ii, jj, ii_c, jj_c, grid, bucket, tol);
         }
     }
 
@@ -154,19 +155,13 @@ void soil_simulator::RelaxTerrain(
 /// (1) The soil column in the neighboring cell is low enough.
 /// (2) There is space on the top of the neighboring soil column.
 void soil_simulator::RelaxBodySoil(
-    SimOut* sim_out, Grid grid, SimParam sim_param, float tol
+    SimOut* sim_out, Grid grid, Bucket* bucket, SimParam sim_param, float tol
 ) {
     // Calculating the maximum slope allowed by the repose angle
     float slope_max = std::tan(sim_param.repose_angle_);
     // Calculating the maximum height different allowed by the repose angle
     float dh_max = grid.cell_size_xy_ * slope_max;
     dh_max = grid.cell_size_z_ * round(dh_max / grid.cell_size_z_);
-
-    // Removing duplicates in body_soil_pos
-    sort(sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
-    sim_out->body_soil_pos_.erase(unique(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end()),
-        sim_out->body_soil_pos_.end());
 
     // Randomizing body_soil_pos to reduce asymmetry
     // random_suffle is not used because it is machine dependent,
@@ -182,14 +177,14 @@ void soil_simulator::RelaxBodySoil(
         {1, 0}, {-1, 0}, {0, 1}, {0, -1}};
 
     // Initializing queue for new body_soil_pos
-    std::vector<std::vector<int>> *new_body_soil_pos = (
-        new std::vector<std::vector<int>>);
+    std::vector<soil_simulator::body_soil> *new_body_soil_pos = (
+        new std::vector<soil_simulator::body_soil>);
 
     // Iterating over all body_soil cells
     for (auto nn = 0; nn < sim_out->body_soil_pos_.size(); nn++) {
-        int ii = sim_out->body_soil_pos_[nn][1];
-        int jj = sim_out->body_soil_pos_[nn][2];
-        int ind = sim_out->body_soil_pos_[nn][0];
+        int ii = sim_out->body_soil_pos_[nn].ii;
+        int jj = sim_out->body_soil_pos_[nn].jj;
+        int ind = sim_out->body_soil_pos_[nn].ind;
 
         // Randomizing direction to avoid asymmetry
         // random_suffle is not used because it is machine dependent,
@@ -223,8 +218,8 @@ void soil_simulator::RelaxBodySoil(
 
             // Relaxing the soil cell
             RelaxUnstableBodyCell(
-                sim_out, status, new_body_soil_pos, dh_max, ii, jj, ind,
-                ii_c, jj_c, grid, tol);
+                sim_out, status, new_body_soil_pos, dh_max, nn, ii, jj, ind,
+                ii_c, jj_c, grid, bucket, tol);
         }
     }
 
@@ -593,7 +588,7 @@ int soil_simulator::CheckUnstableBodyCell(
 /// checks are present.
 void soil_simulator::RelaxUnstableTerrainCell(
     SimOut* sim_out, int status, float dh_max, int ii, int jj, int ii_c,
-    int jj_c, Grid grid, float tol
+    int jj_c, Grid grid, Bucket* bucket, float tol
 ) {
     // Converting status into a string for convenience
     std::string st = std::to_string(status);
@@ -698,8 +693,15 @@ void soil_simulator::RelaxUnstableTerrainCell(
         sim_out->body_soil_[2][ii_c][jj_c] = sim_out->body_[3][ii_c][jj_c];
         sim_out->body_soil_[3][ii_c][jj_c] = h_new_c;
 
+        // Calculating pos of cell in bucket frame
+        auto pos = soil_simulator::CalcBucketFramePos(
+            ii_c, jj_c, sim_out->body_[3][ii_c][jj_c], grid, bucket);
+
         // Adding new bucket soil position to body_soil_pos
-        sim_out->body_soil_pos_.push_back(std::vector<int> {2, ii_c, jj_c});
+        float h_soil = h_new_c - sim_out->body_[3][ii_c][jj_c];
+        sim_out->body_soil_pos_.push_back(
+            soil_simulator::body_soil
+            {2, ii_c, jj_c, pos[0], pos[1], pos[2], h_soil});
     } else if (st[1] == '3') {
         // Soil avalanche on the first bucket soil layer
         h_new = 0.5 * (
@@ -759,8 +761,15 @@ void soil_simulator::RelaxUnstableTerrainCell(
         sim_out->body_soil_[0][ii_c][jj_c] = sim_out->body_[1][ii_c][jj_c];
         sim_out->body_soil_[1][ii_c][jj_c] = h_new_c;
 
+        // Calculating pos of cell in bucket frame
+        auto pos = soil_simulator::CalcBucketFramePos(
+            ii_c, jj_c, sim_out->body_[1][ii_c][jj_c], grid, bucket);
+
         // Adding new bucket soil position to body_soil_pos
-        sim_out->body_soil_pos_.push_back(std::vector<int> {0, ii_c, jj_c});
+        float h_soil = h_new_c - sim_out->body_[1][ii_c][jj_c];
+        sim_out->body_soil_pos_.push_back(
+            soil_simulator::body_soil
+            {0, ii_c, jj_c, pos[0], pos[1], pos[2], h_soil});
     }
 }
 
@@ -774,15 +783,15 @@ void soil_simulator::RelaxUnstableTerrainCell(
 /// Note that it is assumed that the given `status` is accurate, so no extra
 /// checks are present.
 void soil_simulator::RelaxUnstableBodyCell(
-    SimOut* sim_out, int status, std::vector<std::vector<int>>* body_soil_pos,
-    float dh_max, int ii, int jj, int ind, int ii_c, int jj_c, Grid grid,
-    float tol
+    SimOut* sim_out, int status, std::vector<body_soil>* body_soil_pos,
+    float dh_max, int nn, int ii, int jj, int ind, int ii_c, int jj_c,
+    Grid grid, Bucket* bucket, float tol
 ) {
     // Converting status into a string for convenience
     std::string st = std::to_string(status);
     float h_new;
     float h_new_c;
-
+    float h_soil;
     if (st[1] == '0') {
         // No Bucket
         // Calculating new height values
@@ -791,9 +800,15 @@ void soil_simulator::RelaxUnstableBodyCell(
             sim_out->terrain_[ii_c][jj_c]);
         h_new = grid.cell_size_z_ * std::floor(
             (h_new + tol) / grid.cell_size_z_);
-        h_new_c = (
-            sim_out->body_soil_[ind+1][ii][jj] + sim_out->terrain_[ii_c][jj_c] -
-            h_new);
+        h_soil = sim_out->body_soil_[ind+1][ii][jj] - h_new;
+
+        // Checking amount of soil in body_soil_pos_
+        if (h_soil > sim_out->body_soil_pos_[nn].h_soil) {
+            // Not enough soil in body_soil_pos_
+            h_soil = sim_out->body_soil_pos_[nn].h_soil;
+            h_new = sim_out->body_soil_[ind+1][ii][jj] - h_soil;
+        }
+        h_new_c = sim_out->terrain_[ii_c][jj_c] + h_soil;
 
         if (st[0] == '1') {
             // First bucket layer is present
@@ -821,6 +836,7 @@ void soil_simulator::RelaxUnstableBodyCell(
             // Soil on the bucket should partially avalanche
             sim_out->terrain_[ii_c][jj_c] = h_new_c;
             sim_out->body_soil_[ind+1][ii][jj] = h_new;
+            sim_out->body_soil_pos_[nn].h_soil -= h_soil;
         } else {
             // All soil on the bucket should avalanche
             sim_out->terrain_[ii_c][jj_c] += (
@@ -828,6 +844,7 @@ void soil_simulator::RelaxUnstableBodyCell(
                 sim_out->body_soil_[ind][ii][jj]);
             sim_out->body_soil_[ind][ii][jj] = 0.0;
             sim_out->body_soil_[ind+1][ii][jj] = 0.0;
+            sim_out->body_soil_pos_[nn].h_soil = 0.0;
         }
     } else if (st[0] == '1') {
         // Only the first bucket layer
@@ -838,14 +855,21 @@ void soil_simulator::RelaxUnstableBodyCell(
                 sim_out->body_soil_[1][ii_c][jj_c]);
             h_new = grid.cell_size_z_ * std::floor(
                 (h_new + tol) / grid.cell_size_z_);
-            h_new_c = (
-                sim_out->body_soil_[ind+1][ii][jj] +
-                sim_out->body_soil_[1][ii_c][jj_c] - h_new);
+            h_soil = sim_out->body_soil_[ind+1][ii][jj] - h_new;
+
+            // Checking amount of soil in body_soil_pos_
+            if (h_soil > sim_out->body_soil_pos_[nn].h_soil) {
+                // Not enough soil in body_soil_pos_
+                h_soil = sim_out->body_soil_pos_[nn].h_soil;
+                h_new = sim_out->body_soil_[ind+1][ii][jj] - h_soil;
+            }
+            h_new_c = sim_out->body_soil_[1][ii_c][jj_c] + h_soil;
 
             if (h_new - tol > sim_out->body_soil_[ind][ii][jj]) {
                 // Soil on the bucket should partially avalanche
                 sim_out->body_soil_[1][ii_c][jj_c] = h_new_c;
                 sim_out->body_soil_[ind+1][ii][jj] = h_new;
+                sim_out->body_soil_pos_[nn].h_soil -= h_soil;
             } else {
                 // All soil on the bucket should avalanche
                 sim_out->body_soil_[1][ii_c][jj_c] += (
@@ -853,7 +877,15 @@ void soil_simulator::RelaxUnstableBodyCell(
                     sim_out->body_soil_[ind][ii][jj]);
                 sim_out->body_soil_[ind][ii][jj] = 0.0;
                 sim_out->body_soil_[ind+1][ii][jj] = 0.0;
+                sim_out->body_soil_pos_[nn].h_soil = 0.0;
             }
+            // Calculating pos of cell in bucket frame
+            auto pos = soil_simulator::CalcBucketFramePos(
+                ii_c, jj_c, sim_out->body_[1][ii_c][jj_c], grid, bucket);
+
+            // Adding new bucket soil position to body_soil_pos
+            body_soil_pos->push_back(soil_simulator::body_soil
+                {0, ii_c, jj_c, pos[0], pos[1], pos[2], h_soil});
         } else if (st[1] == '4') {
             // Bucket soil is not present
             h_new = 0.5 * (
@@ -861,12 +893,15 @@ void soil_simulator::RelaxUnstableBodyCell(
                 sim_out->body_[1][ii_c][jj_c]);
             h_new = grid.cell_size_z_ * std::floor(
                 (h_new + tol) / grid.cell_size_z_);
-            h_new_c = (
-                sim_out->body_soil_[ind+1][ii][jj] +
-                sim_out->body_[1][ii_c][jj_c] - h_new);
+            h_soil = sim_out->body_soil_[ind+1][ii][jj] - h_new;
 
-            // Adding new bucket soil position to body_soil_pos
-            body_soil_pos->push_back(std::vector<int> {0, ii_c, jj_c});
+            // Checking amount of soil in body_soil_pos_
+            if (h_soil > sim_out->body_soil_pos_[nn].h_soil) {
+                // Not enough soil in body_soil_pos_
+                h_soil = sim_out->body_soil_pos_[nn].h_soil;
+                h_new = sim_out->body_soil_[ind+1][ii][jj] - h_soil;
+            }
+            h_new_c = sim_out->body_[1][ii_c][jj_c] + h_soil;
 
             if (h_new - tol > sim_out->body_soil_[ind][ii][jj]) {
                 // Soil on the bucket should partially avalanche
@@ -874,6 +909,7 @@ void soil_simulator::RelaxUnstableBodyCell(
                     sim_out->body_[1][ii_c][jj_c]);
                 sim_out->body_soil_[1][ii_c][jj_c] = h_new_c;
                 sim_out->body_soil_[ind+1][ii][jj] = h_new;
+                sim_out->body_soil_pos_[nn].h_soil -= h_soil;
             } else {
                 // All soil on the bucket should avalanche
                 sim_out->body_soil_[0][ii_c][jj_c] = (
@@ -884,7 +920,15 @@ void soil_simulator::RelaxUnstableBodyCell(
                     sim_out->body_soil_[ind][ii][jj]);
                 sim_out->body_soil_[ind][ii][jj] = 0.0;
                 sim_out->body_soil_[ind+1][ii][jj] = 0.0;
+                sim_out->body_soil_pos_[nn].h_soil = 0.0;
             }
+            // Calculating pos of cell in bucket frame
+            auto pos = soil_simulator::CalcBucketFramePos(
+                ii_c, jj_c, sim_out->body_[1][ii_c][jj_c], grid, bucket);
+
+            // Adding new bucket soil position to body_soil_pos
+            body_soil_pos->push_back(soil_simulator::body_soil
+                {0, ii_c, jj_c, pos[0], pos[1], pos[2], h_soil});
         }
     } else if (st[0] == '2') {
         // Only the second bucket layer
@@ -895,22 +939,40 @@ void soil_simulator::RelaxUnstableBodyCell(
                 sim_out->body_soil_[3][ii_c][jj_c]);
             h_new = grid.cell_size_z_ * std::floor(
                 (h_new + tol) / grid.cell_size_z_);
-            h_new_c = (
-                sim_out->body_soil_[ind+1][ii][jj] +
-                sim_out->body_soil_[3][ii_c][jj_c] - h_new);
+            h_soil = sim_out->body_soil_[ind+1][ii][jj] - h_new;
+
+            // Checking amount of soil in body_soil_pos_
+            if (h_soil > sim_out->body_soil_pos_[nn].h_soil) {
+                // Not enough soil in body_soil_pos_
+                h_soil = sim_out->body_soil_pos_[nn].h_soil;
+                h_new = sim_out->body_soil_[ind+1][ii][jj] - h_soil;
+            }
+            h_new_c = sim_out->body_soil_[3][ii_c][jj_c] + h_soil;
 
             if (h_new_c - tol > sim_out->body_soil_[ind][ii][jj]) {
                 // Soil on the bucket should partially avalanche
                 sim_out->body_soil_[3][ii_c][jj_c] = h_new_c;
                 sim_out->body_soil_[ind+1][ii][jj] = h_new;
+                sim_out->body_soil_pos_[nn].h_soil -= h_soil;
             } else {
                 // All soil on the bucket should avalanche
+                // -----------------------------------
+                // Check if we can put h_soil here also in other part
+                // -----------------------------------
                 sim_out->body_soil_[3][ii_c][jj_c] += (
                     sim_out->body_soil_[ind+1][ii][jj] -
                     sim_out->body_soil_[ind][ii][jj]);
                 sim_out->body_soil_[ind][ii][jj] = 0.0;
                 sim_out->body_soil_[ind+1][ii][jj] = 0.0;
+                sim_out->body_soil_pos_[nn].h_soil = 0.0;
             }
+            // Calculating pos of cell in bucket frame
+            auto pos = soil_simulator::CalcBucketFramePos(
+                ii_c, jj_c, sim_out->body_[3][ii_c][jj_c], grid, bucket);
+
+            // Adding new bucket soil position to body_soil_pos
+            body_soil_pos->push_back(soil_simulator::body_soil
+                {2, ii_c, jj_c, pos[0], pos[1], pos[2], h_soil});
         } else if (st[1] == '2') {
             // Bucket soil is not present
             h_new = 0.5 * (
@@ -918,12 +980,15 @@ void soil_simulator::RelaxUnstableBodyCell(
                 sim_out->body_[3][ii_c][jj_c]);
             h_new = grid.cell_size_z_ * std::floor(
                 (h_new + tol) / grid.cell_size_z_);
-            h_new_c = (
-                sim_out->body_soil_[ind+1][ii][jj] +
-                sim_out->body_[3][ii_c][jj_c] - h_new);
+            h_soil = sim_out->body_soil_[ind+1][ii][jj] - h_new;
 
-            // Adding new bucket soil position to body_soil_pos
-            body_soil_pos->push_back(std::vector<int> {2, ii_c, jj_c});
+            // Checking amount of soil in body_soil_pos_
+            if (h_soil > sim_out->body_soil_pos_[nn].h_soil) {
+                // Not enough soil in body_soil_pos_
+                h_soil = sim_out->body_soil_pos_[nn].h_soil;
+                h_new = sim_out->body_soil_[ind+1][ii][jj] - h_soil;
+            }
+            h_new_c = sim_out->body_[3][ii_c][jj_c] + h_soil;
 
             if (h_new_c - tol > sim_out->body_soil_[ind][ii][jj]) {
                 // Soil on the bucket should partially avalanche
@@ -931,6 +996,7 @@ void soil_simulator::RelaxUnstableBodyCell(
                     sim_out->body_[3][ii_c][jj_c]);
                 sim_out->body_soil_[3][ii_c][jj_c] = h_new_c;
                 sim_out->body_soil_[ind+1][ii][jj] = h_new;
+                sim_out->body_soil_pos_[nn].h_soil -= h_soil;
             } else {
                 // All soil on the bucket should avalanche
                 sim_out->body_soil_[2][ii_c][jj_c] = (
@@ -941,7 +1007,15 @@ void soil_simulator::RelaxUnstableBodyCell(
                     sim_out->body_soil_[ind][ii][jj]);
                 sim_out->body_soil_[ind][ii][jj] = 0.0;
                 sim_out->body_soil_[ind+1][ii][jj] = 0.0;
+                sim_out->body_soil_pos_[nn].h_soil = 0.0;
             }
+            // Calculating pos of cell in bucket frame
+            auto pos = soil_simulator::CalcBucketFramePos(
+                ii_c, jj_c, sim_out->body_[3][ii_c][jj_c], grid, bucket);
+
+            // Adding new bucket soil position to body_soil_pos
+            body_soil_pos->push_back(soil_simulator::body_soil
+                {2, ii_c, jj_c, pos[0], pos[1], pos[2], h_soil});
         }
     } else if (st[0] == '3') {
         // Both bucket layer
@@ -952,9 +1026,15 @@ void soil_simulator::RelaxUnstableBodyCell(
                 sim_out->body_soil_[3][ii_c][jj_c]);
             h_new = grid.cell_size_z_ * std::floor(
                 (h_new + tol) / grid.cell_size_z_);
-            h_new_c = (
-                sim_out->body_soil_[ind+1][ii][jj] +
-                sim_out->body_soil_[3][ii_c][jj_c] - h_new);
+            h_soil = sim_out->body_soil_[ind+1][ii][jj] - h_new;
+
+            // Checking amount of soil in body_soil_pos_
+            if (h_soil > sim_out->body_soil_pos_[nn].h_soil) {
+                // Not enough soil in body_soil_pos_
+                h_soil = sim_out->body_soil_pos_[nn].h_soil;
+                h_new = sim_out->body_soil_[ind+1][ii][jj] - h_soil;
+            }
+            h_new_c = sim_out->body_soil_[3][ii_c][jj_c] + h_soil;
 
             if (sim_out->body_[0][ii_c][jj_c] > sim_out->body_[2][ii_c][jj_c]) {
                 // Soil should avalanche on the bottom layer
@@ -962,9 +1042,10 @@ void soil_simulator::RelaxUnstableBodyCell(
                     // Soil on the bucket should partially avalanche
                     if (h_new_c - tol > sim_out->body_[0][ii_c][jj_c]) {
                         // Not enough space available
-                        sim_out->body_soil_[ind+1][ii][jj] -= (
+                        h_soil = (
                             sim_out->body_[0][ii_c][jj_c] -
                             sim_out->body_soil_[3][ii_c][jj_c]);
+                        sim_out->body_soil_[ind+1][ii][jj] -= h_soil;
                         sim_out->body_soil_[3][ii_c][jj_c] = (
                             sim_out->body_[0][ii_c][jj_c]);
                     } else {
@@ -972,10 +1053,14 @@ void soil_simulator::RelaxUnstableBodyCell(
                         sim_out->body_soil_[3][ii_c][jj_c] = h_new_c;
                         sim_out->body_soil_[ind+1][ii][jj] = h_new;
                     }
+                    sim_out->body_soil_pos_[nn].h_soil -= h_soil;
                 } else {
                     // All soil on the bucket may avalanche
                     // By construction, it must have enough space for
                     // the full avalanche
+                    // ------------------
+                    // here also h_new_c should not be needed
+                    // ------------------
                     h_new_c = (
                         sim_out->body_soil_[3][ii_c][jj_c] +
                         sim_out->body_soil_[ind+1][ii][jj] -
@@ -984,6 +1069,7 @@ void soil_simulator::RelaxUnstableBodyCell(
                     sim_out->body_soil_[3][ii_c][jj_c] = h_new_c;
                     sim_out->body_soil_[ind][ii][jj] = 0.0;
                     sim_out->body_soil_[ind+1][ii][jj] = 0.0;
+                    sim_out->body_soil_pos_[nn].h_soil = 0.0;
                 }
             } else {
                 // Soil should avalanche on the top layer
@@ -991,6 +1077,7 @@ void soil_simulator::RelaxUnstableBodyCell(
                     // Soil on the bucket should partially avalanche
                     sim_out->body_soil_[3][ii_c][jj_c] = h_new_c;
                     sim_out->body_soil_[ind+1][ii][jj] = h_new;
+                    sim_out->body_soil_pos_[nn].h_soil -= h_soil;
                 } else {
                     // All soil on the bucket should avalanche
                     sim_out->body_soil_[3][ii_c][jj_c] += (
@@ -998,8 +1085,16 @@ void soil_simulator::RelaxUnstableBodyCell(
                         sim_out->body_soil_[ind][ii][jj]);
                     sim_out->body_soil_[ind][ii][jj] = 0.0;
                     sim_out->body_soil_[ind+1][ii][jj] = 0.0;
+                    sim_out->body_soil_pos_[nn].h_soil = 0.0;
                 }
             }
+            // Calculating pos of cell in bucket frame
+            auto pos = soil_simulator::CalcBucketFramePos(
+                ii_c, jj_c, sim_out->body_[3][ii_c][jj_c], grid, bucket);
+
+            // Adding new bucket soil position to body_soil_pos
+            body_soil_pos->push_back(soil_simulator::body_soil
+                {2, ii_c, jj_c, pos[0], pos[1], pos[2], h_soil});
         } else if (st[1] == '2') {
             // Soil should avalanche on the second bucket layer
             h_new = 0.5 * (
@@ -1007,12 +1102,15 @@ void soil_simulator::RelaxUnstableBodyCell(
                 sim_out->body_[3][ii_c][jj_c]);
             h_new = grid.cell_size_z_ * std::floor(
                 (h_new + tol) / grid.cell_size_z_);
-            h_new_c = (
-                sim_out->body_soil_[ind+1][ii][jj] +
-                sim_out->body_[3][ii_c][jj_c] - h_new);
+            h_soil = sim_out->body_soil_[ind+1][ii][jj] - h_new;
 
-            // Adding new bucket soil position to body_soil_pos
-            body_soil_pos->push_back(std::vector<int> {2, ii_c, jj_c});
+            // Checking amount of soil in body_soil_pos_
+            if (h_soil > sim_out->body_soil_pos_[nn].h_soil) {
+                // Not enough soil in body_soil_pos_
+                h_soil = sim_out->body_soil_pos_[nn].h_soil;
+                h_new = sim_out->body_soil_[ind+1][ii][jj] - h_soil;
+            }
+            h_new_c = sim_out->body_[3][ii_c][jj_c] + h_soil;
 
             if (sim_out->body_[0][ii_c][jj_c] > sim_out->body_[2][ii_c][jj_c]) {
                 // Soil should avalanche on the bottom layer
@@ -1020,9 +1118,10 @@ void soil_simulator::RelaxUnstableBodyCell(
                     // Soil on the bucket should partially avalanche
                     if (h_new_c - tol > sim_out->body_[0][ii_c][jj_c]) {
                         // Not enough space available
-                        sim_out->body_soil_[ind+1][ii][jj] -= (
+                        h_soil = (
                             sim_out->body_[0][ii_c][jj_c] -
                             sim_out->body_[3][ii_c][jj_c]);
+                        sim_out->body_soil_[ind+1][ii][jj] -= h_soil;
                         sim_out->body_soil_[2][ii_c][jj_c] = (
                             sim_out->body_[3][ii_c][jj_c]);
                         sim_out->body_soil_[3][ii_c][jj_c] = (
@@ -1034,6 +1133,7 @@ void soil_simulator::RelaxUnstableBodyCell(
                         sim_out->body_soil_[3][ii_c][jj_c] = h_new_c;
                         sim_out->body_soil_[ind+1][ii][jj] = h_new;
                     }
+                    sim_out->body_soil_pos_[nn].h_soil -= h_soil;
                 } else {
                     // All soil on the bucket may avalanche
                     // By construction, it must have enough space for
@@ -1048,6 +1148,7 @@ void soil_simulator::RelaxUnstableBodyCell(
                     sim_out->body_soil_[3][ii_c][jj_c] = h_new_c;
                     sim_out->body_soil_[ind][ii][jj] = 0.0;
                     sim_out->body_soil_[ind+1][ii][jj] = 0.0;
+                    sim_out->body_soil_pos_[nn].h_soil = 0.0;
                 }
             } else {
                 // Soil should avalanche on the top layer
@@ -1057,6 +1158,7 @@ void soil_simulator::RelaxUnstableBodyCell(
                         sim_out->body_[3][ii_c][jj_c]);
                     sim_out->body_soil_[3][ii_c][jj_c] = h_new_c;
                     sim_out->body_soil_[ind+1][ii][jj] = h_new;
+                    sim_out->body_soil_pos_[nn].h_soil -= h_soil;
                 } else {
                     // All soil on the bucket should avalanche
                     sim_out->body_soil_[2][ii_c][jj_c] = (
@@ -1067,8 +1169,16 @@ void soil_simulator::RelaxUnstableBodyCell(
                         sim_out->body_soil_[ind][ii][jj]);
                     sim_out->body_soil_[ind][ii][jj] = 0.0;
                     sim_out->body_soil_[ind+1][ii][jj] = 0.0;
+                    sim_out->body_soil_pos_[nn].h_soil = 0.0;
                 }
             }
+            // Calculating pos of cell in bucket frame
+            auto pos = soil_simulator::CalcBucketFramePos(
+                ii_c, jj_c, sim_out->body_[3][ii_c][jj_c], grid, bucket);
+
+            // Adding new bucket soil position to body_soil_pos
+            body_soil_pos->push_back(soil_simulator::body_soil
+                {2, ii_c, jj_c, pos[0], pos[1], pos[2], h_soil});
         } else if (st[1] == '3') {
             // Soil should avalanche on the first bucket soil layer
             h_new = 0.5 * (
@@ -1076,9 +1186,15 @@ void soil_simulator::RelaxUnstableBodyCell(
                 sim_out->body_soil_[1][ii_c][jj_c]);
             h_new = grid.cell_size_z_ * std::floor(
                 (h_new + tol) / grid.cell_size_z_);
-            h_new_c = (
-                sim_out->body_soil_[ind+1][ii][jj] +
-                sim_out->body_soil_[1][ii_c][jj_c] - h_new);
+            h_soil = sim_out->body_soil_[ind+1][ii][jj] - h_new;
+
+            // Checking amount of soil in body_soil_pos_
+            if (h_soil > sim_out->body_soil_pos_[nn].h_soil) {
+                // Not enough soil in body_soil_pos_
+                h_soil = sim_out->body_soil_pos_[nn].h_soil;
+                h_new = sim_out->body_soil_[ind+1][ii][jj] - h_soil;
+            }
+            h_new_c = sim_out->body_soil_[1][ii_c][jj_c] + h_soil;
 
             if (sim_out->body_[0][ii_c][jj_c] > sim_out->body_[2][ii_c][jj_c]) {
                 // Soil should avalanche on the top layer
@@ -1086,6 +1202,7 @@ void soil_simulator::RelaxUnstableBodyCell(
                     // Soil on the bucket should partially avalanche
                     sim_out->body_soil_[1][ii_c][jj_c] = h_new_c;
                     sim_out->body_soil_[ind+1][ii][jj] = h_new;
+                    sim_out->body_soil_pos_[nn].h_soil -= h_soil;
                 } else {
                     // All soil on the bucket should avalanche
                     sim_out->body_soil_[1][ii_c][jj_c] += (
@@ -1093,6 +1210,7 @@ void soil_simulator::RelaxUnstableBodyCell(
                         sim_out->body_soil_[ind][ii][jj]);
                     sim_out->body_soil_[ind][ii][jj] = 0.0;
                     sim_out->body_soil_[ind+1][ii][jj] = 0.0;
+                    sim_out->body_soil_pos_[nn].h_soil = 0.0;
                 }
             } else {
                 // Soil should avalanche on the bottom layer
@@ -1100,9 +1218,10 @@ void soil_simulator::RelaxUnstableBodyCell(
                     // Soil on the bucket should partially avalanche
                     if (h_new_c - tol > sim_out->body_[2][ii_c][jj_c]) {
                         // Not enough space available
-                        sim_out->body_soil_[ind+1][ii][jj] -= (
+                        h_soil = (
                             sim_out->body_[2][ii_c][jj_c] -
                             sim_out->body_soil_[1][ii_c][jj_c]);
+                        sim_out->body_soil_[ind+1][ii][jj] -= h_soil;
                         sim_out->body_soil_[1][ii_c][jj_c] = (
                             sim_out->body_[2][ii_c][jj_c]);
                     } else {
@@ -1110,6 +1229,7 @@ void soil_simulator::RelaxUnstableBodyCell(
                         sim_out->body_soil_[1][ii_c][jj_c] = h_new_c;
                         sim_out->body_soil_[ind+1][ii][jj] = h_new;
                     }
+                    sim_out->body_soil_pos_[nn].h_soil -= h_soil;
                 } else {
                     // All soil on the bucket may avalanche
                     // By construction, it must have enough space for
@@ -1122,8 +1242,16 @@ void soil_simulator::RelaxUnstableBodyCell(
                     sim_out->body_soil_[1][ii_c][jj_c] = h_new_c;
                     sim_out->body_soil_[ind][ii][jj] = 0.0;
                     sim_out->body_soil_[ind+1][ii][jj] = 0.0;
+                    sim_out->body_soil_pos_[nn].h_soil = 0.0;
                 }
             }
+            // Calculating pos of cell in bucket frame
+            auto pos = soil_simulator::CalcBucketFramePos(
+                ii_c, jj_c, sim_out->body_[1][ii_c][jj_c], grid, bucket);
+
+            // Adding new bucket soil position to body_soil_pos
+            body_soil_pos->push_back(soil_simulator::body_soil
+                {0, ii_c, jj_c, pos[0], pos[1], pos[2], h_soil});
         } else if (st[1] == '4') {
             // Soil should avalanche on the first bucket layer
             h_new = 0.5 * (
@@ -1131,12 +1259,15 @@ void soil_simulator::RelaxUnstableBodyCell(
                 sim_out->body_[1][ii_c][jj_c]);
             h_new = grid.cell_size_z_ * std::floor(
                 (h_new + tol) / grid.cell_size_z_);
-            h_new_c = (
-                sim_out->body_soil_[ind+1][ii][jj] +
-                sim_out->body_[1][ii_c][jj_c] - h_new);
+            h_soil = sim_out->body_soil_[ind+1][ii][jj] - h_new;
 
-            // Adding new bucket soil position to body_soil_pos
-            body_soil_pos->push_back(std::vector<int> {0, ii_c, jj_c});
+            // Checking amount of soil in body_soil_pos_
+            if (h_soil > sim_out->body_soil_pos_[nn].h_soil) {
+                // Not enough soil in body_soil_pos_
+                h_soil = sim_out->body_soil_pos_[nn].h_soil;
+                h_new = sim_out->body_soil_[ind+1][ii][jj] - h_soil;
+            }
+            h_new_c = sim_out->body_[1][ii_c][jj_c] + h_soil;
 
             if (sim_out->body_[0][ii_c][jj_c] > sim_out->body_[2][ii_c][jj_c]) {
                 // Soil should avalanche on the top layer
@@ -1146,6 +1277,7 @@ void soil_simulator::RelaxUnstableBodyCell(
                         sim_out->body_[1][ii_c][jj_c]);
                     sim_out->body_soil_[1][ii_c][jj_c] = h_new_c;
                     sim_out->body_soil_[ind+1][ii][jj] = h_new;
+                    sim_out->body_soil_pos_[nn].h_soil -= h_soil;
                 } else {
                     // All soil on the bucket should avalanche
                     sim_out->body_soil_[0][ii_c][jj_c] = (
@@ -1156,6 +1288,7 @@ void soil_simulator::RelaxUnstableBodyCell(
                         sim_out->body_soil_[ind][ii][jj]);
                     sim_out->body_soil_[ind][ii][jj] = 0.0;
                     sim_out->body_soil_[ind+1][ii][jj] = 0.0;
+                    sim_out->body_soil_pos_[nn].h_soil = 0.0;
                 }
             } else {
                 // Soil should avalanche on the bottom layer
@@ -1163,9 +1296,10 @@ void soil_simulator::RelaxUnstableBodyCell(
                     // Soil on the bucket should partially avalanche
                     if (h_new_c - tol > sim_out->body_[2][ii_c][jj_c]) {
                         // Not enough space available
-                        sim_out->body_soil_[ind+1][ii][jj] -= (
+                        h_soil = (
                             sim_out->body_[2][ii_c][jj_c] -
                             sim_out->body_[1][ii_c][jj_c]);
+                        sim_out->body_soil_[ind+1][ii][jj] -= h_soil;
                         sim_out->body_soil_[0][ii_c][jj_c] = (
                             sim_out->body_[1][ii_c][jj_c]);
                         sim_out->body_soil_[1][ii_c][jj_c] = (
@@ -1177,6 +1311,7 @@ void soil_simulator::RelaxUnstableBodyCell(
                         sim_out->body_soil_[1][ii_c][jj_c] = h_new_c;
                         sim_out->body_soil_[ind+1][ii][jj] = h_new;
                     }
+                    sim_out->body_soil_pos_[nn].h_soil -= h_soil;
                 } else {
                     // All soil on the bucket may avalanche
                     // By construction, it must have enough space for
@@ -1191,8 +1326,16 @@ void soil_simulator::RelaxUnstableBodyCell(
                     sim_out->body_soil_[1][ii_c][jj_c] = h_new_c;
                     sim_out->body_soil_[ind][ii][jj] = 0.0;
                     sim_out->body_soil_[ind+1][ii][jj] = 0.0;
+                    sim_out->body_soil_pos_[nn].h_soil = 0.0;
                 }
             }
+            // Calculating pos of cell in bucket frame
+            auto pos = soil_simulator::CalcBucketFramePos(
+                ii_c, jj_c, sim_out->body_[1][ii_c][jj_c], grid, bucket);
+
+            // Adding new bucket soil position to body_soil_pos
+            body_soil_pos->push_back(soil_simulator::body_soil
+                {0, ii_c, jj_c, pos[0], pos[1], pos[2], h_soil});
         }
     }
 }

--- a/soil_simulator/relax.cpp
+++ b/soil_simulator/relax.cpp
@@ -163,15 +163,6 @@ void soil_simulator::RelaxBodySoil(
     float dh_max = grid.cell_size_xy_ * slope_max;
     dh_max = grid.cell_size_z_ * round(dh_max / grid.cell_size_z_);
 
-    // Randomizing body_soil_pos to reduce asymmetry
-    // random_suffle is not used because it is machine dependent,
-    // which makes unit testing difficult
-    for (int aa = sim_out->body_soil_pos_.size() - 1; aa > 0; aa--) {
-        std::uniform_int_distribution<int> dist(0, aa);
-        int bb = dist(rng);
-        std::swap(sim_out->body_soil_pos_[aa], sim_out->body_soil_pos_[bb]);
-    }
-
     // Storing all possible directions for relaxation
     std::vector<std::vector<int>> directions = {
         {1, 0}, {-1, 0}, {0, 1}, {0, -1}};
@@ -823,7 +814,6 @@ void soil_simulator::RelaxUnstableBodyCell(
         if (h_soil > sim_out->body_soil_pos_[nn].h_soil) {
             // Not enough soil in body_soil_pos_
             h_soil = sim_out->body_soil_pos_[nn].h_soil;
-            h_new = sim_out->body_soil_[ind+1][ii][jj] - h_soil;
         }
         h_new_c = sim_out->terrain_[ii_c][jj_c] + h_soil;
 
@@ -831,23 +821,22 @@ void soil_simulator::RelaxUnstableBodyCell(
             // First bucket layer is present
             if (h_new_c - tol > sim_out->body_[0][ii_c][jj_c]) {
                 // Not enough space for all the soil
-                h_new_c = sim_out->body_[0][ii_c][jj_c];
-                h_new = (
-                    sim_out->body_soil_[ind+1][ii][jj] -
-                    sim_out->body_[0][ii_c][jj_c] +
+                h_soil = (
+                    sim_out->body_[0][ii_c][jj_c] -
                     sim_out->terrain_[ii_c][jj_c]);
+                h_new_c = sim_out->body_[0][ii_c][jj_c];
             }
         } else if (st[0] == '2') {
             // Second bucket layer is present
             if (h_new_c - tol > sim_out->body_[2][ii_c][jj_c]) {
                 // Not enough space for all the soil
-                h_new_c = sim_out->body_[2][ii_c][jj_c];
-                h_new = (
-                    sim_out->body_soil_[ind+1][ii][jj] -
-                    sim_out->body_[2][ii_c][jj_c] +
+                h_soil = (
+                    sim_out->body_[2][ii_c][jj_c] -
                     sim_out->terrain_[ii_c][jj_c]);
+                h_new_c = sim_out->body_[2][ii_c][jj_c];
             }
         }
+        h_new = sim_out->body_soil_[ind+1][ii][jj] - h_soil;
 
         if (h_new - tol > sim_out->body_soil_[ind][ii][jj]) {
             // Soil on the bucket should partially avalanche

--- a/soil_simulator/relax.cpp
+++ b/soil_simulator/relax.cpp
@@ -176,6 +176,13 @@ void soil_simulator::RelaxBodySoil(
         int ii = sim_out->body_soil_pos_[nn].ii;
         int jj = sim_out->body_soil_pos_[nn].jj;
         int ind = sim_out->body_soil_pos_[nn].ind;
+        int h_soil = sim_out->body_soil_pos_[nn].h_soil;
+
+        // Checking if soil is present
+        if (h_soil < tol) {
+            // No soil to be moved
+            continue;
+        }
 
         // Randomizing direction to avoid asymmetry
         // random_suffle is not used because it is machine dependent,

--- a/soil_simulator/relax.hpp
+++ b/soil_simulator/relax.hpp
@@ -18,18 +18,22 @@ extern std::mt19937 rng;
 ///
 /// \param sim_out: Class that stores simulation outputs.
 /// \param grid: Class that stores information related to the simulation grid.
+/// \param bucket: Class that stores information related to the bucket object.
 /// \param sim_param: Class that stores information related to the simulation.
 /// \param tol: Small number used to handle numerical approximation errors.
-void RelaxTerrain(SimOut* sim_out, Grid grid, SimParam sim_param, float tol);
+void RelaxTerrain(
+    SimOut* sim_out, Grid grid, Bucket* bucket, SimParam sim_param, float tol);
 
 /// \brief This function moves the soil in `body_soil_` towards a state closer
 ///        to equilibrium.
 ///
 /// \param sim_out: Class that stores simulation outputs.
 /// \param grid: Class that stores information related to the simulation grid.
+/// \param bucket: Class that stores information related to the bucket object.
 /// \param sim_param: Class that stores information related to the simulation.
 /// \param tol: Small number used to handle numerical approximation errors.
-void RelaxBodySoil(SimOut* sim_out, Grid grid, SimParam sim_param, float tol);
+void RelaxBodySoil(
+    SimOut* sim_out, Grid grid, Bucket* bucket, SimParam sim_param, float tol);
 
 /// \brief This function locates all the cells in `terrain_` that have a height
 ///        difference larger than `dh_max` with at least one neighboring cell.
@@ -88,10 +92,11 @@ int CheckUnstableBodyCell(
 /// \param ii_c: Index of the neighboring cell in the X direction.
 /// \param jj_c: Index of the neighboring cell in the Y direction.
 /// \param grid: Class that stores information related to the simulation grid.
+/// \param bucket: Class that stores information related to the bucket object.
 /// \param tol: Small number used to handle numerical approximation errors.
 void RelaxUnstableTerrainCell(
     SimOut* sim_out, int status, float dh_max, int ii, int jj, int ii_c,
-    int jj_c, Grid grid, float tol);
+    int jj_c, Grid grid, Bucket* bucket, float tol);
 
 /// \brief This function moves the soil from the soil layer `ind` of
 ///        `body_soil_` at (`ii`, `jj`) to the soil column in (`ii_c`, `jj_c`).
@@ -101,16 +106,18 @@ void RelaxUnstableTerrainCell(
 /// \param body_soil_pos: Queue to append new body_soil_pos.
 /// \param dh_max: Maximum height difference allowed between two neighboring
 ///                cells. [m]
+/// \param nn: Index of the considered soil in `body_soil_pos_`.
 /// \param ii: Index of the considered cell in the X direction.
 /// \param jj: Index of the considered cell in the Y direction.
 /// \param ind: Index of the considered soil layer.
 /// \param ii_c: Index of the neighboring cell in the X direction.
 /// \param jj_c: Index of the neighboring cell in the Y direction.
 /// \param grid: Class that stores information related to the simulation grid.
+/// \param bucket: Class that stores information related to the bucket object.
 /// \param tol: Small number used to handle numerical approximation errors.
 void RelaxUnstableBodyCell(
-    SimOut* sim_out, int status, std::vector<std::vector<int>>* body_soil_pos,
-    float dh_max, int ii, int jj, int ind, int ii_c, int jj_c, Grid grid,
-    float tol);
+    SimOut* sim_out, int status, std::vector<body_soil>* body_soil_pos,
+    float dh_max, int nn, int ii, int jj, int ind, int ii_c, int jj_c,
+    Grid grid, Bucket* bucket, float tol);
 
 }  // namespace soil_simulator

--- a/soil_simulator/soil_dynamics.cpp
+++ b/soil_simulator/soil_dynamics.cpp
@@ -35,7 +35,7 @@ bool soil_simulator::SoilDynamics::step(
     soil_simulator::UpdateBodySoil(sim_out, pos, ori, grid, bucket, tol);
 
     // Moving intersecting soil cells
-    soil_simulator::MoveIntersectingCells(sim_out, bucket, tol);
+    soil_simulator::MoveIntersectingCells(sim_out, grid, bucket, tol);
 
     // Assuming that the terrain is not at equilibrium
     sim_out->equilibrium_ = false;

--- a/soil_simulator/soil_dynamics.cpp
+++ b/soil_simulator/soil_dynamics.cpp
@@ -35,7 +35,7 @@ bool soil_simulator::SoilDynamics::step(
     soil_simulator::UpdateBodySoil(sim_out, pos, ori, grid, bucket, tol);
 
     // Moving intersecting soil cells
-    soil_simulator::MoveIntersectingCells(sim_out, tol);
+    soil_simulator::MoveIntersectingCells(sim_out, bucket, tol);
 
     // Assuming that the terrain is not at equilibrium
     sim_out->equilibrium_ = false;
@@ -56,10 +56,10 @@ bool soil_simulator::SoilDynamics::step(
             sim_out->bucket_area_[1][1], sim_out->relax_area_[1][1]);
 
         // Relaxing the terrain
-        RelaxTerrain(sim_out, grid, sim_param, tol);
+        RelaxTerrain(sim_out, grid, bucket, sim_param, tol);
 
         // Relaxing the soil resting on the bucket
-        RelaxBodySoil(sim_out, grid, sim_param, tol);
+        RelaxBodySoil(sim_out, grid, bucket, sim_param, tol);
     }
     return true;
 }

--- a/soil_simulator/soil_dynamics.cpp
+++ b/soil_simulator/soil_dynamics.cpp
@@ -58,6 +58,15 @@ bool soil_simulator::SoilDynamics::step(
         // Relaxing the terrain
         RelaxTerrain(sim_out, grid, bucket, sim_param, tol);
 
+        // Randomizing body_soil_pos to reduce asymmetry
+        // random_suffle is not used because it is machine dependent,
+        // which makes unit testing difficult
+        for (int aa = sim_out->body_soil_pos_.size() - 1; aa > 0; aa--) {
+            std::uniform_int_distribution<int> dist(0, aa);
+            int bb = dist(rng);
+            std::swap(sim_out->body_soil_pos_[aa], sim_out->body_soil_pos_[bb]);
+        }
+
         // Relaxing the soil resting on the bucket
         RelaxBodySoil(sim_out, grid, bucket, sim_param, tol);
     }

--- a/soil_simulator/soil_dynamics.cpp
+++ b/soil_simulator/soil_dynamics.cpp
@@ -5,6 +5,7 @@ Copyright, 2023, Vilella Kenny.
 */
 #include <algorithm>
 #include <iostream>
+#include <utility>
 #include <vector>
 #include "soil_simulator/soil_dynamics.hpp"
 #include "soil_simulator/types.hpp"

--- a/soil_simulator/types.hpp
+++ b/soil_simulator/types.hpp
@@ -9,6 +9,33 @@ Copyright, 2023, Vilella Kenny.
 
 namespace soil_simulator {
 
+/// \brief Store information related to the position of the bucket sol.
+struct body_soil{
+    /// Index of the bucket soil layer.
+    int ind;
+
+    /// Index of the bucket soil position in the X direction.
+    int ii;
+
+    /// Index of the bucket soil position in the Y direction.
+    int jj;
+
+    /// Cartesian coordinate in the X direction where the bucket soil avalanched
+    /// on the bucket in the bucket frame. [m]
+    float x_b;
+
+    /// Cartesian coordinate in the Y direction where the bucket soil avalanched
+    /// on the bucket in the bucket frame. [m]
+    float y_b;
+
+    /// Cartesian coordinate in the Z direction where the bucket soil avalanched
+    /// on the bucket in the bucket frame. [m]
+    float z_b;
+
+    /// Vertical extent of the soil column. [m]
+    float h_soil;
+};
+
 /// \brief Store all parameters related to the simulation grid.
 ///
 /// Convention:
@@ -335,9 +362,8 @@ class SimOut {
      /// each XY position. [m]
      std::vector<std::vector<std::vector<float>>> body_soil_;
 
-     /// Store the indices of locations where there is soil resting on
-     /// the bucket.
-     std::vector<std::vector<int>> body_soil_pos_;
+     /// Store the information related to the soil resting on the bucket.
+     std::vector<body_soil> body_soil_pos_;
 
      /// Store the 2D bounding box of the bucket with a buffer determined
      /// by the parameter `cell_buffer_` of `SimParam`.

--- a/soil_simulator/types.hpp
+++ b/soil_simulator/types.hpp
@@ -112,7 +112,7 @@ class Grid {
 
      /// Vector providing a conversion between cell's index and cell's position
      /// in the Z direction.
-     std::vector<float> vect_z_;
+     std::vector<double> vect_z_;
 
      /// \brief Create a new instance of `Grid` using the grid size in [m].
      ///

--- a/soil_simulator/utils.cpp
+++ b/soil_simulator/utils.cpp
@@ -222,22 +222,27 @@ bool soil_simulator::CheckVolume(
 
     terrain_volume = grid.cell_area_ * terrain_volume;
 
-    // Removing duplicates in body_soil_pos
-    sort(sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
-    sim_out->body_soil_pos_.erase(unique(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end()),
-        sim_out->body_soil_pos_.end());
-
     // Calculating volume of bucket soil
     float body_soil_volume = 0.0;
-    for (auto nn = 0; nn < sim_out->body_soil_pos_.size(); nn++) {
-        int ii = sim_out->body_soil_pos_[nn][1];
-        int jj = sim_out->body_soil_pos_[nn][2];
-        int ind = sim_out->body_soil_pos_[nn][0];
-        body_soil_volume += (
-            sim_out->body_soil_[ind+1][ii][jj] -
-            sim_out->body_soil_[ind][ii][jj]);
-    }
+    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
+        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++) {
+            if (
+                (sim_out->body_soil_[0][ii][jj] != 0.0) ||
+                (sim_out->body_soil_[1][ii][jj] != 0.0)) {
+                // Bucket soil is present
+                body_soil_volume += (
+                    sim_out->body_soil_[1][ii][jj] -
+                    sim_out->body_soil_[0][ii][jj]);
+            }
+            if (
+                (sim_out->body_soil_[2][ii][jj] != 0.0) ||
+                (sim_out->body_soil_[3][ii][jj] != 0.0)) {
+                // Bucket soil is present
+                body_soil_volume += (
+                    sim_out->body_soil_[3][ii][jj] -
+                    sim_out->body_soil_[2][ii][jj]);
+            }
+        }
     body_soil_volume = grid.cell_area_ * body_soil_volume;
 
     // Calculating total volume of soil
@@ -411,14 +416,13 @@ bool soil_simulator::CheckSoil(
     // Iterating over all cells where bucket soil is located
     for (auto nn = 0; nn < sim_out->body_soil_pos_.size(); nn++) {
         // Renaming for convenience
-        int ii = sim_out->body_soil_pos_[nn][1];
-        int jj = sim_out->body_soil_pos_[nn][2];
-        int ind = sim_out->body_soil_pos_[nn][0];
+        int ii = sim_out->body_soil_pos_[nn].ii;
+        int jj = sim_out->body_soil_pos_[nn].jj;
+        int ind = sim_out->body_soil_pos_[nn].ind;
         float body_min = sim_out->body_[ind][ii][jj];
         float body_max = sim_out->body_[ind+1][ii][jj];
         float body_soil_min = sim_out->body_soil_[ind][ii][jj];
         float body_soil_max = sim_out->body_soil_[ind+1][ii][jj];
-
 
         // Check that soil is actually present
         bool bucket_soil_presence = (
@@ -482,12 +486,6 @@ void soil_simulator::WriteSoil(
         "/body_soil_" + terrain_filename.substr(
             terrain_filename.find_last_of("_")+1, terrain_filename.size()));
 
-    // Removing duplicates in body_soil_pos
-    sort(sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
-    sim_out->body_soil_pos_.erase(unique(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end()),
-        sim_out->body_soil_pos_.end());
-
     std::ofstream body_soil_file;
     body_soil_file.open(new_body_soil_filename);
     body_soil_file << "x,y,z\n";
@@ -497,14 +495,25 @@ void soil_simulator::WriteSoil(
         body_soil_file << grid.vect_x_[0] << "," << grid.vect_y_[0] << ","
                 << grid.vect_z_[0] << "\n";
     } else {
-        for (auto nn = 0; nn < sim_out->body_soil_pos_.size(); nn++) {
-            int ii = sim_out->body_soil_pos_[nn][1];
-            int jj = sim_out->body_soil_pos_[nn][2];
-            int ind = sim_out->body_soil_pos_[nn][0];
-
-            body_soil_file << grid.vect_x_[ii] << "," << grid.vect_y_[jj] << ","
-                << sim_out->body_soil_[ind+1][ii][jj] << "\n";
-        }
+        for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
+            for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++) {
+                if (
+                    (sim_out->body_soil_[0][ii][jj] != 0.0) ||
+                    (sim_out->body_soil_[1][ii][jj] != 0.0)) {
+                    // Bucket soil is present
+                    body_soil_file << grid.vect_x_[ii] << "," <<
+                        grid.vect_y_[jj] << "," <<
+                        sim_out->body_soil_[1][ii][jj] << "\n";
+                }
+                if (
+                    (sim_out->body_soil_[2][ii][jj] != 0.0) ||
+                    (sim_out->body_soil_[3][ii][jj] != 0.0)) {
+                    // Bucket soil is present
+                    body_soil_file << grid.vect_x_[ii] << "," <<
+                        grid.vect_y_[jj] << "," <<
+                        sim_out->body_soil_[3][ii][jj] << "\n";
+                }
+            }
     }
 }
 

--- a/soil_simulator/utils.cpp
+++ b/soil_simulator/utils.cpp
@@ -139,6 +139,28 @@ std::vector<float> soil_simulator::CalcNormal(
     return normal;
 }
 
+
+std::vector<float> soil_simulator::CalcBucketFramePos(
+    int ii, int jj, float z, Grid grid, Bucket* bucket
+) {
+    // Calculating cell's position in bucket frame
+    std::vector<float> cell_pos = {
+        grid.vect_x_[ii] - bucket->pos_[0],
+        grid.vect_y_[jj] - bucket->pos_[1],
+        z - bucket->pos_[2]};
+
+    // Inversing rotation
+    std::vector<float> inv_ori = {
+        bucket->ori_[0], -bucket->ori_[1], -bucket->ori_[2],
+        -bucket->ori_[3]};
+
+    // Calculating reference position of cell in bucket frame
+    auto cell_local_pos = soil_simulator::CalcRotationQuaternion(
+        inv_ori, cell_pos);
+
+    return cell_local_pos;
+}
+
 /// The mathematical reasoning behind this implementation can be easily found
 /// in the Wiki page of Quaternion or elsewhere.
 std::vector<float> soil_simulator::CalcRotationQuaternion(

--- a/soil_simulator/utils.cpp
+++ b/soil_simulator/utils.cpp
@@ -106,10 +106,13 @@ bool soil_simulator::CheckBucketMovement(
     float max_dist = std::max(
         {j_r_dist, j_l_dist, b_r_dist, b_l_dist, t_r_dist, t_l_dist});
 
-    if (max_dist < 0.1 * grid.cell_size_xy_) {
+    // Calculating min cell size
+    float min_cell_size = std::min(grid.cell_size_xy_, grid.cell_size_z_);
+
+    if (max_dist < 0.5 * min_cell_size) {
         // Bucket has only slightly moved since last update
         return false;
-    } else if (max_dist > 2 * grid.cell_size_xy_) {
+    } else if (max_dist > 2 * min_cell_size) {
         LOG(WARNING) << "WARNING\nMovement made by the bucket is larger than "
             "two cell size.\nThe validity of the soil update cannot be ensured";
     }

--- a/soil_simulator/utils.hpp
+++ b/soil_simulator/utils.hpp
@@ -53,6 +53,9 @@ bool CheckBucketMovement(
 std::vector<float> CalcNormal(
     std::vector<float> a, std::vector<float> b, std::vector<float> c);
 
+std::vector<float> CalcBucketFramePos(
+    int ii, int jj, float z, Grid grid, Bucket* bucket);
+
 /// \brief This function applies a rotation `ori` to the Cartesian
 ///        coordinates `pos`.
 ///

--- a/test/benchmarks/benchmark_intersecting_cells.cpp
+++ b/test/benchmarks/benchmark_intersecting_cells.cpp
@@ -30,7 +30,7 @@ static void BM_MoveIntersectingCells(benchmark::State& state) {
         sim_out, pos, ori, grid, bucket, sim_param, 1e-5);
 
     for (auto _ : state)
-        soil_simulator::MoveIntersectingCells(sim_out, 1.e-5);
+        soil_simulator::MoveIntersectingCells(sim_out, grid, bucket, 1.e-5);
     delete sim_out;
     delete bucket;
 }
@@ -67,6 +67,12 @@ static void BM_MoveIntersectingBodySoil(benchmark::State& state) {
 
     // Defining inputs
     soil_simulator::Grid grid(4.0, 4.0, 3.0, 0.05, 0.01);
+    std::vector<float> o_pos = {0.0, 0.0, 0.0};
+    std::vector<float> j_pos = {0.0, 0.0, 0.0};
+    std::vector<float> b_pos = {0.0, 0.0, -0.5};
+    std::vector<float> t_pos = {0.7, 0.0, -0.5};
+    soil_simulator::Bucket *bucket = new soil_simulator::Bucket(
+        o_pos, j_pos, b_pos, t_pos, 0.5);
     soil_simulator::SimOut *sim_out = new soil_simulator::SimOut(grid);
     for (auto ii = 19; ii < 30; ii++)
         for (auto jj = 23; jj < 41; jj++) {
@@ -87,8 +93,9 @@ static void BM_MoveIntersectingBodySoil(benchmark::State& state) {
         sim_out->body_soil_[1][ii][39] = 0.7;
 
     for (auto _ : state)
-        soil_simulator::MoveIntersectingBodySoil(sim_out, 1.e-5);
+        soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1.e-5);
     delete sim_out;
+    delete bucket;
 }
 BENCHMARK(BM_MoveIntersectingBodySoil);
 
@@ -121,6 +128,12 @@ static void BM_MoveBodySoil(benchmark::State& state) {
     // Defining inputs
     soil_simulator::Grid grid(4.0, 4.0, 3.0, 0.05, 0.01);
     soil_simulator::SimOut *sim_out = new soil_simulator::SimOut(grid);
+    std::vector<float> o_pos = {0.0, 0.0, 0.0};
+    std::vector<float> j_pos = {0.0, 0.0, 0.0};
+    std::vector<float> b_pos = {0.0, 0.0, -0.5};
+    std::vector<float> t_pos = {0.7, 0.0, -0.5};
+    soil_simulator::Bucket *bucket = new soil_simulator::Bucket(
+        o_pos, j_pos, b_pos, t_pos, 0.5);
     sim_out->body_[0][5][7] = 0.1;
     sim_out->body_[1][5][7] = 0.3;
     sim_out->body_[2][5][7] = 0.6;
@@ -138,7 +151,8 @@ static void BM_MoveBodySoil(benchmark::State& state) {
 
     for (auto _ : state)
         soil_simulator::MoveBodySoil(
-            sim_out, 0, 5, 7, 0.4, 5, 11, 0.5, true, 1.e-5);
+            sim_out, 0, 5, 7, 0.4, 5, 11, 0.5, true, grid, bucket, 1.e-5);
     delete sim_out;
+    delete bucket;
 }
 BENCHMARK(BM_MoveBodySoil);

--- a/test/benchmarks/benchmark_relax.cpp
+++ b/test/benchmarks/benchmark_relax.cpp
@@ -6,11 +6,18 @@ Copyright, 2023, Vilella Kenny.
 #include <benchmark/benchmark.h>
 #include <random>
 #include "soil_simulator/relax.hpp"
+#include "soil_simulator/utils.hpp"
 
 // -- RelaxTerrain --
 static void BM_RelaxTerrain(benchmark::State& state) {
     // Defining inputs
     soil_simulator::Grid grid(4.0, 4.0, 3.0, 0.05, 0.01);
+    std::vector<float> o_pos = {0.0, 0.0, 0.0};
+    std::vector<float> j_pos = {0.0, 0.0, 0.0};
+    std::vector<float> b_pos = {0.0, 0.0, -0.5};
+    std::vector<float> t_pos = {0.7, 0.0, -0.5};
+    soil_simulator::Bucket *bucket = new soil_simulator::Bucket(
+        o_pos, j_pos, b_pos, t_pos, 0.5);
     soil_simulator::SimParam sim_param(0.85, 3, 4);
     soil_simulator::SimOut *sim_out = new soil_simulator::SimOut(grid);
     for (auto ii = 49; ii < 65; ii++)
@@ -32,7 +39,8 @@ static void BM_RelaxTerrain(benchmark::State& state) {
     sim_out->impact_area_[1][1] = 68;
 
     for (auto _ : state)
-        soil_simulator::RelaxTerrain(sim_out, grid, sim_param, 1.e-5);
+        soil_simulator::RelaxTerrain(sim_out, grid, bucket, sim_param, 1.e-5);
+    delete bucket;
     delete sim_out;
 }
 BENCHMARK(BM_RelaxTerrain)->Unit(benchmark::kMicrosecond);
@@ -41,6 +49,12 @@ BENCHMARK(BM_RelaxTerrain)->Unit(benchmark::kMicrosecond);
 static void BM_RelaxBodySoil(benchmark::State& state) {
     // Defining inputs
     soil_simulator::Grid grid(4.0, 4.0, 3.0, 0.05, 0.01);
+    std::vector<float> o_pos = {0.0, 0.0, 0.0};
+    std::vector<float> j_pos = {0.0, 0.0, 0.0};
+    std::vector<float> b_pos = {0.0, 0.0, -0.5};
+    std::vector<float> t_pos = {0.7, 0.0, -0.5};
+    soil_simulator::Bucket *bucket = new soil_simulator::Bucket(
+        o_pos, j_pos, b_pos, t_pos, 0.5);
     soil_simulator::SimParam sim_param(0.85, 3, 4);
     soil_simulator::SimOut *sim_out = new soil_simulator::SimOut(grid);
     for (auto ii = 49; ii < 65; ii++)
@@ -53,14 +67,20 @@ static void BM_RelaxBodySoil(benchmark::State& state) {
             sim_out->body_[1][ii][jj] = 0.1;
             sim_out->body_soil_[0][ii][jj] = 0.1;
             sim_out->body_soil_[1][ii][jj] = 0.4;
-            sim_out->body_soil_pos_.push_back(std::vector<int> {0, ii, jj});
+            auto pos = soil_simulator::CalcBucketFramePos(
+                ii, jj, 0.1, grid, bucket);
+            sim_out->body_soil_pos_.push_back(soil_simulator::body_soil
+                 {0, ii, jj, pos[0], pos[1], pos[2], 0.3});
         }
     for (auto ii = 49; ii < 65; ii++)
         for (auto jj = 60; jj < 65; jj++) {
             sim_out->body_[1][ii][jj] = 0.4;
             sim_out->body_soil_[0][ii][jj] = 0.4;
             sim_out->body_soil_[1][ii][jj] = 0.7;
-            sim_out->body_soil_pos_.push_back(std::vector<int> {0, ii, jj});
+            auto pos = soil_simulator::CalcBucketFramePos(
+                ii, jj, 0.1, grid, bucket);
+            sim_out->body_soil_pos_.push_back(soil_simulator::body_soil
+                {0, ii, jj, pos[0], pos[1], pos[2], 0.3});
         }
     sim_out->impact_area_[0][0] = 44;
     sim_out->impact_area_[1][0] = 45;
@@ -68,7 +88,8 @@ static void BM_RelaxBodySoil(benchmark::State& state) {
     sim_out->impact_area_[1][1] = 68;
 
     for (auto _ : state)
-        soil_simulator::RelaxBodySoil(sim_out, grid, sim_param, 1.e-5);
+        soil_simulator::RelaxBodySoil(sim_out, grid, bucket, sim_param, 1.e-5);
+    delete bucket;
     delete sim_out;
 }
 BENCHMARK(BM_RelaxBodySoil)->Unit(benchmark::kMicrosecond);
@@ -111,6 +132,12 @@ BENCHMARK(BM_CheckUnstableTerrainCell);
 static void BM_RelaxUnstableTerrainCell(benchmark::State& state) {
     // Defining inputs
     soil_simulator::Grid grid(4.0, 4.0, 3.0, 0.05, 0.01);
+    std::vector<float> o_pos = {0.0, 0.0, 0.0};
+    std::vector<float> j_pos = {0.0, 0.0, 0.0};
+    std::vector<float> b_pos = {0.0, 0.0, -0.5};
+    std::vector<float> t_pos = {0.7, 0.0, -0.5};
+    soil_simulator::Bucket *bucket = new soil_simulator::Bucket(
+        o_pos, j_pos, b_pos, t_pos, 0.5);
     soil_simulator::SimParam sim_param(0.85, 3, 4);
     soil_simulator::SimOut *sim_out = new soil_simulator::SimOut(grid);
     sim_out->terrain_[50][55] = 0.4;
@@ -119,7 +146,8 @@ static void BM_RelaxUnstableTerrainCell(benchmark::State& state) {
 
     for (auto _ : state)
         soil_simulator::RelaxUnstableTerrainCell(
-            sim_out, 142, 0.1, 50, 55, 49, 55, grid, 1.e-5);
+            sim_out, 142, 0.1, 50, 55, 49, 55, grid, bucket, 1.e-5);
+    delete bucket;
     delete sim_out;
 }
 BENCHMARK(BM_RelaxUnstableTerrainCell);
@@ -128,6 +156,12 @@ BENCHMARK(BM_RelaxUnstableTerrainCell);
 static void BM_CheckUnstableBodyCell(benchmark::State& state) {
     // Defining inputs
     soil_simulator::Grid grid(4.0, 4.0, 3.0, 0.05, 0.01);
+    std::vector<float> o_pos = {0.0, 0.0, 0.0};
+    std::vector<float> j_pos = {0.0, 0.0, 0.0};
+    std::vector<float> b_pos = {0.0, 0.0, -0.5};
+    std::vector<float> t_pos = {0.7, 0.0, -0.5};
+    soil_simulator::Bucket *bucket = new soil_simulator::Bucket(
+        o_pos, j_pos, b_pos, t_pos, 0.5);
     soil_simulator::SimParam sim_param(0.85, 3, 4);
     soil_simulator::SimOut *sim_out = new soil_simulator::SimOut(grid);
     sim_out->terrain_[50][61] = 0.4;
@@ -140,13 +174,17 @@ static void BM_CheckUnstableBodyCell(benchmark::State& state) {
     sim_out->body_[1][50][60] = 0.1;
     sim_out->body_soil_[0][50][60] = 0.1;
     sim_out->body_soil_[1][50][60] = 0.4;
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 50, 61});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 50, 60});
-
+    auto pos = soil_simulator::CalcBucketFramePos(50, 61, 0.4, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 50, 61, pos[0], pos[1], pos[2], 0.3});
+    pos = soil_simulator::CalcBucketFramePos(50, 60, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 50, 60, pos[0], pos[1], pos[2], 0.3});
     for (auto _ : state)
         soil_simulator::CheckUnstableBodyCell(
             sim_out, 50, 61, 0, 50, 60, 0.1, 1.e-5);
     delete sim_out;
+    delete bucket;
 }
 BENCHMARK(BM_CheckUnstableBodyCell);
 
@@ -155,6 +193,12 @@ static void BM_RelaxUnstableBodyCell(benchmark::State& state) {
     // Defining inputs
     soil_simulator::Grid grid(4.0, 4.0, 3.0, 0.05, 0.01);
     soil_simulator::SimParam sim_param(0.85, 3, 4);
+    std::vector<float> o_pos = {0.0, 0.0, 0.0};
+    std::vector<float> j_pos = {0.0, 0.0, 0.0};
+    std::vector<float> b_pos = {0.0, 0.0, -0.5};
+    std::vector<float> t_pos = {0.7, 0.0, -0.5};
+    soil_simulator::Bucket *bucket = new soil_simulator::Bucket(
+        o_pos, j_pos, b_pos, t_pos, 0.5);
     soil_simulator::SimOut *sim_out = new soil_simulator::SimOut(grid);
     sim_out->terrain_[50][61] = 0.4;
     sim_out->body_[0][50][61] = 0.0;
@@ -166,14 +210,20 @@ static void BM_RelaxUnstableBodyCell(benchmark::State& state) {
     sim_out->body_[1][50][60] = 0.1;
     sim_out->body_soil_[0][50][60] = 0.1;
     sim_out->body_soil_[1][50][60] = 0.4;
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 50, 61});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 50, 60});
-    std::vector<std::vector<int>> *body_soil_pos = (
-        new std::vector<std::vector<int>>);
+    auto pos = soil_simulator::CalcBucketFramePos(50, 61, 0.4, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 50, 61, pos[0], pos[1], pos[2], 0.3});
+    pos = soil_simulator::CalcBucketFramePos(50, 60, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 50, 60, pos[0], pos[1], pos[2], 0.3});
+    std::vector<soil_simulator::body_soil> *body_soil_pos = (
+        new std::vector<soil_simulator::body_soil>);
 
     for (auto _ : state)
         soil_simulator::RelaxUnstableBodyCell(
-            sim_out, 13, body_soil_pos, 0.1, 50, 61, 0, 50, 60, grid, 1.e-5);
+            sim_out, 13, body_soil_pos, 0.1, 0, 50, 61, 0, 50, 60, grid, bucket,
+            1.e-5);
+    delete bucket;
     delete sim_out;
     delete body_soil_pos;
 }

--- a/test/example/soil_evolution.cpp
+++ b/test/example/soil_evolution.cpp
@@ -259,7 +259,8 @@ void soil_simulator::SoilEvolution(
 
        if (max_bucket_vel != 0.0) {
            // Bucket is moving
-           dt_i = grid.cell_size_xy_ / max_bucket_vel;
+           dt_i = std::min(grid.cell_size_xy_, grid.cell_size_z_) /
+               max_bucket_vel;
        } else {
            // No bucket movement
            dt_i = dt;

--- a/test/unit_tests/test_body_soil.cpp
+++ b/test/unit_tests/test_body_soil.cpp
@@ -26,13 +26,19 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     sim_out->body_[1][11][10] = 0.1;
     sim_out->body_soil_[0][10][10] = 0.1;
     sim_out->body_soil_[1][10][10] = 0.2;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 10};
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 10, 0.0, 0.0, 0.0, 0.1});
     soil_simulator::UpdateBodySoil(
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][11][10], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][10], 0.2, 1.e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 11, 10}));
+    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 10);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -50,6 +56,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
         for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
             EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1.e-5);
+    sim_out->body_soil_pos_.erase(
+        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing for a simple lateral translation (2) --
     pos = std::vector<float> {grid.cell_size_xy_, 0.0, 0.0};
@@ -58,12 +66,19 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     sim_out->body_[1][11][10] = 0.1;
     sim_out->body_soil_[2][10][10] = 0.1;
     sim_out->body_soil_[3][10][10] = 0.2;
-    sim_out->body_soil_pos_[0] = std::vector<int> {2, 10, 10};
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 10, 0.0, 0.0, 0.0, 0.1});
     soil_simulator::UpdateBodySoil(
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][11][10], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][10], 0.2, 1.e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 11, 10}));
+    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 10);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -81,6 +96,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
         for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
             EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1.e-5);
+    sim_out->body_soil_pos_.erase(
+        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing for a simple lateral translation (3) --
     pos = std::vector<float> {grid.cell_size_xy_, 0.0, 0.0};
@@ -89,12 +106,19 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     sim_out->body_[3][11][10] = 0.1;
     sim_out->body_soil_[0][10][10] = 0.1;
     sim_out->body_soil_[1][10][10] = 0.2;
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 10};
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 10, 0.0, 0.0, 0.0, 0.1});
     soil_simulator::UpdateBodySoil(
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][11][10], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][10], 0.2, 1.e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {2, 11, 10}));
+    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 10);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -112,6 +136,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
         for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
             EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1.e-5);
+    sim_out->body_soil_pos_.erase(
+        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing for a simple lateral translation (4) --
     pos = std::vector<float> {grid.cell_size_xy_, 0.0, 0.0};
@@ -120,12 +146,19 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     sim_out->body_[3][11][10] = 0.1;
     sim_out->body_soil_[2][10][10] = 0.1;
     sim_out->body_soil_[3][10][10] = 0.2;
-    sim_out->body_soil_pos_[0] = std::vector<int> {2, 10, 10};
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 10, 0.0, 0.0, 0.0, 0.1});
     soil_simulator::UpdateBodySoil(
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][11][10], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][10], 0.2, 1.e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {2, 11, 10}));
+    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 10);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -143,6 +176,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
         for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
             EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1.e-5);
+    sim_out->body_soil_pos_.erase(
+        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing for a simple rotation from (11, 10) to (10, 11) --
     pos = std::vector<float> {0.0, 0.0, 0.0};
@@ -151,12 +186,19 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     sim_out->body_[1][10][11] = 0.1;
     sim_out->body_soil_[0][11][10] = 0.1;
     sim_out->body_soil_[1][11][10] = 0.2;
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 11, 10};
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 10, 0.1, 0.0, 0.0, 0.1});
     soil_simulator::UpdateBodySoil(
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][11], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][11], 0.2, 1.e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 11}));
+    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 10);
+    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 11);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, 0.1, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, 0., 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -174,6 +216,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
         for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
             EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1.e-5);
+    sim_out->body_soil_pos_.erase(
+        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing for a simple rotation from (11, 10) to (11, 11) --
     pos = std::vector<float> {0.0, 0.0, 0.0};
@@ -182,12 +226,19 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     sim_out->body_[1][11][11] = 0.1;
     sim_out->body_soil_[0][11][10] = 0.1;
     sim_out->body_soil_[1][11][10] = 0.2;
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 11, 10};
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 10, 0.1, 0.0, 0.0, 0.1});
     soil_simulator::UpdateBodySoil(
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][11][11], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][11], 0.2, 1.e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 11, 11}));
+    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 11);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, 0.1, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -205,6 +256,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
         for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
             EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1.e-5);
+    sim_out->body_soil_pos_.erase(
+        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing for a rotation + translation from (11, 10) to (12, 11) --
     pos = std::vector<float> {grid.cell_size_xy_, 0.0, 0.0};
@@ -213,12 +266,19 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     sim_out->body_[1][12][11] = 0.1;
     sim_out->body_soil_[0][11][10] = 0.1;
     sim_out->body_soil_[1][11][10] = 0.2;
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 11, 10};
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 10, 0.1, 0.0, 0.0, 0.1});
     soil_simulator::UpdateBodySoil(
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][12][11], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][12][11], 0.2, 1.e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 12, 11}));
+    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 12);
+    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 11);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, 0.1, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -236,13 +296,16 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
         for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
             EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1.e-5);
+    sim_out->body_soil_pos_.erase(
+        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing for a large transformation --
     pos = std::vector<float> {0.0, 0.0, 0.0};
     ori = std::vector<float> {0.0, 0.0, 1.0, 0.0};
     sim_out->body_soil_[0][11][10] = 0.1;
     sim_out->body_soil_[1][11][10] = 0.2;
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 11, 10};
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 10, 0.1, 0.0, 0.0, 0.1});
     soil_simulator::UpdateBodySoil(
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->terrain_[9][10], 0.1, 1.e-5);
@@ -260,31 +323,47 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
         for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
             EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1.e-5);
+    sim_out->body_soil_pos_.erase(
+        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing when two body_soil move to the same position (1) --
     pos = std::vector<float> {0.0, 0.0, 0.0};
     ori = std::vector<float> {0.707107, 0.0, 0.707107, 0.0};
-    sim_out->body_[0][9][10] = 0.0;
-    sim_out->body_[1][9][10] = 0.1;
+    sim_out->body_[0][10][10] = 0.0;
+    sim_out->body_[1][10][10] = 0.1;
     sim_out->body_soil_[0][11][10] = 0.1;
     sim_out->body_soil_[1][11][10] = 0.2;
     sim_out->body_soil_[0][12][10] = 0.1;
     sim_out->body_soil_[1][12][10] = 0.3;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 11, 10};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 12, 10});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 10, 0.1, 0.0, 0.0, 0.1});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 12, 10, 0.2, 0.0, 0.0, 0.2});
     soil_simulator::UpdateBodySoil(
         sim_out, pos, ori, grid, bucket, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_[0][9][10], 0.1, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_[1][9][10], 0.4, 1.e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 9, 10}));
+    EXPECT_NEAR(sim_out->body_soil_[0][10][10], 0.1, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_[1][10][10], 0.4, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 10);
+    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 10);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, 0.1, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
+    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 10);
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, 0.2, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
-    sim_out->body_[0][9][10] = 0.0;
-    sim_out->body_[1][9][10] = 0.0;
-    sim_out->body_soil_[0][9][10] = 0.0;
-    sim_out->body_soil_[1][9][10] = 0.0;
+    sim_out->body_[0][10][10] = 0.0;
+    sim_out->body_[1][10][10] = 0.0;
+    sim_out->body_soil_[0][10][10] = 0.0;
+    sim_out->body_soil_[1][10][10] = 0.0;
     // Checking that everything is resetted
     for (auto ii = 0; ii < sim_out->body_.size(); ii++)
         for (auto jj = 0; jj < sim_out->body_[0].size(); jj++)
@@ -295,31 +374,47 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
         for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
             EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1.e-5);
+    sim_out->body_soil_pos_.erase(
+        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing when two body_soil move to the same position (2) --
     pos = std::vector<float> {0.0, 0.0, 0.0};
     ori = std::vector<float> {0.707107, 0.0, 0.707107, 0.0};
-    sim_out->body_[0][9][10] = 0.0;
-    sim_out->body_[1][9][10] = 0.1;
+    sim_out->body_[0][10][10] = 0.0;
+    sim_out->body_[1][10][10] = 0.1;
     sim_out->body_soil_[0][11][10] = 0.1;
     sim_out->body_soil_[1][11][10] = 0.2;
     sim_out->body_soil_[2][12][10] = 0.1;
     sim_out->body_soil_[3][12][10] = 0.3;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 11, 10};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 12, 10});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 10, 0.1, 0.0, 0.0, 0.1});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 12, 10, 0.2, 0.0, 0.0, 0.2});
     soil_simulator::UpdateBodySoil(
         sim_out, pos, ori, grid, bucket, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_[0][9][10], 0.1, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_[1][9][10], 0.4, 1.e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 9, 10}));
+    EXPECT_NEAR(sim_out->body_soil_[0][10][10], 0.1, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_[1][10][10], 0.4, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 10);
+    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 10);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, 0.1, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
+    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 10);
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, 0.2, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
-    sim_out->body_[0][9][10] = 0.0;
-    sim_out->body_[1][9][10] = 0.0;
-    sim_out->body_soil_[0][9][10] = 0.0;
-    sim_out->body_soil_[1][9][10] = 0.0;
+    sim_out->body_[0][10][10] = 0.0;
+    sim_out->body_[1][10][10] = 0.0;
+    sim_out->body_soil_[0][10][10] = 0.0;
+    sim_out->body_soil_[1][10][10] = 0.0;
     // Checking that everything is resetted
     for (auto ii = 0; ii < sim_out->body_.size(); ii++)
         for (auto jj = 0; jj < sim_out->body_[0].size(); jj++)
@@ -330,31 +425,47 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
         for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
             EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1.e-5);
+    sim_out->body_soil_pos_.erase(
+        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing when two body_soil move to the same position (3) --
     pos = std::vector<float> {0.0, 0.0, 0.0};
     ori = std::vector<float> {0.707107, 0.0, 0.707107, 0.0};
-    sim_out->body_[2][9][10] = 0.0;
-    sim_out->body_[3][9][10] = 0.1;
+    sim_out->body_[2][10][10] = 0.0;
+    sim_out->body_[3][10][10] = 0.1;
     sim_out->body_soil_[0][11][10] = 0.1;
     sim_out->body_soil_[1][11][10] = 0.2;
     sim_out->body_soil_[2][12][10] = 0.1;
     sim_out->body_soil_[3][12][10] = 0.3;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 11, 10};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 12, 10});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 10, 0.1, 0.0, 0.0, 0.1});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 12, 10, 0.2, 0.0, 0.0, 0.2});
     soil_simulator::UpdateBodySoil(
         sim_out, pos, ori, grid, bucket, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_[2][9][10], 0.1, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_[3][9][10], 0.4, 1.e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {2, 9, 10}));
+    EXPECT_NEAR(sim_out->body_soil_[2][10][10], 0.1, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_[3][10][10], 0.4, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 10);
+    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 10);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, 0.1, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
+    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 10);
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, 0.2, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
-    sim_out->body_[2][9][10] = 0.0;
-    sim_out->body_[3][9][10] = 0.0;
-    sim_out->body_soil_[2][9][10] = 0.0;
-    sim_out->body_soil_[3][9][10] = 0.0;
+    sim_out->body_[2][10][10] = 0.0;
+    sim_out->body_[3][10][10] = 0.0;
+    sim_out->body_soil_[2][10][10] = 0.0;
+    sim_out->body_soil_[3][10][10] = 0.0;
     // Checking that everything is resetted
     for (auto ii = 0; ii < sim_out->body_.size(); ii++)
         for (auto jj = 0; jj < sim_out->body_[0].size(); jj++)
@@ -365,6 +476,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
         for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
             EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1.e-5);
+    sim_out->body_soil_pos_.erase(
+        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     delete sim_out;
     delete bucket;

--- a/test/unit_tests/test_intersecting_cells.cpp
+++ b/test/unit_tests/test_intersecting_cells.cpp
@@ -42,6 +42,7 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_EQ(wall_presence, false);
     EXPECT_NEAR(h_soil, 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[5][7], 0.6, 1e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     sim_out->terrain_[5][7] = 0.0;
     for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
         for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
@@ -61,6 +62,7 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_EQ(wall_presence, false);
     EXPECT_NEAR(h_soil, 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[5][7], 0.6, 1e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     sim_out->terrain_[5][7] = 0.0;
     sim_out->body_[0][5][7] = 0.0;
     sim_out->body_[1][5][7] = 0.0;
@@ -82,6 +84,7 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_EQ(wall_presence, true);
     EXPECT_NEAR(h_soil, 0.6, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[5][7], 0.0, 1e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     sim_out->body_[0][5][7] = 0.0;
     sim_out->body_[1][5][7] = 0.0;
     for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
@@ -117,6 +120,7 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.6, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     sim_out->body_[0][5][7] = 0.0;
     sim_out->body_[1][5][7] = 0.0;
     sim_out->body_soil_[0][5][7] = 0.0;
@@ -149,6 +153,7 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.6, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     sim_out->body_[0][5][7] = 0.0;
     sim_out->body_[1][5][7] = 0.0;
     sim_out->body_soil_[0][5][7] = 0.0;
@@ -185,6 +190,7 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.6, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     sim_out->body_[0][5][7] = 0.0;
     sim_out->body_[1][5][7] = 0.0;
     sim_out->body_soil_[0][5][7] = 0.0;
@@ -207,6 +213,7 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_EQ(wall_presence, false);
     EXPECT_NEAR(h_soil, 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[5][7], 0.6, 1e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     sim_out->body_[2][5][7] = 0.0;
     sim_out->body_[3][5][7] = 0.0;
     sim_out->terrain_[5][7] = 0.0;
@@ -234,6 +241,7 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(h_soil, 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][5][7], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][5][7], 0.7, 1e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     sim_out->body_[2][5][7] = 0.0;
     sim_out->body_[3][5][7] = 0.0;
     sim_out->body_soil_[2][5][7] = 0.0;
@@ -270,6 +278,7 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.6, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     sim_out->body_[2][5][7] = 0.0;
     sim_out->body_[3][5][7] = 0.0;
     sim_out->body_soil_[2][5][7] = 0.0;
@@ -301,6 +310,7 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.6, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     sim_out->body_[2][5][7] = 0.0;
     sim_out->body_[3][5][7] = 0.0;
     sim_out->body_soil_[2][5][7] = 0.0;
@@ -336,6 +346,7 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.6, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     sim_out->body_[2][5][7] = 0.0;
     sim_out->body_[3][5][7] = 0.0;
     sim_out->body_soil_[2][5][7] = 0.0;
@@ -369,6 +380,7 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_EQ(jj, 7);
     EXPECT_NEAR(sim_out->body_soil_[0][5][7], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][5][7], 0.2, 1e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     sim_out->body_[0][5][7] = 0.0;
     sim_out->body_[1][5][7] = 0.0;
     sim_out->body_[2][5][7] = 0.0;
@@ -404,6 +416,7 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_EQ(jj, 7);
     EXPECT_NEAR(sim_out->body_soil_[2][5][7], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][5][7], 0.6, 1e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     sim_out->body_[0][5][7] = 0.0;
     sim_out->body_[1][5][7] = 0.0;
     sim_out->body_[2][5][7] = 0.0;
@@ -440,6 +453,7 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.6, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     sim_out->body_[0][5][7] = 0.0;
     sim_out->body_[1][5][7] = 0.0;
     sim_out->body_[2][5][7] = 0.0;
@@ -476,6 +490,7 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.6, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     sim_out->body_[0][5][7] = 0.0;
     sim_out->body_[1][5][7] = 0.0;
     sim_out->body_[2][5][7] = 0.0;
@@ -516,6 +531,7 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.6, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     sim_out->body_[0][5][7] = 0.0;
     sim_out->body_[1][5][7] = 0.0;
     sim_out->body_[2][5][7] = 0.0;
@@ -556,6 +572,7 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.6, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     sim_out->body_[0][5][7] = 0.0;
     sim_out->body_[1][5][7] = 0.0;
     sim_out->body_[2][5][7] = 0.0;
@@ -596,6 +613,7 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.6, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     sim_out->body_[0][5][7] = 0.0;
     sim_out->body_[1][5][7] = 0.0;
     sim_out->body_[2][5][7] = 0.0;
@@ -636,6 +654,7 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     sim_out->body_[0][5][7] = 0.0;
     sim_out->body_[1][5][7] = 0.0;
     sim_out->body_[2][5][7] = 0.0;
@@ -675,6 +694,7 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     sim_out->body_[0][5][7] = 0.0;
     sim_out->body_[1][5][7] = 0.0;
     sim_out->body_[2][5][7] = 0.0;
@@ -714,6 +734,7 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     sim_out->body_[0][5][7] = 0.0;
     sim_out->body_[1][5][7] = 0.0;
     sim_out->body_[2][5][7] = 0.0;
@@ -757,6 +778,7 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     sim_out->body_[0][5][7] = 0.0;
     sim_out->body_[1][5][7] = 0.0;
     sim_out->body_[2][5][7] = 0.0;
@@ -800,6 +822,7 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.4, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     sim_out->body_[0][5][7] = 0.0;
     sim_out->body_[1][5][7] = 0.0;
     sim_out->body_[2][5][7] = 0.0;
@@ -843,6 +866,7 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     sim_out->body_[0][5][7] = 0.0;
     sim_out->body_[1][5][7] = 0.0;
     sim_out->body_[2][5][7] = 0.0;
@@ -886,6 +910,7 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     sim_out->body_[0][5][7] = 0.0;
     sim_out->body_[1][5][7] = 0.0;
     sim_out->body_[2][5][7] = 0.0;
@@ -938,6 +963,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.7, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.3, 1e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -953,7 +980,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_soil_pos_.erase(
         sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
-/*
     // -- Testing when soil is avalanching on the terrain (2) --
     // -- Second bucket layer at bottom                       --
     soil_simulator::rng.seed(1234);
@@ -965,17 +991,20 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_soil_[1][10][15] = 0.7;
     sim_out->body_soil_[2][10][15] = 0.3;
     sim_out->body_soil_[3][10][15] = 0.8;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.1});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.5});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.3, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -1002,17 +1031,20 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_soil_[1][10][15] = 0.0;
     sim_out->body_soil_[2][10][15] = 0.0;
     sim_out->body_soil_[3][10][15] = 0.1;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, -0.5, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.0, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], -0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.3, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -1040,17 +1072,20 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_soil_[3][10][15] = 0.7;
     sim_out->body_[0][11][15] = 0.4;
     sim_out->body_[1][11][15] = 1.0;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.7, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.3, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -1080,17 +1115,20 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_soil_[3][10][15] = 0.7;
     sim_out->body_[0][11][15] = 0.4;
     sim_out->body_[1][11][15] = 0.5;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.7, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.3, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -1120,17 +1158,20 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_soil_[3][10][15] = 0.8;
     sim_out->body_[0][11][15] = 0.4;
     sim_out->body_[1][11][15] = 1.0;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.1});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.5});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.3, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -1164,10 +1205,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[1][11][15] = 0.7;
     sim_out->body_soil_[0][11][15] = 0.7;
     sim_out->body_soil_[1][11][15] = 0.8;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    pos0 = soil_simulator::CalcBucketFramePos(11, 15, 0.8, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 15, pos0[0], pos0[1], pos0[2], 0.1});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -1176,9 +1222,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.8, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.7, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -1210,17 +1255,20 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_soil_[3][10][15] = 0.7;
     sim_out->body_[2][11][15] = 0.4;
     sim_out->body_[3][11][15] = 1.0;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.7, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.3, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -1250,17 +1298,20 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_soil_[3][10][15] = 0.7;
     sim_out->body_[2][11][15] = 0.4;
     sim_out->body_[3][11][15] = 0.5;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.7, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.3, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -1290,17 +1341,20 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_soil_[3][10][15] = 0.8;
     sim_out->body_[2][11][15] = 0.4;
     sim_out->body_[3][11][15] = 1.0;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.1});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.5});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.3, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -1332,17 +1386,20 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->terrain_[11][15] = 0.3;
     sim_out->body_[2][11][15] = 0.4;
     sim_out->body_[3][11][15] = 0.5;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.7, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.6, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -1372,9 +1429,13 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_soil_[3][10][15] = 0.7;
     sim_out->body_[0][11][15] = 0.0;
     sim_out->body_[1][11][15] = 0.2;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    auto posA = soil_simulator::CalcBucketFramePos(11, 15, 0.2, grid, bucket);
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -1383,9 +1444,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -1416,9 +1483,13 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_soil_[3][10][15] = 0.8;
     sim_out->body_[0][11][15] = 0.0;
     sim_out->body_[1][11][15] = 0.2;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.1});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.5});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.2, grid, bucket);
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.7, 1e-5);
@@ -1427,9 +1498,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -1460,9 +1537,13 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_soil_[3][10][15] = 0.7;
     sim_out->body_[2][11][15] = 0.0;
     sim_out->body_[3][11][15] = 0.2;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.2, grid, bucket);
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -1471,9 +1552,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {2, 11, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -1504,9 +1591,13 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_soil_[3][10][15] = 0.8;
     sim_out->body_[2][11][15] = 0.0;
     sim_out->body_[3][11][15] = 0.2;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.1});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.5});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.2, grid, bucket);
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.7, 1e-5);
@@ -1515,9 +1606,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {2, 11, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -1551,10 +1648,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[1][11][15] = 0.1;
     sim_out->body_soil_[0][11][15] = 0.1;
     sim_out->body_soil_[1][11][15] = 0.2;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 15, posA[0], posA[1], posA[2], 0.1});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -1563,9 +1665,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -1599,10 +1707,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[1][11][15] = 0.1;
     sim_out->body_soil_[0][11][15] = 0.1;
     sim_out->body_soil_[1][11][15] = 0.2;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.1});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.5});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 15, posA[0], posA[1], posA[2], 0.1});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.7, 1e-5);
@@ -1611,9 +1724,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -1647,10 +1766,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[3][11][15] = 0.1;
     sim_out->body_soil_[2][11][15] = 0.1;
     sim_out->body_soil_[3][11][15] = 0.2;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 11, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 11, 15, posA[0], posA[1], posA[2], 0.1});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -1659,9 +1783,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {2, 11, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -1695,10 +1825,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[3][11][15] = 0.1;
     sim_out->body_soil_[2][11][15] = 0.1;
     sim_out->body_soil_[3][11][15] = 0.2;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 11, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.1});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.5});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 11, 15, posA[0], posA[1], posA[2], 0.1});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.7, 1e-5);
@@ -1707,9 +1842,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {2, 11, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -1743,9 +1884,13 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[1][11][15] = 0.2;
     sim_out->body_[2][11][15] = 0.5;
     sim_out->body_[3][11][15] = 0.7;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.2, grid, bucket);
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -1754,9 +1899,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -1792,9 +1943,13 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[1][11][15] = 0.2;
     sim_out->body_[2][11][15] = 0.5;
     sim_out->body_[3][11][15] = 0.7;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.1});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.5});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.2, grid, bucket);
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.7, 1e-5);
@@ -1803,9 +1958,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -1841,9 +2002,13 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[1][11][15] = 0.7;
     sim_out->body_[2][11][15] = 0.0;
     sim_out->body_[3][11][15] = 0.2;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.2, grid, bucket);
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -1852,9 +2017,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {2, 11, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -1890,9 +2061,13 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[1][11][15] = 0.7;
     sim_out->body_[2][11][15] = 0.0;
     sim_out->body_[3][11][15] = 0.2;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.1});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.5});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.2, grid, bucket);
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.7, 1e-5);
@@ -1901,9 +2076,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {2, 11, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -1941,10 +2122,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[3][11][15] = 0.7;
     sim_out->body_soil_[0][11][15] = 0.1;
     sim_out->body_soil_[1][11][15] = 0.2;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 15, posA[0], posA[1], posA[2], 0.1});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -1953,9 +2139,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -1993,10 +2185,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[3][11][15] = 0.7;
     sim_out->body_soil_[0][11][15] = 0.1;
     sim_out->body_soil_[1][11][15] = 0.2;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.1});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.5});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 15, posA[0], posA[1], posA[2], 0.1});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.7, 1e-5);
@@ -2005,9 +2202,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -2045,10 +2248,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[3][11][15] = 0.1;
     sim_out->body_soil_[2][11][15] = 0.1;
     sim_out->body_soil_[3][11][15] = 0.2;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 11, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 11, 15, posA[0], posA[1], posA[2], 0.1});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -2057,9 +2265,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {2, 11, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -2097,10 +2311,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[3][11][15] = 0.1;
     sim_out->body_soil_[2][11][15] = 0.1;
     sim_out->body_soil_[3][11][15] = 0.2;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 11, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.1});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.5});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 11, 15, posA[0], posA[1], posA[2], 0.1});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.7, 1e-5);
@@ -2109,9 +2328,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {2, 11, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -2147,9 +2372,13 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[1][11][15] = 0.2;
     sim_out->body_[2][11][15] = 0.4;
     sim_out->body_[3][11][15] = 0.7;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.2, grid, bucket);
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -2159,9 +2388,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.4, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.1, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     sim_out->terrain_[12][15] = 0.0;
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
@@ -2198,9 +2433,13 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[1][11][15] = 0.2;
     sim_out->body_[2][11][15] = 0.4;
     sim_out->body_[3][11][15] = 0.7;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.1});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.5});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.2, grid, bucket);
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.7, 1e-5);
@@ -2210,9 +2449,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.4, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.1, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     sim_out->terrain_[12][15] = 0.0;
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
@@ -2249,9 +2494,13 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[1][11][15] = 0.7;
     sim_out->body_[2][11][15] = 0.0;
     sim_out->body_[3][11][15] = 0.2;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.2, grid, bucket);
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -2261,9 +2510,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.4, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.1, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {2, 11, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     sim_out->terrain_[12][15] = 0.0;
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
@@ -2300,9 +2555,13 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[1][11][15] = 0.7;
     sim_out->body_[2][11][15] = 0.0;
     sim_out->body_[3][11][15] = 0.2;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.1});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.5});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.2, grid, bucket);
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.7, 1e-5);
@@ -2312,9 +2571,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.4, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.1, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {2, 11, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     sim_out->terrain_[12][15] = 0.0;
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
@@ -2353,10 +2618,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[3][11][15] = 0.7;
     sim_out->body_soil_[0][11][15] = 0.1;
     sim_out->body_soil_[1][11][15] = 0.2;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 15, posA[0], posA[1], posA[2], 0.1});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -2366,9 +2636,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.4, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.1, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     sim_out->terrain_[12][15] = 0.0;
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
@@ -2407,10 +2683,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[3][11][15] = 1.3;
     sim_out->body_soil_[0][11][15] = 0.1;
     sim_out->body_soil_[1][11][15] = 0.7;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.1});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.5});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 15, posA[0], posA[1], posA[2], 0.6});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.7, 1e-5);
@@ -2420,9 +2701,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.9, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.1, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     sim_out->terrain_[12][15] = 0.0;
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
@@ -2461,10 +2748,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[3][11][15] = 0.1;
     sim_out->body_soil_[2][11][15] = 0.1;
     sim_out->body_soil_[3][11][15] = 0.2;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 11, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 11, 15, posA[0], posA[1], posA[2], 0.1});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -2474,9 +2766,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.4, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.1, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {2, 11, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     sim_out->terrain_[12][15] = 0.0;
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
@@ -2515,10 +2813,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[3][11][15] = 0.1;
     sim_out->body_soil_[2][11][15] = 0.1;
     sim_out->body_soil_[3][11][15] = 0.7;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 11, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.1});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.5});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 11, 15, posA[0], posA[1], posA[2], 0.6});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.7, 1e-5);
@@ -2528,9 +2831,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.9, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.1, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {2, 11, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     sim_out->terrain_[12][15] = 0.0;
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
@@ -2576,12 +2885,21 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[1][12][15] = 0.4;
     sim_out->body_soil_[0][12][15] = 0.4;
     sim_out->body_soil_[1][12][15] = 0.8;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 12, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.1, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(11, 15, 0.8, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 15, posA[0], posA[1], posA[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 11, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    pos0 = soil_simulator::CalcBucketFramePos(12, 15, 0.4, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 12, 15, pos0[0], pos0[1], pos0[2], 0.4});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -2595,11 +2913,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][12][15], 0.8, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.2, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[3] == std::vector<int> {2, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[4] == std::vector<int> {0, 12, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.1, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 6);
     sim_out->terrain_[12][15] = 0.0;
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
@@ -2651,12 +2973,21 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[1][12][15] = 0.6;
     sim_out->body_soil_[0][12][15] = 0.6;
     sim_out->body_soil_[1][12][15] = 0.8;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 12, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.6});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    pos0 = soil_simulator::CalcBucketFramePos(11, 15, 0.9, grid, bucket);
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.4, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 15, pos0[0], pos0[1], pos0[2], 0.3});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 11, 15, posA[0], posA[1], posA[2], 0.3});
+    pos0 = soil_simulator::CalcBucketFramePos(12, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 12, 15, pos0[0], pos0[1], pos0[2], 0.2});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -2670,11 +3001,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][12][15], 0.8, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.3, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[3] == std::vector<int> {2, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[4] == std::vector<int> {0, 12, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.1, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 6);
     sim_out->terrain_[12][15] = 0.0;
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
@@ -2726,12 +3061,21 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[3][12][15] = 0.4;
     sim_out->body_soil_[2][12][15] = 0.4;
     sim_out->body_soil_[3][12][15] = 0.8;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 12, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.8});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    pos0 = soil_simulator::CalcBucketFramePos(11, 15, 0.0, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(11, 15, 0.8, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 11, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    posA = soil_simulator::CalcBucketFramePos(12, 15, 0.4, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 12, 15, posA[0], posA[1], posA[2], 0.4});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -2745,11 +3089,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 0.8, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.6, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[3] == std::vector<int> {2, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[4] == std::vector<int> {2, 12, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 5);
     sim_out->terrain_[12][15] = 0.0;
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
@@ -2801,12 +3142,21 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[3][12][15] = 0.6;
     sim_out->body_soil_[2][12][15] = 0.6;
     sim_out->body_soil_[3][12][15] = 0.8;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 12, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.8});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    pos0 = soil_simulator::CalcBucketFramePos(11, 15, 0.8, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(11, 15, 0.4, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 15, pos0[0], pos0[1], pos0[2], 0.1});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 11, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    posA = soil_simulator::CalcBucketFramePos(12, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 12, 15, posA[0], posA[1], posA[2], 0.2});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -2820,11 +3170,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 0.8, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.6, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[3] == std::vector<int> {2, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[4] == std::vector<int> {2, 12, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 5);
     sim_out->terrain_[12][15] = 0.0;
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
@@ -2876,12 +3223,21 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[1][12][15] = 0.4;
     sim_out->body_soil_[0][12][15] = 0.4;
     sim_out->body_soil_[1][12][15] = 0.8;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 12, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.1, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(11, 15, 0.8, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 15, posA[0], posA[1], posA[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 11, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    pos0 = soil_simulator::CalcBucketFramePos(12, 15, 0.4, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 12, 15, pos0[0], pos0[1], pos0[2], 0.2});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -2895,11 +3251,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][12][15], 0.8, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.2, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[3] == std::vector<int> {2, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[4] == std::vector<int> {0, 12, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.1, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 6);
     sim_out->terrain_[12][15] = 0.0;
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
@@ -2951,12 +3311,21 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[1][12][15] = 0.6;
     sim_out->body_soil_[0][12][15] = 0.6;
     sim_out->body_soil_[1][12][15] = 0.8;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 12, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    pos0 = soil_simulator::CalcBucketFramePos(11, 15, 1.0, grid, bucket);
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.2, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 15, pos0[0], pos0[1], pos0[2], 0.2});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 11, 15, posA[0], posA[1], posA[2], 0.6});
+    pos0 = soil_simulator::CalcBucketFramePos(12, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 12, 15, pos0[0], pos0[1], pos0[2], 0.2});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -2970,11 +3339,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][12][15], 0.8, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.2, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[3] == std::vector<int> {2, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[4] == std::vector<int> {0, 12, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.1, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 6);
     sim_out->terrain_[12][15] = 0.0;
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
@@ -3026,12 +3399,21 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[3][12][15] = 0.4;
     sim_out->body_soil_[2][12][15] = 0.4;
     sim_out->body_soil_[3][12][15] = 0.8;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 12, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.8});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.0, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(11, 15, 0.8, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 15, posA[0], posA[1], posA[2], 0.4});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 11, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    pos2 = soil_simulator::CalcBucketFramePos(12, 15, 0.4, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 12, 15, pos2[0], pos2[1], pos2[2], 0.2});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -3045,11 +3427,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 0.8, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.5, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[3] == std::vector<int> {2, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[4] == std::vector<int> {2, 12, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.1, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 6);
     sim_out->terrain_[12][15] = 0.0;
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
@@ -3101,12 +3487,21 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[3][12][15] = 0.6;
     sim_out->body_soil_[2][12][15] = 0.6;
     sim_out->body_soil_[3][12][15] = 0.8;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 12, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.8});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    pos0 = soil_simulator::CalcBucketFramePos(11, 15, 0.8, grid, bucket);
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.2, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 15, pos0[0], pos0[1], pos0[2], 0.1});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 11, 15, posA[0], posA[1], posA[2], 0.1});
+    pos2 = soil_simulator::CalcBucketFramePos(12, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 12, 15, pos2[0], pos2[1], pos2[2], 0.2});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -3120,11 +3515,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 0.8, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.4, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[3] == std::vector<int> {2, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[4] == std::vector<int> {2, 12, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 6);
     sim_out->terrain_[12][15] = 0.0;
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
@@ -3167,10 +3566,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[1][11][15] = 0.2;
     sim_out->body_soil_[0][11][15] = 0.2;
     sim_out->body_soil_[1][11][15] = 0.8;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.2, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 15, posA[0], posA[1], posA[2], 0.6});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -3179,9 +3583,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 1.1, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     sim_out->terrain_[12][15] = 0.0;
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
@@ -3216,10 +3626,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[3][11][15] = 0.2;
     sim_out->body_soil_[2][11][15] = 0.2;
     sim_out->body_soil_[3][11][15] = 0.5;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 11, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.2, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 11, 15, posA[0], posA[1], posA[2], 0.3});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -3228,9 +3643,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.8, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {2, 11, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     sim_out->terrain_[12][15] = 0.0;
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
@@ -3274,12 +3695,21 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[1][12][15] = 0.3;
     sim_out->body_soil_[0][12][15] = 0.3;
     sim_out->body_soil_[1][12][15] = 0.4;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 12, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    pos0 = soil_simulator::CalcBucketFramePos(11, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(11, 15, 0.8, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 15, pos0[0], pos0[1], pos0[2], 0.2});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 11, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    posA = soil_simulator::CalcBucketFramePos(12, 15, 0.3, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 12, 15, posA[0], posA[1], posA[2], 0.1});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -3293,11 +3723,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][12][15], 0.7, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.0, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[3] == std::vector<int> {2, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[4] == std::vector<int> {0, 12, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].ii, 12);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 6);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -3346,11 +3780,19 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_soil_[3][11][15] = 0.5;
     sim_out->body_[0][12][15] = 0.0;
     sim_out->body_[1][12][15] = 0.1;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 11, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    pos0 = soil_simulator::CalcBucketFramePos(11, 15, 0.8, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(11, 15, 0.4, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 15, pos0[0], pos0[1], pos0[2], 0.1});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 11, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    posA = soil_simulator::CalcBucketFramePos(12, 15, 0.1, grid, bucket);
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -3364,11 +3806,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][12][15], 0.4, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.0, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[3] == std::vector<int> {2, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[4] == std::vector<int> {0, 12, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[4].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[4].ii, 12);
+    EXPECT_EQ(sim_out->body_soil_pos_[4].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[4].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[4].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[4].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[4].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 5);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -3419,12 +3865,21 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[3][12][15] = 0.1;
     sim_out->body_soil_[2][12][15] = 0.1;
     sim_out->body_soil_[3][12][15] = 0.3;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 12, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    pos0 = soil_simulator::CalcBucketFramePos(11, 15, 0.1, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(11, 15, 0.8, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 15, pos0[0], pos0[1], pos0[2], 0.6});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 11, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    posA = soil_simulator::CalcBucketFramePos(12, 15, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 12, 15, posA[0], posA[1], posA[2], 0.2});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -3438,11 +3893,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.0, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[3] == std::vector<int> {2, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[4] == std::vector<int> {2, 12, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].ii, 12);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 6);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -3491,11 +3950,19 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_soil_[3][11][15] = 0.5;
     sim_out->body_[2][12][15] = 0.0;
     sim_out->body_[3][12][15] = 0.3;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 11, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    pos0 = soil_simulator::CalcBucketFramePos(11, 15, 0.8, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(11, 15, 0.4, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 15, pos0[0], pos0[1], pos0[2], 0.1});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 11, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    posA = soil_simulator::CalcBucketFramePos(12, 15, 0.3, grid, bucket);
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -3509,11 +3976,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.0, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[3] == std::vector<int> {2, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[4] == std::vector<int> {2, 12, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[4].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[4].ii, 12);
+    EXPECT_EQ(sim_out->body_soil_pos_[4].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[4].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[4].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[4].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[4].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 5);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -3564,12 +4035,21 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[1][12][15] = 0.3;
     sim_out->body_soil_[0][12][15] = 0.3;
     sim_out->body_soil_[1][12][15] = 0.4;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 12, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(11, 15, 0.8, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 15, posA[0], posA[1], posA[2], 0.1});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 11, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    auto posB = soil_simulator::CalcBucketFramePos(12, 15, 0.3, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 12, 15, posB[0], posB[1], posB[2], 0.1});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -3583,11 +4063,22 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][12][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.0, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[3] == std::vector<int> {2, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[4] == std::vector<int> {0, 12, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.1, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[6].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[6].ii, 12);
+    EXPECT_EQ(sim_out->body_soil_pos_[6].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[6].x_b, posB[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[6].y_b, posB[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[6].z_b, posB[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[6].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 7);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -3636,11 +4127,19 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[1][12][15] = 0.1;
     sim_out->body_soil_[0][12][15] = 0.1;
     sim_out->body_soil_[1][12][15] = 0.2;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 12, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    pos0 = soil_simulator::CalcBucketFramePos(11, 15, 0.8, grid, bucket);
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.4, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 15, pos0[0], pos0[1], pos0[2], 0.1});
+    posB = soil_simulator::CalcBucketFramePos(12, 15, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 12, 15, posB[0], posB[1], posB[2], 0.1});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -3654,11 +4153,22 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][12][15], 0.4, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.0, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[3] == std::vector<int> {0, 12, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[4] == std::vector<int> {2, 11, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[4].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[4].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[4].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[4].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[4].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[4].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[4].h_soil, 0.1, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].ii, 12);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].x_b, posB[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].y_b, posB[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posB[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 6);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -3705,11 +4215,19 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[3][12][15] = 0.1;
     sim_out->body_soil_[2][12][15] = 0.1;
     sim_out->body_soil_[3][12][15] = 0.3;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 12, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.4, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(11, 15, 0.8, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 11, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    posB = soil_simulator::CalcBucketFramePos(12, 15, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 12, 15, posB[0], posB[1], posB[2], 0.2});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -3723,11 +4241,22 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 0.4, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.0, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {2, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[3] == std::vector<int> {2, 12, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[4] == std::vector<int> {0, 11, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[4].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[4].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[4].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[4].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[4].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[4].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[4].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].ii, 12);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].x_b, posB[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].y_b, posB[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posB[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.1, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 6);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -3778,12 +4307,21 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[3][12][15] = 0.2;
     sim_out->body_soil_[2][12][15] = 0.2;
     sim_out->body_soil_[3][12][15] = 0.3;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 12, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    pos0 = soil_simulator::CalcBucketFramePos(11, 15, 0.8, grid, bucket);
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.3, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 15, pos0[0], pos0[1], pos0[2], 0.1});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 11, 15, posA[0], posA[1], posA[2], 0.1});
+    posB = soil_simulator::CalcBucketFramePos(12, 15, 0.2, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 12, 15, posB[0], posB[1], posB[2], 0.1});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -3797,11 +4335,22 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.0, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[3] == std::vector<int> {2, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[4] == std::vector<int> {2, 12, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[5].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.1, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[6].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[6].ii, 12);
+    EXPECT_EQ(sim_out->body_soil_pos_[6].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[6].x_b, posB[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[6].y_b, posB[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[6].z_b, posB[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[6].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 7);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -3892,14 +4441,28 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[1][12][17] = 1.7;
     sim_out->body_[2][12][17] = 0.1;
     sim_out->body_[3][12][17] = 0.3;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 16});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 14});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 9, 14});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 16});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 1.2});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.2, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 15, posA[0], posA[1], posA[2], 0.1});
+    posB = soil_simulator::CalcBucketFramePos(10, 16, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 16, posB[0], posB[1], posB[2], 0.3});
+    auto posC = soil_simulator::CalcBucketFramePos(11, 14, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 14, posC[0], posC[1], posC[2], 0.1});
+    auto posD = soil_simulator::CalcBucketFramePos(9, 14, 0.3, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 9, 14, posD[0], posD[1], posD[2], 0.1});
+    pos0 = soil_simulator::CalcBucketFramePos(11, 16, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 16, pos0[0], pos0[1], pos0[2], 0.7});
+    auto posE = soil_simulator::CalcBucketFramePos(12, 17, 0.3, grid, bucket);
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -3917,14 +4480,43 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][11][16], 0.8, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][12][17], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][12][17], 0.5, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[3] == std::vector<int> {2, 10, 16}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[4] == std::vector<int> {0, 11, 14}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[5] == std::vector<int> {2, 9, 14}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[6] == std::vector<int> {0, 11, 16}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[7] == std::vector<int> {2, 12, 17}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[7].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[7].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[7].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[7].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[7].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[7].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[7].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[8].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[8].ii, 10);
+    EXPECT_EQ(sim_out->body_soil_pos_[8].jj, 16);
+    EXPECT_NEAR(sim_out->body_soil_pos_[8].x_b, posB[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[8].y_b, posB[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[8].z_b, posB[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[8].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[9].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[9].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[9].jj, 14);
+    EXPECT_NEAR(sim_out->body_soil_pos_[9].x_b, posC[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[9].y_b, posC[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[9].z_b, posC[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[9].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[10].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[10].ii, 9);
+    EXPECT_EQ(sim_out->body_soil_pos_[10].jj, 14);
+    EXPECT_NEAR(sim_out->body_soil_pos_[10].x_b, posD[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[10].y_b, posD[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[10].z_b, posD[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[10].h_soil, 0.1, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[11].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[11].ii, 12);
+    EXPECT_EQ(sim_out->body_soil_pos_[11].jj, 17);
+    EXPECT_NEAR(sim_out->body_soil_pos_[11].x_b, posE[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[11].y_b, posE[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[11].z_b, posE[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[11].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 12);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -4005,11 +4597,18 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[3][12][15] = 0.2;
     sim_out->body_soil_[2][12][15] = 0.2;
     sim_out->body_soil_[3][12][15] = 0.5;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 12, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 1.2});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    pos0 = soil_simulator::CalcBucketFramePos(11, 15, 0.2, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 15, pos0[0], pos0[1], pos0[2], 0.3});
+    posA = soil_simulator::CalcBucketFramePos(12, 15, 0.2, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 12, 15, posA[0], posA[1], posA[2], 0.3});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -4021,10 +4620,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 1.5, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.0, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[3] == std::vector<int> {2, 12, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[4].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[4].ii, 12);
+    EXPECT_EQ(sim_out->body_soil_pos_[4].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[4].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[4].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[4].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[4].h_soil, 1.0, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 5);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -4071,11 +4675,18 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[3][12][15] = 0.3;
     sim_out->body_soil_[2][12][15] = 0.3;
     sim_out->body_soil_[3][12][15] = 0.8;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 12, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 1.2});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    pos2 = soil_simulator::CalcBucketFramePos(11, 15, 0.2, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 11, 15, pos2[0], pos2[1], pos2[2], 0.2});
+    posA = soil_simulator::CalcBucketFramePos(12, 15, 0.3, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 12, 15, posA[0], posA[1], posA[2], 0.5});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -4087,10 +4698,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 1.8, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.0, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {2, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[3] == std::vector<int> {2, 12, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[4].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[4].ii, 12);
+    EXPECT_EQ(sim_out->body_soil_pos_[4].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[4].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[4].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[4].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[4].h_soil, 1.0, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 5);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -4179,14 +4795,28 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[1][12][17] = 0.3;
     sim_out->body_[2][12][17] = 0.6;
     sim_out->body_[3][12][17] = 0.7;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 16});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 14});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 9, 14});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 16});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    pos0 = soil_simulator::CalcBucketFramePos(11, 15, 0.2, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 15, pos0[0], pos0[1], pos0[2], 0.3});
+    pos2 = soil_simulator::CalcBucketFramePos(10, 16, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 16, pos2[0], pos2[1], pos2[2], 0.6});
+    pos0 = soil_simulator::CalcBucketFramePos(11, 14, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 14, pos0[0], pos0[1], pos0[2], 0.8});
+    pos2 = soil_simulator::CalcBucketFramePos(9, 14, 0.4, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 9, 14, pos2[0], pos2[1], pos2[2], 0.1});
+    pos0 = soil_simulator::CalcBucketFramePos(11, 16, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 16, pos0[0], pos0[1], pos0[2], 0.7});
+    posA = soil_simulator::CalcBucketFramePos(12, 17, 0.3, grid, bucket);
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -4204,14 +4834,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][11][16], 0.8, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][12][17], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][12][17], 0.6, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[3] == std::vector<int> {2, 10, 16}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[4] == std::vector<int> {0, 11, 14}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[5] == std::vector<int> {2, 9, 14}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[6] == std::vector<int> {0, 11, 16}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[7] == std::vector<int> {0, 12, 17}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[7].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[7].ii, 12);
+    EXPECT_EQ(sim_out->body_soil_pos_[7].jj, 17);
+    EXPECT_NEAR(sim_out->body_soil_pos_[7].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[7].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[7].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[7].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 8);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -4292,10 +4923,16 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[1][12][15] = 0.8;
     sim_out->body_[2][12][15] = 0.0;
     sim_out->body_[3][12][15] = 0.1;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 11, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    pos2 = soil_simulator::CalcBucketFramePos(11, 15, 0.4, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 11, 15, pos2[0], pos2[1], pos2[2], 0.5});
+    posA = soil_simulator::CalcBucketFramePos(12, 15, 0.1, grid, bucket);
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -4307,10 +4944,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 0.4, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.0, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {2, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[3] == std::vector<int> {2, 12, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 12);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -4409,13 +5051,30 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[1][20][15] = 0.1;
     sim_out->body_[2][20][15] = 0.9;
     sim_out->body_[3][20][15] = 1.0;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 12, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 13, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 15, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 17, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 2.7});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    posB = soil_simulator::CalcBucketFramePos(12, 15, 0.4, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 12, 15, posB[0], posB[1], posB[2], 0.1});
+    posC = soil_simulator::CalcBucketFramePos(13, 15, 0.5, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 13, 15, posC[0], posC[1], posC[2], 0.2});
+    posE = soil_simulator::CalcBucketFramePos(15, 15, 0.2, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 15, 15, posE[0], posE[1], posE[2], 0.2});
+    auto posG = soil_simulator::CalcBucketFramePos(17, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 17, 15, posG[0], posG[1], posG[2], 0.2});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.2, grid, bucket);
+    posD = soil_simulator::CalcBucketFramePos(14, 15, 0.2, grid, bucket);
+    auto posF = soil_simulator::CalcBucketFramePos(16, 15, 0.5, grid, bucket);
+    auto posH = soil_simulator::CalcBucketFramePos(18, 15, 0.8, grid, bucket);
+    auto posI = soil_simulator::CalcBucketFramePos(19, 15, 0.4, grid, bucket);
+    auto posJ = soil_simulator::CalcBucketFramePos(20, 15, 0.1, grid, bucket);
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -4441,18 +5100,78 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][19][15], 0.9, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][20][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][20][15], 0.5, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 12, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[3] == std::vector<int> {0, 13, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[4] == std::vector<int> {0, 15, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[5] == std::vector<int> {2, 17, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[6] == std::vector<int> {0, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[7] == std::vector<int> {0, 14, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[8] == std::vector<int> {2, 16, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[9] == std::vector<int> {0, 18, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[10] == std::vector<int> {2, 19, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[11] == std::vector<int> {0, 20, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[6].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[6].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[6].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[6].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[6].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[6].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[6].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[7].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[7].ii, 12);
+    EXPECT_EQ(sim_out->body_soil_pos_[7].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[7].x_b, posB[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[7].y_b, posB[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[7].z_b, posB[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[7].h_soil, 0.1, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[8].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[8].ii, 13);
+    EXPECT_EQ(sim_out->body_soil_pos_[8].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[8].x_b, posC[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[8].y_b, posC[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[8].z_b, posC[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[8].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[9].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[9].ii, 14);
+    EXPECT_EQ(sim_out->body_soil_pos_[9].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[9].x_b, posD[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[9].y_b, posD[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[9].z_b, posD[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[9].h_soil, 0.4, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[10].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[10].ii, 15);
+    EXPECT_EQ(sim_out->body_soil_pos_[10].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[10].x_b, posE[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[10].y_b, posE[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[10].z_b, posE[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[10].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[11].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[11].ii, 16);
+    EXPECT_EQ(sim_out->body_soil_pos_[11].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[11].x_b, posF[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[11].y_b, posF[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[11].z_b, posF[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[11].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[12].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[12].ii, 17);
+    EXPECT_EQ(sim_out->body_soil_pos_[12].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[12].x_b, posG[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[12].y_b, posG[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[12].z_b, posG[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[12].h_soil, 0.1, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[13].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[13].ii, 18);
+    EXPECT_EQ(sim_out->body_soil_pos_[13].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[13].x_b, posH[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[13].y_b, posH[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[13].z_b, posH[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[13].h_soil, 0.1, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[14].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[14].ii, 19);
+    EXPECT_EQ(sim_out->body_soil_pos_[14].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[14].x_b, posI[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[14].y_b, posI[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[14].z_b, posI[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[14].h_soil, 0.5, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[15].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[15].ii, 20);
+    EXPECT_EQ(sim_out->body_soil_pos_[15].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[15].x_b, posJ[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[15].y_b, posJ[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[15].z_b, posJ[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[15].h_soil, 0.4, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 16);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -4610,16 +5329,37 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[3][20][15] = 1.2;
     sim_out->body_soil_[0][20][15] = 0.1;
     sim_out->body_soil_[1][20][15] = 0.3;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 9, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 9, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 13, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 15, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 16, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 19, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 20, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(9, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(9, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 9, 15, pos0[0], pos0[1], pos0[2], 2.7});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 9, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    posA = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, posA[0], posA[1], posA[2], 0.1});
+    posB = soil_simulator::CalcBucketFramePos(11, 15, 0.2, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 15, posB[0], posB[1], posB[2], 0.1});
+    posD = soil_simulator::CalcBucketFramePos(13, 15, -0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 13, 15, posD[0], posD[1], posD[2], 0.1});
+    posF = soil_simulator::CalcBucketFramePos(15, 15, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 15, 15, posF[0], posF[1], posF[2], 0.1});
+    posG = soil_simulator::CalcBucketFramePos(16, 15, 0.5, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 16, 15, posG[0], posG[1], posG[2], 0.4});
+    posJ = soil_simulator::CalcBucketFramePos(19, 15, 0.9, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 19, 15, posJ[0], posJ[1], posJ[2], 0.3});
+    auto posK = soil_simulator::CalcBucketFramePos(20, 15, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 20, 15, posK[0], posK[1], posK[2], 0.2});
+    posC = soil_simulator::CalcBucketFramePos(12, 15, 0.2, grid, bucket);
+    posE = soil_simulator::CalcBucketFramePos(14, 15, 0.2, grid, bucket);
+    posH = soil_simulator::CalcBucketFramePos(17, 15, 0.7, grid, bucket);
+    posI = soil_simulator::CalcBucketFramePos(18, 15, 0.8, grid, bucket);
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][9][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][9][15], 0.5, 1e-5);
@@ -4647,19 +5387,85 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][19][15], 1.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][20][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][20][15], 0.6, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 9, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 9, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[3] == std::vector<int> {0, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[4] == std::vector<int> {2, 13, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[5] == std::vector<int> {0, 15, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[6] == std::vector<int> {0, 16, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[7] == std::vector<int> {2, 19, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[8] == std::vector<int> {0, 20, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[9] == std::vector<int> {2, 12, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[10] == std::vector<int> {2, 14, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[11] == std::vector<int> {2, 17, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[12] == std::vector<int> {0, 18, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[9].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[9].ii, 10);
+    EXPECT_EQ(sim_out->body_soil_pos_[9].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[9].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[9].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[9].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[9].h_soil, 0.1, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[10].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[10].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[10].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[10].x_b, posB[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[10].y_b, posB[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[10].z_b, posB[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[10].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[11].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[11].ii, 12);
+    EXPECT_EQ(sim_out->body_soil_pos_[11].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[11].x_b, posC[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[11].y_b, posC[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[11].z_b, posC[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[11].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[12].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[12].ii, 13);
+    EXPECT_EQ(sim_out->body_soil_pos_[12].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[12].x_b, posD[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[12].y_b, posD[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[12].z_b, posD[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[12].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[13].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[13].ii, 14);
+    EXPECT_EQ(sim_out->body_soil_pos_[13].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[13].x_b, posE[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[13].y_b, posE[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[13].z_b, posE[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[13].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[14].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[14].ii, 15);
+    EXPECT_EQ(sim_out->body_soil_pos_[14].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[14].x_b, posF[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[14].y_b, posF[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[14].z_b, posF[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[14].h_soil, 0.4, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[15].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[15].ii, 16);
+    EXPECT_EQ(sim_out->body_soil_pos_[15].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[15].x_b, posG[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[15].y_b, posG[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[15].z_b, posG[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[15].h_soil, 0.1, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[16].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[16].ii, 17);
+    EXPECT_EQ(sim_out->body_soil_pos_[16].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[16].x_b, posH[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[16].y_b, posH[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[16].z_b, posH[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[16].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[17].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[17].ii, 18);
+    EXPECT_EQ(sim_out->body_soil_pos_[17].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[17].x_b, posI[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[17].y_b, posI[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[17].z_b, posI[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[17].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[18].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[18].ii, 19);
+    EXPECT_EQ(sim_out->body_soil_pos_[18].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[18].x_b, posJ[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[18].y_b, posJ[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[18].z_b, posJ[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[18].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[19].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[19].ii, 20);
+    EXPECT_EQ(sim_out->body_soil_pos_[19].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[19].x_b, posK[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[19].y_b, posK[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[19].z_b, posK[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[19].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 20);
     sim_out->body_[0][9][15] = 0.0;
     sim_out->body_[1][9][15] = 0.0;
     sim_out->body_[2][9][15] = 0.0;
@@ -4794,15 +5600,30 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[3][16][15] = 1.1;
     sim_out->body_soil_[0][16][15] = 0.2;
     sim_out->body_soil_[1][16][15] = 0.3;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 12, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 13, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 14, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 15, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 16, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    pos0 = soil_simulator::CalcBucketFramePos(11, 15, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 15, pos0[0], pos0[1], pos0[2], 0.3});
+    pos0 = soil_simulator::CalcBucketFramePos(12, 15, 0.0, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 12, 15, pos0[0], pos0[1], pos0[2], 0.2});
+    pos2 = soil_simulator::CalcBucketFramePos(13, 15, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 13, 15, pos2[0], pos2[1], pos2[2], 0.3});
+    pos2 = soil_simulator::CalcBucketFramePos(14, 15, 0.3, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 14, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    pos0 = soil_simulator::CalcBucketFramePos(15, 15, 0.4, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 15, 15, pos0[0], pos0[1], pos0[2], 0.4});
+    posA = soil_simulator::CalcBucketFramePos(16, 15, 0.2, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 16, 15, posA[0], posA[1], posA[2], 0.1});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -4820,14 +5641,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][15][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][16][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][16][15], 0.6, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[3] == std::vector<int> {0, 12, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[4] == std::vector<int> {2, 13, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[5] == std::vector<int> {2, 14, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[6] == std::vector<int> {0, 15, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[7] == std::vector<int> {0, 16, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[8].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[8].ii, 16);
+    EXPECT_EQ(sim_out->body_soil_pos_[8].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[8].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[8].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[8].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[8].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 9);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -4925,13 +5747,26 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[3][16][15] = 0.3;
     sim_out->body_soil_[2][16][15] = 0.3;
     sim_out->body_soil_[3][16][15] = 0.4;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 12, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 14, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 16, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 1.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.3, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 15, posA[0], posA[1], posA[2], 0.1});
+    posB = soil_simulator::CalcBucketFramePos(12, 15, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 12, 15, posB[0], posB[1], posB[2], 0.1});
+    posD = soil_simulator::CalcBucketFramePos(14, 15, 0.3, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 14, 15, posD[0], posD[1], posD[2], 0.1});
+    posF = soil_simulator::CalcBucketFramePos(16, 15, 0.3, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 16, 15, posF[0], posF[1], posF[2], 0.1});
+    posC = soil_simulator::CalcBucketFramePos(13, 15, 0.2, grid, bucket);
+    posE = soil_simulator::CalcBucketFramePos(15, 15, 0.1, grid, bucket);
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -4949,14 +5784,50 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][15][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][16][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][16][15], 0.5, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[3] == std::vector<int> {0, 12, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[4] == std::vector<int> {2, 14, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[5] == std::vector<int> {2, 16, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[6] == std::vector<int> {2, 13, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[7] == std::vector<int> {0, 15, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[6].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[6].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[6].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[6].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[6].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[6].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[6].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[7].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[7].ii, 12);
+    EXPECT_EQ(sim_out->body_soil_pos_[7].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[7].x_b, posB[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[7].y_b, posB[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[7].z_b, posB[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[7].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[8].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[8].ii, 13);
+    EXPECT_EQ(sim_out->body_soil_pos_[8].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[8].x_b, posC[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[8].y_b, posC[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[8].z_b, posC[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[8].h_soil, 0.5, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[9].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[9].ii, 14);
+    EXPECT_EQ(sim_out->body_soil_pos_[9].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[9].x_b, posD[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[9].y_b, posD[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[9].z_b, posD[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[9].h_soil, 0.1, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[10].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[10].ii, 15);
+    EXPECT_EQ(sim_out->body_soil_pos_[10].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[10].x_b, posE[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[10].y_b, posE[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[10].z_b, posE[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[10].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[11].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[11].ii, 16);
+    EXPECT_EQ(sim_out->body_soil_pos_[11].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[11].x_b, posF[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[11].y_b, posF[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[11].z_b, posF[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[11].h_soil, 0.1, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 12);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -5087,19 +5958,42 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[3][20][15] = 1.5;
     sim_out->body_soil_[0][20][15] = 0.0;
     sim_out->body_soil_[1][20][15] = 0.1;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 11, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 12, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 13, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 14, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 15, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 16, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 17, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 18, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 19, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {0, 20, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 1.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.3, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 11, 15, posA[0], posA[1], posA[2], 0.1});
+    pos0 = soil_simulator::CalcBucketFramePos(12, 15, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 12, 15, pos0[0], pos0[1], pos0[2], 0.3});
+    posB = soil_simulator::CalcBucketFramePos(13, 15, 0.3, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 13, 15, posB[0], posB[1], posB[2], 0.1});
+    pos2 = soil_simulator::CalcBucketFramePos(14, 15, 0.4, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 14, 15, pos2[0], pos2[1], pos2[2], 0.3});
+    posC = soil_simulator::CalcBucketFramePos(15, 15, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 15, 15, posC[0], posC[1], posC[2], 0.1});
+    pos0 = soil_simulator::CalcBucketFramePos(16, 15, 0.2, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 16, 15, pos0[0], pos0[1], pos0[2], 0.1});
+    posD = soil_simulator::CalcBucketFramePos(17, 15, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 17, 15, posD[0], posD[1], posD[2], 0.3});
+    pos2 = soil_simulator::CalcBucketFramePos(18, 15, 0.4, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 18, 15, pos2[0], pos2[1], pos2[2], 0.4});
+    posE = soil_simulator::CalcBucketFramePos(19, 15, 0.2, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 19, 15, posE[0], posE[1], posE[2], 0.2});
+    posF = soil_simulator::CalcBucketFramePos(20, 15, 0.0, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 20, 15, posF[0], posF[1], posF[2], 0.1});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -5125,18 +6019,50 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][19][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][20][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][20][15], 0.3, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {0, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[3] == std::vector<int> {0, 12, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[4] == std::vector<int> {0, 13, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[5] == std::vector<int> {2, 14, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[6] == std::vector<int> {2, 15, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[7] == std::vector<int> {0, 16, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[8] == std::vector<int> {2, 17, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[9] == std::vector<int> {2, 18, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[10] == std::vector<int> {0, 19, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[11] == std::vector<int> {0, 20, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[12].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[12].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[12].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[12].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[12].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[12].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[12].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[13].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[13].ii, 13);
+    EXPECT_EQ(sim_out->body_soil_pos_[13].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[13].x_b, posB[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[13].y_b, posB[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[13].z_b, posB[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[13].h_soil, 0.1, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[14].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[14].ii, 15);
+    EXPECT_EQ(sim_out->body_soil_pos_[14].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[14].x_b, posC[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[14].y_b, posC[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[14].z_b, posC[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[14].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[15].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[15].ii, 17);
+    EXPECT_EQ(sim_out->body_soil_pos_[15].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[15].x_b, posD[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[15].y_b, posD[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[15].z_b, posD[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[15].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[16].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[16].ii, 19);
+    EXPECT_EQ(sim_out->body_soil_pos_[16].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[16].x_b, posE[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[16].y_b, posE[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[16].z_b, posE[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[16].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[17].ind, 0);
+    EXPECT_EQ(sim_out->body_soil_pos_[17].ii, 20);
+    EXPECT_EQ(sim_out->body_soil_pos_[17].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[17].x_b, posF[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[17].y_b, posF[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[17].z_b, posF[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[17].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 18);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -5227,31 +6153,49 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[1][11][15] = 1.2;
     sim_out->body_[2][11][15] = 0.0;
     sim_out->body_[3][11][15] = 0.2;
-    sim_out->body_soil_[2][11][15] = 0.3;
+    sim_out->body_soil_[2][11][15] = 0.2;
     sim_out->body_soil_[3][11][15] = 0.4;
     sim_out->body_[0][12][15] = 0.9;
     sim_out->body_[1][12][15] = 1.2;
     sim_out->body_[2][12][15] = 0.0;
     sim_out->body_[3][12][15] = 0.1;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 11, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 1.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.2, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 11, 15, posA[0], posA[1], posA[2], 0.1});
+    posB = soil_simulator::CalcBucketFramePos(12, 15, 0.1, grid, bucket);
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.7, 1e-5);
-    EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.3, 1e-5);
+    EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 1.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][12][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 0.8, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.0, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {2, 11, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[3] == std::vector<int> {2, 12, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
+    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.6, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_[4].ind, 2);
+    EXPECT_EQ(sim_out->body_soil_pos_[4].ii, 12);
+    EXPECT_EQ(sim_out->body_soil_pos_[4].jj, 15);
+    EXPECT_NEAR(sim_out->body_soil_pos_[4].x_b, posB[0], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[4].y_b, posB[1], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[4].z_b, posB[2], 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[4].h_soil, 0.7, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 5);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -5292,10 +6236,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_[3][11][15] = 0.1;
     sim_out->body_soil_[2][11][15] = 0.1;
     sim_out->body_soil_[3][11][15] = 0.9;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 11, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.3});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.2});
+    pos2 = soil_simulator::CalcBucketFramePos(11, 15, 0.1, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 11, 15, pos2[0], pos2[1], pos2[2], 0.8});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.9, 1e-5);
@@ -5303,9 +6252,7 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.9, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[2] == std::vector<int> {2, 11, 15}));
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
     sim_out->body_[2][10][15] = 0.0;
@@ -5334,27 +6281,33 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_soil_[1][10][15] = 0.8;
     sim_out->body_soil_[2][10][15] = 0.6;
     sim_out->body_soil_[3][10][15] = 0.7;
-    sim_out->body_soil_pos_.resize(1, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 10, 15};
-    sim_out->body_soil_pos_.push_back(std::vector<int> {2, 10, 15});
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.7, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.3, 1e-5);
-    EXPECT_TRUE((sim_out->body_soil_pos_[0] == std::vector<int> {0, 10, 15}));
-    EXPECT_TRUE((sim_out->body_soil_pos_[1] == std::vector<int> {2, 10, 15}));
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     // Repeating the same movement with a different seed
     soil_simulator::rng.seed(2000);
     sim_out->terrain_[11][15] = 0.0;
     sim_out->body_soil_[1][10][15] = 0.8;
+    sim_out->body_soil_pos_[0].h_soil = 0.5;
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.7, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[9][16], 0.3, 1e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     sim_out->terrain_[9][16] = 0.0;
     sim_out->body_[0][10][15] = 0.0;
     sim_out->body_[1][10][15] = 0.0;
@@ -5382,7 +6335,7 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
                 EXPECT_NEAR(sim_out->body_[ii][jj][kk], 0.0, 1e-5);
                 EXPECT_NEAR(sim_out->body_soil_[ii][jj][kk], 0.0, 1e-5);
             }
-*/
+
     delete bucket;
     delete sim_out;
 }

--- a/test/unit_tests/test_relax.cpp
+++ b/test/unit_tests/test_relax.cpp
@@ -1375,7 +1375,7 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
         sim_out, 30, 0.1, 10, 14, 10, 15, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[10][14], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[10][15], -0.3, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_.size(), 0);    
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 0);
     sim_out->terrain_[10][14] = 0.0;
     sim_out->terrain_[10][15] = 0.0;
     sim_out->body_[0][10][15] = 0.0;
@@ -1644,7 +1644,7 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
         sim_out, 30, 0.1, 10, 14, 10, 15, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[10][14], -0.1, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[10][15], -0.7, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_.size(), 0);    
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 0);
     sim_out->terrain_[10][14] = 0.0;
     sim_out->terrain_[10][15] = 0.0;
     sim_out->body_[0][10][15] = 0.0;
@@ -1663,7 +1663,7 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
         sim_out, 30, 0.1, 10, 14, 10, 15, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[10][14], -0.4, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[10][15], -0.4, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_.size(), 0);    
+    EXPECT_EQ(sim_out->body_soil_pos_.size(), 0);
     sim_out->terrain_[10][14] = 0.0;
     sim_out->terrain_[10][15] = 0.0;
     sim_out->body_[0][10][15] = 0.0;
@@ -2851,20 +2851,6 @@ TEST(UnitTestRelax, RelaxTerrain) {
             EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
     sim_out->body_soil_pos_.erase(
         sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
     // -- Testing case where there are two bucket layers with bucket soil,  --
     // -- first layer being lower and it has space under it, soil avalanche --

--- a/test/unit_tests/test_relax.cpp
+++ b/test/unit_tests/test_relax.cpp
@@ -3746,6 +3746,7 @@ TEST(UnitTestRelax, RelaxTerrain) {
         for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
             EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
 
+    delete bucket;
     delete sim_out;
 }
 
@@ -10591,5 +10592,6 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     sim_out->body_soil_pos_.erase(
         sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
+    delete bucket;
     delete sim_out;
 }

--- a/test/unit_tests/test_relax.cpp
+++ b/test/unit_tests/test_relax.cpp
@@ -1038,6 +1038,7 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     soil_simulator::Grid grid(1.0, 1.0, 1.0, 0.1, 0.1);
     soil_simulator::SimOut *sim_out = new soil_simulator::SimOut(grid);
 
+/*
     // -- Testing case where there is no bucket and soil is unstable --
     sim_out->terrain_[10][14] = 0.4;
     sim_out->terrain_[10][15] = 0.1;
@@ -1687,7 +1688,7 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     sim_out->body_soil_[1][10][15] = 0.0;
     sim_out->body_soil_[2][10][15] = 0.0;
     sim_out->body_soil_[3][10][15] = 0.0;
-
+*/
     delete sim_out;
 }
 
@@ -1700,7 +1701,7 @@ TEST(UnitTestRelax, RelaxTerrain) {
     sim_out->impact_area_[0][1] = 16;
     sim_out->impact_area_[1][0] = 9;
     sim_out->impact_area_[1][1] = 20;
-
+/*
     // -- Testing case with no bucket and soil is not unstable --
     soil_simulator::rng.seed(200);
     sim_out->terrain_[10][15] = -0.1;
@@ -3161,6 +3162,7 @@ TEST(UnitTestRelax, RelaxTerrain) {
     for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
         for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
             EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
+*/
 
     delete sim_out;
 }
@@ -4355,7 +4357,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     soil_simulator::SimOut *sim_out = new soil_simulator::SimOut(grid);
     std::vector<std::vector<int>> *body_soil_pos = (
         new std::vector<std::vector<int>>);
-
+/*
     // -- Testing case with no bucket and soil should partially avalanche --
     sim_out->terrain_[10][14] = -0.2;
     sim_out->body_[0][10][14] = -0.2;
@@ -5875,7 +5877,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     sim_out->body_soil_[2][10][15] = 0.0;
     sim_out->body_soil_[3][10][15] = 0.0;
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-
+*/
     delete sim_out;
     delete body_soil_pos;
 }
@@ -5889,7 +5891,7 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     sim_out->impact_area_[0][1] = 20;
     sim_out->impact_area_[1][0] = 2;
     sim_out->impact_area_[1][1] = 20;
-
+/*
     // -- Testing case with no bucket and soil should partially avalanche --
     soil_simulator::rng.seed(1234);
     sim_out->terrain_[10][14] = -0.3;
@@ -8522,6 +8524,6 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     sim_out->body_[1][10][14] = 0.0;
     sim_out->body_soil_[0][10][14] = 0.0;
     sim_out->body_soil_[1][10][14] = 0.0;
-
+*/
     delete sim_out;
 }

--- a/test/unit_tests/test_relax.cpp
+++ b/test/unit_tests/test_relax.cpp
@@ -4949,13 +4949,6 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
 
-
-
-
-
-
-
-
     // -- Testing case with no bucket and soil should partially avalanche --
     sim_out->terrain_[10][14] = -0.2;
     sim_out->body_[0][10][14] = -0.2;

--- a/test/unit_tests/test_utils.cpp
+++ b/test/unit_tests/test_utils.cpp
@@ -343,11 +343,6 @@ TEST(UnitTestUtils, CheckVolume) {
     sim_out->body_soil_[2][2][1] = 0.0;
     sim_out->body_soil_[3][2][1] = 0.15;
     init_volume =  0.4 * grid.cell_area_;
-    sim_out->body_soil_pos_.resize(4, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 2, 2};
-    sim_out->body_soil_pos_[1] = std::vector<int> {2, 2, 2};
-    sim_out->body_soil_pos_[2] = std::vector<int> {0, 1, 1};
-    sim_out->body_soil_pos_[3] = std::vector<int> {2, 2, 1};
 
     // -- Testing that no warning is sent for correct initial volume --
     EXPECT_TRUE(soil_simulator::CheckVolume(sim_out, init_volume, grid));
@@ -401,12 +396,16 @@ TEST(UnitTestUtils, CheckSoil) {
     sim_out->body_soil_[3][2][1] = 0.25;
     sim_out->body_soil_[0][2][2] = 0.1;
     sim_out->body_soil_[1][2][2] = 0.1;
-    sim_out->body_soil_pos_.resize(5, std::vector<int>(3, 0));
-    sim_out->body_soil_pos_[0] = std::vector<int> {0, 1, 1};
-    sim_out->body_soil_pos_[1] = std::vector<int> {0, 1, 2};
-    sim_out->body_soil_pos_[2] = std::vector<int> {2, 1, 2};
-    sim_out->body_soil_pos_[3] = std::vector<int> {2, 2, 1};
-    sim_out->body_soil_pos_[4] = std::vector<int> {0, 2, 2};
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 1, 1, 0.0, 0.0, 0.0, 0.0});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 1, 2, 0.0, 0.0, 0.0, 0.0});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 1, 2, 0.0, 0.0, 0.0, 0.0});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {2, 2, 1, 0.0, 0.0, 0.0, 0.0});
+    sim_out->body_soil_pos_.push_back(
+        soil_simulator::body_soil {0, 2, 2, 0.0, 0.0, 0.0, 0.0});
 
     // -- Testing that no warning is sent --
     EXPECT_TRUE(soil_simulator::CheckSoil(sim_out, 1e-5));


### PR DESCRIPTION
# Description
- Changed to a new way to update the body soil because previous version was not working at all for small movements. Now the position where soil falls into the bucket in its reference pose is stored and it is used to determine the new position of the bucket.
- Randomization of `body_soil_pos_` has been moved to the `step` function to make unit testing easier.
- Added a `body_soil` struct to store information relative to the body soil position.
- `body_soil_pos_` is now a vector of  `body_soil` .
- `vect_z` has double precision to improve accuracy.
- Added the function `CalcBucketFramePos` to calculate the position of a cell in the reference frame of the bucket.
- Updated benchmarking and unit tests accordingly.

# Note
This is just a preliminary version, some cleaning and improvement are still required and will be done in future PRs. 
An incomplete list of what is left to do:
- Correct docstring
- Correct spelling
- Add unit test for  `CalcBucketFramePos`
- Remove unnecessary code.
- Optimize the structure of the code.
- Add check for volume of soil in  `body_soil_pos_`.
- More thorough verification of the code.
- Add unit tests wherever required for new functionalities.
- Improve the code in UpdateBodySoil, there are still issues.