### PR TITLE
Refactor UpdateBodySoil: cleaning up and minor improvements (2) 

### DIFF
--- a/soil_simulator/body_soil.cpp
+++ b/soil_simulator/body_soil.cpp
@@ -69,11 +69,6 @@ void soil_simulator::UpdateBodySoil(
         auto new_cell_pos = soil_simulator::CalcRotationQuaternion(
             ori, cell_pos);
 
-        // Calculating movement made by the bucket
-        // This is not good as new_cell_pos is in the global frame
-        float dx = new_cell_pos[0] - cell_pos[0];
-        float dy = new_cell_pos[1] - cell_pos[1];
-
         // Calculating new cell position in global frame
         new_cell_pos[0] += pos[0];
         new_cell_pos[1] += pos[1];
@@ -87,9 +82,11 @@ void soil_simulator::UpdateBodySoil(
 
         // Establishing order of exploration
         std::vector<std::vector<int>> directions;
-        int sx = copysign(1, dx);
-        int sy = copysign(1, dy);
-        if (std::abs(dx) > std::abs(dy)) {
+        int sx;
+        int sy;
+        (ii_n > ii) ? sx = 1 : sx = -1;
+        (jj_n > jj) ? sy = 1 : sy = -1;
+        if (std::abs(sx) > std::abs(sy)) {
             // Main direction follows X
             directions = {
                 {0, 0}, {sx, 0}, {sx, sy}, {0, sy}, {sx, -sy},

--- a/soil_simulator/body_soil.cpp
+++ b/soil_simulator/body_soil.cpp
@@ -20,14 +20,15 @@ Copyright, 2023, Vilella Kenny.
 ///
 /// It is difficult to track accurately each bucket wall. This is currently done
 /// by looking at the height difference between the previous and new soil
-/// locations, if this height difference is lower than twice the minimum cell
+/// locations, if this height difference is lower than thrice the vertical cell
 /// size, it is assumed to be the same bucket wall.
 ///
 /// If no bucket wall is present, the soil is moved down to the terrain and a
 /// warning is issued as it should normally not happen.
 ///
 /// The new positions of the soil resting on the bucket are collected into
-/// `sim_out.body_soil_pos_` along with the required information.
+/// `sim_out.body_soil_pos_` along with the required information using the
+/// `body_soil` struct.
 void soil_simulator::UpdateBodySoil(
     SimOut* sim_out, std::vector<float> pos, std::vector<float> ori, Grid grid,
     Bucket* bucket, float tol
@@ -48,8 +49,7 @@ void soil_simulator::UpdateBodySoil(
         sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // Iterating over all XY positions where body_soil is present
-    float min_cell_height_diff = 3 * std::min(
-        grid.cell_size_z_, grid.cell_size_xy_);
+    float min_cell_height_diff = 3 * grid.cell_size_z_;
     for (auto nn = 0; nn < old_body_soil_pos.size(); nn++) {
         int ind = old_body_soil_pos[nn].ind;
         int ii = old_body_soil_pos[nn].ii;

--- a/soil_simulator/body_soil.cpp
+++ b/soil_simulator/body_soil.cpp
@@ -60,7 +60,7 @@ void soil_simulator::UpdateBodySoil(
         float h_soil = old_body_soil_pos[nn].h_soil;
 
         if (h_soil < tol) {
-            // No soil tto be moved
+            // No soil to be moved
             continue;
         }
 
@@ -70,6 +70,7 @@ void soil_simulator::UpdateBodySoil(
             ori, cell_pos);
 
         // Calculating movement made by the bucket
+        // This is not good as new_cell_pos is in the global frame
         float dx = new_cell_pos[0] - cell_pos[0];
         float dy = new_cell_pos[1] - cell_pos[1];
 
@@ -89,10 +90,12 @@ void soil_simulator::UpdateBodySoil(
         int sx = copysign(1, dx);
         int sy = copysign(1, dy);
         if (std::abs(dx) > std::abs(dy)) {
+            // Main direction follows X
             directions = {
                 {0, 0}, {sx, 0}, {sx, sy}, {0, sy}, {sx, -sy},
                 {0, -sy}, {-sx, sy}, {-sx, 0}, {-sx, -sy}};
         } else {
+            // Main direction follows Y
             directions = {
                 {0, 0}, {0, sy}, {sx, sy}, {sx, 0}, {-sx, sy},
                 {-sx, 0}, {sx, -sy}, {0, -sy}, {-sx, -sy}};
@@ -110,7 +113,8 @@ void soil_simulator::UpdateBodySoil(
                     < min_cell_height_diff)
             ) {
                 // First bucket layer is present
-                // Moving body_soil to new location
+                // Moving body_soil to new location, this implementation works
+                // regardless of the presence of body_soil
                 sim_out->body_soil_[1][ii_t][jj_t] += (
                     sim_out->body_[1][ii_t][jj_t] -
                     sim_out->body_soil_[0][ii_t][jj_t] + h_soil);
@@ -128,8 +132,9 @@ void soil_simulator::UpdateBodySoil(
                 (std::abs(new_cell_pos[2] - sim_out->body_[3][ii_t][jj_t]) - tol
                     < min_cell_height_diff)
             ) {
-                // Bucket is present
-                // Moving body_soil to new location
+                // Second bucket layer is present
+                // Moving body_soil to new location, this implementation works
+                // regardless of the presence of body_soil
                 sim_out->body_soil_[3][ii_t][jj_t] += (
                     sim_out->body_[3][ii_t][jj_t] -
                     sim_out->body_soil_[2][ii_t][jj_t] + h_soil);

--- a/soil_simulator/intersecting_cells.cpp
+++ b/soil_simulator/intersecting_cells.cpp
@@ -100,6 +100,9 @@ void soil_simulator::MoveIntersectingBodySoil(
             continue;
         }
 
+        // Updating bucket soil
+        sim_out->body_soil_[ind+1][ii][jj] -= h_soil;
+
         // Randomizing direction to avoid asymmetry
         // random_suffle is not used because it is machine dependent,
         // which makes unit testing difficult
@@ -143,9 +146,6 @@ void soil_simulator::MoveIntersectingBodySoil(
                 "layer could be moved\nThe extra soil has been arbitrarily "
                 "removed";
         }
-
-        // Updating bucket soil
-        sim_out->body_soil_[ind+1][ii][jj] = sim_out->body_[ind_t][ii][jj];
     }
 }
 

--- a/soil_simulator/intersecting_cells.cpp
+++ b/soil_simulator/intersecting_cells.cpp
@@ -306,12 +306,11 @@ std::tuple<int, int, int, float, bool> soil_simulator::MoveBodySoil(
             sim_out->body_[ind_p+1][ii_p][jj_p]) {
             // Soil avalanche below the second bucket layer to the terrain
             // Note that all soil is going to the terrain without considering
-            // the space  available. If there is not enough space available, the
+            // the space available. If there is not enough space available, the
             // soil would intersect with the bucket and later be moved by
             // the MoveIntersectingBody function
             sim_out->terrain_[ii_n][jj_n] += h_soil;
-            h_soil = 0.0;
-            return {ind_p, ii_p, jj_p, h_soil, wall_presence};
+            return {ind_p, ii_p, jj_p, 0.0, wall_presence};
         } else if (sim_out->body_[3][ii_n][jj_n] + tol > max_h) {
             // Bucket is blocking the movement
             return {ind_p, ii_p, jj_p, h_soil, true};
@@ -350,7 +349,7 @@ std::tuple<int, int, int, float, bool> soil_simulator::MoveBodySoil(
             sim_out->body_[ind_p+1][ii_p][jj_p]) {
             // Soil avalanche below the first bucket layer to the terrain
             // Note that all soil is going to the terrain without considering
-            // the space  available. If there is not enough space available, the
+            // the space available. If there is not enough space available, the
             // soil would intersect with the bucket and later be moved by the
             // MoveIntersectingBody function
             sim_out->terrain_[ii_n][jj_n] += h_soil;
@@ -414,6 +413,10 @@ std::tuple<int, int, int, float, bool> soil_simulator::MoveBodySoil(
             }
         }
 
+        // Calculating pos of cell in bucket frame
+        auto pos = soil_simulator::CalcBucketFramePos(
+            ii_n, jj_n, sim_out->body_[ind_b_n+1][ii_n][jj_n], grid, bucket);
+
         // Only option left is that there is space for the intersecting soil
         if (bucket_soil_presence) {
             // Soil should go into the existing bucket soil layer
@@ -421,11 +424,6 @@ std::tuple<int, int, int, float, bool> soil_simulator::MoveBodySoil(
             float delta_h = (
                 sim_out->body_[ind_t_n][ii_n][jj_n] -
                 sim_out->body_soil_[ind_b_n+1][ii_n][jj_n]);
-
-            // Calculating pos of cell in bucket frame
-            auto pos = soil_simulator::CalcBucketFramePos(
-                ii_n, jj_n, sim_out->body_[ind_b_n+1][ii_n][jj_n], grid,
-                bucket);
 
             if (delta_h < h_soil) {
                 // Not enough space
@@ -460,12 +458,6 @@ std::tuple<int, int, int, float, bool> soil_simulator::MoveBodySoil(
             float delta_h = (
                 sim_out->body_[ind_t_n][ii_n][jj_n] -
                 sim_out->body_[ind_b_n+1][ii_n][jj_n]);
-
-            // Calculating pos of cell in bucket frame
-            auto pos = soil_simulator::CalcBucketFramePos(
-                ii_n, jj_n, sim_out->body_[ind_b_n+1][ii_n][jj_n], grid,
-                bucket);
-
 
             if (delta_h < h_soil) {
                 // Not enough space

--- a/soil_simulator/intersecting_cells.cpp
+++ b/soil_simulator/intersecting_cells.cpp
@@ -61,17 +61,17 @@ void soil_simulator::MoveIntersectingBodySoil(
 
         int ind_t;
         if (ind == 0) {
-            // First bucket soil layer
+            // Soil is on the first bucket soil layer
             ind_t = 2;
         } else {
-            // Second bucket soil layer
+            // Soil is on the second bucket soil layer
             ind_t = 0;
         }
 
         if (
             (sim_out->body_[ind_t][ii][jj] == 0.0) &&
             (sim_out->body_[ind_t+1][ii][jj] == 0.0)) {
-            // No additionnal bucket layer
+            // No additionnal bucket layer, soil cannot be intersecting
             continue;
         }
 

--- a/soil_simulator/intersecting_cells.hpp
+++ b/soil_simulator/intersecting_cells.hpp
@@ -54,6 +54,7 @@ void MoveIntersectingBody(SimOut* sim_out, float tol);
 /// \param jj_n: Index of the new considered position in the Y direction.
 /// \param h_soil: Height of the soil column left to be moved. [m]
 /// \param wall_presence: Indicates whether a wall is blocking the movement.
+/// \param grid: Class that stores information related to the simulation grid.
 /// \param bucket: Class that stores information related to the bucket object.
 /// \param tol: Small number used to handle numerical approximation errors.
 ///

--- a/soil_simulator/relax.cpp
+++ b/soil_simulator/relax.cpp
@@ -781,7 +781,7 @@ void soil_simulator::RelaxUnstableTerrainCell(
             ii_c, jj_c, sim_out->body_[1][ii_c][jj_c], grid, bucket);
 
         // Adding new bucket soil position to body_soil_pos
-        float h_soil = h_new_c - sim_out->body_[1][ii_c][jj_c];
+        h_soil = h_new_c - sim_out->body_[1][ii_c][jj_c];
         sim_out->body_soil_pos_.push_back(
             soil_simulator::body_soil
             {0, ii_c, jj_c, pos[0], pos[1], pos[2], h_soil});
@@ -852,9 +852,7 @@ void soil_simulator::RelaxUnstableBodyCell(
             sim_out->body_soil_pos_[nn].h_soil -= h_soil;
         } else {
             // All soil on the bucket should avalanche
-            sim_out->terrain_[ii_c][jj_c] += (
-                sim_out->body_soil_[ind+1][ii][jj] -
-                sim_out->body_soil_[ind][ii][jj]);
+            sim_out->terrain_[ii_c][jj_c] += h_soil;
             sim_out->body_soil_[ind][ii][jj] = 0.0;
             sim_out->body_soil_[ind+1][ii][jj] = 0.0;
             sim_out->body_soil_pos_[nn].h_soil = 0.0;
@@ -876,22 +874,19 @@ void soil_simulator::RelaxUnstableBodyCell(
                 h_soil = sim_out->body_soil_pos_[nn].h_soil;
                 h_new = sim_out->body_soil_[ind+1][ii][jj] - h_soil;
             }
-            h_new_c = sim_out->body_soil_[1][ii_c][jj_c] + h_soil;
 
             if (h_new - tol > sim_out->body_soil_[ind][ii][jj]) {
                 // Soil on the bucket should partially avalanche
-                sim_out->body_soil_[1][ii_c][jj_c] = h_new_c;
                 sim_out->body_soil_[ind+1][ii][jj] = h_new;
                 sim_out->body_soil_pos_[nn].h_soil -= h_soil;
             } else {
                 // All soil on the bucket should avalanche
-                sim_out->body_soil_[1][ii_c][jj_c] += (
-                    sim_out->body_soil_[ind+1][ii][jj] -
-                    sim_out->body_soil_[ind][ii][jj]);
                 sim_out->body_soil_[ind][ii][jj] = 0.0;
                 sim_out->body_soil_[ind+1][ii][jj] = 0.0;
                 sim_out->body_soil_pos_[nn].h_soil = 0.0;
             }
+            sim_out->body_soil_[1][ii_c][jj_c] += h_soil;
+
             // Calculating pos of cell in bucket frame
             auto pos = soil_simulator::CalcBucketFramePos(
                 ii_c, jj_c, sim_out->body_[1][ii_c][jj_c], grid, bucket);
@@ -914,27 +909,21 @@ void soil_simulator::RelaxUnstableBodyCell(
                 h_soil = sim_out->body_soil_pos_[nn].h_soil;
                 h_new = sim_out->body_soil_[ind+1][ii][jj] - h_soil;
             }
-            h_new_c = sim_out->body_[1][ii_c][jj_c] + h_soil;
 
+            sim_out->body_soil_[0][ii_c][jj_c] = sim_out->body_[1][ii_c][jj_c];
             if (h_new - tol > sim_out->body_soil_[ind][ii][jj]) {
                 // Soil on the bucket should partially avalanche
-                sim_out->body_soil_[0][ii_c][jj_c] = (
-                    sim_out->body_[1][ii_c][jj_c]);
-                sim_out->body_soil_[1][ii_c][jj_c] = h_new_c;
                 sim_out->body_soil_[ind+1][ii][jj] = h_new;
                 sim_out->body_soil_pos_[nn].h_soil -= h_soil;
             } else {
                 // All soil on the bucket should avalanche
-                sim_out->body_soil_[0][ii_c][jj_c] = (
-                    sim_out->body_[1][ii_c][jj_c]);
-                sim_out->body_soil_[1][ii_c][jj_c] = (
-                    sim_out->body_[1][ii_c][jj_c] +
-                    sim_out->body_soil_[ind+1][ii][jj] -
-                    sim_out->body_soil_[ind][ii][jj]);
                 sim_out->body_soil_[ind][ii][jj] = 0.0;
                 sim_out->body_soil_[ind+1][ii][jj] = 0.0;
                 sim_out->body_soil_pos_[nn].h_soil = 0.0;
             }
+            sim_out->body_soil_[1][ii_c][jj_c] = (
+                    sim_out->body_[1][ii_c][jj_c] + h_soil);
+
             // Calculating pos of cell in bucket frame
             auto pos = soil_simulator::CalcBucketFramePos(
                 ii_c, jj_c, sim_out->body_[1][ii_c][jj_c], grid, bucket);
@@ -960,25 +949,19 @@ void soil_simulator::RelaxUnstableBodyCell(
                 h_soil = sim_out->body_soil_pos_[nn].h_soil;
                 h_new = sim_out->body_soil_[ind+1][ii][jj] - h_soil;
             }
-            h_new_c = sim_out->body_soil_[3][ii_c][jj_c] + h_soil;
 
-            if (h_new_c - tol > sim_out->body_soil_[ind][ii][jj]) {
+            if (h_new - tol > sim_out->body_soil_[ind][ii][jj]) {
                 // Soil on the bucket should partially avalanche
-                sim_out->body_soil_[3][ii_c][jj_c] = h_new_c;
                 sim_out->body_soil_[ind+1][ii][jj] = h_new;
                 sim_out->body_soil_pos_[nn].h_soil -= h_soil;
             } else {
                 // All soil on the bucket should avalanche
-                // -----------------------------------
-                // Check if we can put h_soil here also in other part
-                // -----------------------------------
-                sim_out->body_soil_[3][ii_c][jj_c] += (
-                    sim_out->body_soil_[ind+1][ii][jj] -
-                    sim_out->body_soil_[ind][ii][jj]);
                 sim_out->body_soil_[ind][ii][jj] = 0.0;
                 sim_out->body_soil_[ind+1][ii][jj] = 0.0;
                 sim_out->body_soil_pos_[nn].h_soil = 0.0;
             }
+            sim_out->body_soil_[3][ii_c][jj_c] += h_soil;
+
             // Calculating pos of cell in bucket frame
             auto pos = soil_simulator::CalcBucketFramePos(
                 ii_c, jj_c, sim_out->body_[3][ii_c][jj_c], grid, bucket);
@@ -1001,27 +984,21 @@ void soil_simulator::RelaxUnstableBodyCell(
                 h_soil = sim_out->body_soil_pos_[nn].h_soil;
                 h_new = sim_out->body_soil_[ind+1][ii][jj] - h_soil;
             }
-            h_new_c = sim_out->body_[3][ii_c][jj_c] + h_soil;
 
-            if (h_new_c - tol > sim_out->body_soil_[ind][ii][jj]) {
+            sim_out->body_soil_[2][ii_c][jj_c] = sim_out->body_[3][ii_c][jj_c];
+            if (h_new - tol > sim_out->body_soil_[ind][ii][jj]) {
                 // Soil on the bucket should partially avalanche
-                sim_out->body_soil_[2][ii_c][jj_c] = (
-                    sim_out->body_[3][ii_c][jj_c]);
-                sim_out->body_soil_[3][ii_c][jj_c] = h_new_c;
                 sim_out->body_soil_[ind+1][ii][jj] = h_new;
                 sim_out->body_soil_pos_[nn].h_soil -= h_soil;
             } else {
                 // All soil on the bucket should avalanche
-                sim_out->body_soil_[2][ii_c][jj_c] = (
-                    sim_out->body_[3][ii_c][jj_c]);
-                sim_out->body_soil_[3][ii_c][jj_c] = (
-                    sim_out->body_[3][ii_c][jj_c] +
-                    sim_out->body_soil_[ind+1][ii][jj] -
-                    sim_out->body_soil_[ind][ii][jj]);
                 sim_out->body_soil_[ind][ii][jj] = 0.0;
                 sim_out->body_soil_[ind+1][ii][jj] = 0.0;
                 sim_out->body_soil_pos_[nn].h_soil = 0.0;
             }
+            sim_out->body_soil_[3][ii_c][jj_c] = (
+                sim_out->body_[3][ii_c][jj_c] + h_soil);
+
             // Calculating pos of cell in bucket frame
             auto pos = soil_simulator::CalcBucketFramePos(
                 ii_c, jj_c, sim_out->body_[3][ii_c][jj_c], grid, bucket);
@@ -1071,15 +1048,7 @@ void soil_simulator::RelaxUnstableBodyCell(
                     // All soil on the bucket may avalanche
                     // By construction, it must have enough space for
                     // the full avalanche
-                    // ------------------
-                    // here also h_new_c should not be needed
-                    // ------------------
-                    h_new_c = (
-                        sim_out->body_soil_[3][ii_c][jj_c] +
-                        sim_out->body_soil_[ind+1][ii][jj] -
-                        sim_out->body_soil_[ind][ii][jj]);
-
-                    sim_out->body_soil_[3][ii_c][jj_c] = h_new_c;
+                    sim_out->body_soil_[3][ii_c][jj_c] += h_soil;
                     sim_out->body_soil_[ind][ii][jj] = 0.0;
                     sim_out->body_soil_[ind+1][ii][jj] = 0.0;
                     sim_out->body_soil_pos_[nn].h_soil = 0.0;
@@ -1093,9 +1062,7 @@ void soil_simulator::RelaxUnstableBodyCell(
                     sim_out->body_soil_pos_[nn].h_soil -= h_soil;
                 } else {
                     // All soil on the bucket should avalanche
-                    sim_out->body_soil_[3][ii_c][jj_c] += (
-                        sim_out->body_soil_[ind+1][ii][jj] -
-                        sim_out->body_soil_[ind][ii][jj]);
+                    sim_out->body_soil_[3][ii_c][jj_c] += h_soil;
                     sim_out->body_soil_[ind][ii][jj] = 0.0;
                     sim_out->body_soil_[ind+1][ii][jj] = 0.0;
                     sim_out->body_soil_pos_[nn].h_soil = 0.0;
@@ -1127,6 +1094,8 @@ void soil_simulator::RelaxUnstableBodyCell(
             }
             h_new_c = sim_out->body_[3][ii_c][jj_c] + h_soil;
 
+
+            sim_out->body_soil_[2][ii_c][jj_c] = sim_out->body_[3][ii_c][jj_c];
             if (sim_out->body_[0][ii_c][jj_c] > sim_out->body_[2][ii_c][jj_c]) {
                 // Soil should avalanche on the bottom layer
                 if (h_new - tol > sim_out->body_soil_[ind][ii][jj]) {
@@ -1137,14 +1106,10 @@ void soil_simulator::RelaxUnstableBodyCell(
                             sim_out->body_[0][ii_c][jj_c] -
                             sim_out->body_[3][ii_c][jj_c]);
                         sim_out->body_soil_[ind+1][ii][jj] -= h_soil;
-                        sim_out->body_soil_[2][ii_c][jj_c] = (
-                            sim_out->body_[3][ii_c][jj_c]);
                         sim_out->body_soil_[3][ii_c][jj_c] = (
                             sim_out->body_[0][ii_c][jj_c]);
                     } else {
                         // Enough space for the partial avalanche
-                        sim_out->body_soil_[2][ii_c][jj_c] = (
-                            sim_out->body_[3][ii_c][jj_c]);
                         sim_out->body_soil_[3][ii_c][jj_c] = h_new_c;
                         sim_out->body_soil_[ind+1][ii][jj] = h_new;
                     }
@@ -1153,13 +1118,6 @@ void soil_simulator::RelaxUnstableBodyCell(
                     // All soil on the bucket may avalanche
                     // By construction, it must have enough space for
                     // the full avalanche
-                    h_new_c = (
-                        sim_out->body_[3][ii_c][jj_c] +
-                        sim_out->body_soil_[ind+1][ii][jj] -
-                        sim_out->body_soil_[ind][ii][jj]);
-
-                    sim_out->body_soil_[2][ii_c][jj_c] = (
-                        sim_out->body_[3][ii_c][jj_c]);
                     sim_out->body_soil_[3][ii_c][jj_c] = h_new_c;
                     sim_out->body_soil_[ind][ii][jj] = 0.0;
                     sim_out->body_soil_[ind+1][ii][jj] = 0.0;
@@ -1167,26 +1125,19 @@ void soil_simulator::RelaxUnstableBodyCell(
                 }
             } else {
                 // Soil should avalanche on the top layer
+                sim_out->body_soil_[3][ii_c][jj_c] = h_new_c;
                 if (h_new - tol > sim_out->body_soil_[ind][ii][jj]) {
                     // Soil on the bucket should partially avalanche
-                    sim_out->body_soil_[2][ii_c][jj_c] = (
-                        sim_out->body_[3][ii_c][jj_c]);
-                    sim_out->body_soil_[3][ii_c][jj_c] = h_new_c;
                     sim_out->body_soil_[ind+1][ii][jj] = h_new;
                     sim_out->body_soil_pos_[nn].h_soil -= h_soil;
                 } else {
                     // All soil on the bucket should avalanche
-                    sim_out->body_soil_[2][ii_c][jj_c] = (
-                        sim_out->body_[3][ii_c][jj_c]);
-                    sim_out->body_soil_[3][ii_c][jj_c] = (
-                        sim_out->body_[3][ii_c][jj_c] +
-                        sim_out->body_soil_[ind+1][ii][jj] -
-                        sim_out->body_soil_[ind][ii][jj]);
                     sim_out->body_soil_[ind][ii][jj] = 0.0;
                     sim_out->body_soil_[ind+1][ii][jj] = 0.0;
                     sim_out->body_soil_pos_[nn].h_soil = 0.0;
                 }
             }
+
             // Calculating pos of cell in bucket frame
             auto pos = soil_simulator::CalcBucketFramePos(
                 ii_c, jj_c, sim_out->body_[3][ii_c][jj_c], grid, bucket);
@@ -1220,9 +1171,7 @@ void soil_simulator::RelaxUnstableBodyCell(
                     sim_out->body_soil_pos_[nn].h_soil -= h_soil;
                 } else {
                     // All soil on the bucket should avalanche
-                    sim_out->body_soil_[1][ii_c][jj_c] += (
-                        sim_out->body_soil_[ind+1][ii][jj] -
-                        sim_out->body_soil_[ind][ii][jj]);
+                    sim_out->body_soil_[1][ii_c][jj_c] += h_soil;
                     sim_out->body_soil_[ind][ii][jj] = 0.0;
                     sim_out->body_soil_[ind+1][ii][jj] = 0.0;
                     sim_out->body_soil_pos_[nn].h_soil = 0.0;
@@ -1249,12 +1198,7 @@ void soil_simulator::RelaxUnstableBodyCell(
                     // All soil on the bucket may avalanche
                     // By construction, it must have enough space for
                     // the full avalanche
-                    h_new_c = (
-                        sim_out->body_soil_[1][ii_c][jj_c] +
-                        sim_out->body_soil_[ind+1][ii][jj] -
-                        sim_out->body_soil_[ind][ii][jj]);
-
-                    sim_out->body_soil_[1][ii_c][jj_c] = h_new_c;
+                    sim_out->body_soil_[1][ii_c][jj_c] += h_soil;
                     sim_out->body_soil_[ind][ii][jj] = 0.0;
                     sim_out->body_soil_[ind+1][ii][jj] = 0.0;
                     sim_out->body_soil_pos_[nn].h_soil = 0.0;
@@ -1286,23 +1230,16 @@ void soil_simulator::RelaxUnstableBodyCell(
             }
             h_new_c = sim_out->body_[1][ii_c][jj_c] + h_soil;
 
+            sim_out->body_soil_[0][ii_c][jj_c] = sim_out->body_[1][ii_c][jj_c];
             if (sim_out->body_[0][ii_c][jj_c] > sim_out->body_[2][ii_c][jj_c]) {
                 // Soil should avalanche on the top layer
+                sim_out->body_soil_[1][ii_c][jj_c] = h_new_c;
                 if (h_new - tol > sim_out->body_soil_[ind][ii][jj]) {
                     // Soil on the bucket should partially avalanche
-                    sim_out->body_soil_[0][ii_c][jj_c] = (
-                        sim_out->body_[1][ii_c][jj_c]);
-                    sim_out->body_soil_[1][ii_c][jj_c] = h_new_c;
                     sim_out->body_soil_[ind+1][ii][jj] = h_new;
                     sim_out->body_soil_pos_[nn].h_soil -= h_soil;
                 } else {
                     // All soil on the bucket should avalanche
-                    sim_out->body_soil_[0][ii_c][jj_c] = (
-                        sim_out->body_[1][ii_c][jj_c]);
-                    sim_out->body_soil_[1][ii_c][jj_c] = (
-                        sim_out->body_[1][ii_c][jj_c] +
-                        sim_out->body_soil_[ind+1][ii][jj] -
-                        sim_out->body_soil_[ind][ii][jj]);
                     sim_out->body_soil_[ind][ii][jj] = 0.0;
                     sim_out->body_soil_[ind+1][ii][jj] = 0.0;
                     sim_out->body_soil_pos_[nn].h_soil = 0.0;
@@ -1317,14 +1254,10 @@ void soil_simulator::RelaxUnstableBodyCell(
                             sim_out->body_[2][ii_c][jj_c] -
                             sim_out->body_[1][ii_c][jj_c]);
                         sim_out->body_soil_[ind+1][ii][jj] -= h_soil;
-                        sim_out->body_soil_[0][ii_c][jj_c] = (
-                            sim_out->body_[1][ii_c][jj_c]);
                         sim_out->body_soil_[1][ii_c][jj_c] = (
                             sim_out->body_[2][ii_c][jj_c]);
                     } else {
                         // Enough space for the partial avalanche
-                        sim_out->body_soil_[0][ii_c][jj_c] = (
-                            sim_out->body_[1][ii_c][jj_c]);
                         sim_out->body_soil_[1][ii_c][jj_c] = h_new_c;
                         sim_out->body_soil_[ind+1][ii][jj] = h_new;
                     }
@@ -1338,14 +1271,13 @@ void soil_simulator::RelaxUnstableBodyCell(
                         sim_out->body_soil_[ind+1][ii][jj] -
                         sim_out->body_soil_[ind][ii][jj]);
 
-                    sim_out->body_soil_[0][ii_c][jj_c] = (
-                        sim_out->body_[1][ii_c][jj_c]);
                     sim_out->body_soil_[1][ii_c][jj_c] = h_new_c;
                     sim_out->body_soil_[ind][ii][jj] = 0.0;
                     sim_out->body_soil_[ind+1][ii][jj] = 0.0;
                     sim_out->body_soil_pos_[nn].h_soil = 0.0;
                 }
             }
+
             // Calculating pos of cell in bucket frame
             auto pos = soil_simulator::CalcBucketFramePos(
                 ii_c, jj_c, sim_out->body_[1][ii_c][jj_c], grid, bucket);

--- a/soil_simulator/types.hpp
+++ b/soil_simulator/types.hpp
@@ -9,7 +9,7 @@ Copyright, 2023, Vilella Kenny.
 
 namespace soil_simulator {
 
-/// \brief Store information related to the position of the bucket sol.
+/// \brief Store information related to the position of the bucket soil.
 struct body_soil{
     /// Index of the bucket soil layer.
     int ind;
@@ -20,16 +20,16 @@ struct body_soil{
     /// Index of the bucket soil position in the Y direction.
     int jj;
 
-    /// Cartesian coordinate in the X direction where the bucket soil avalanched
-    /// on the bucket in the bucket frame. [m]
+    /// Cartesian coordinate in the X direction of the bucket soil in the
+    /// reference bucket frame. [m]
     float x_b;
 
-    /// Cartesian coordinate in the Y direction where the bucket soil avalanched
-    /// on the bucket in the bucket frame. [m]
+    /// Cartesian coordinate in the Y direction of the bucket soil in the
+    /// reference bucket frame. [m]
     float y_b;
 
-    /// Cartesian coordinate in the Z direction where the bucket soil avalanched
-    /// on the bucket in the bucket frame. [m]
+    /// Cartesian coordinate in the Z direction of the bucket soil in the
+    /// reference bucket frame. [m]
     float z_b;
 
     /// Vertical extent of the soil column. [m]

--- a/soil_simulator/utils.cpp
+++ b/soil_simulator/utils.cpp
@@ -142,7 +142,6 @@ std::vector<float> soil_simulator::CalcNormal(
     return normal;
 }
 
-
 std::vector<float> soil_simulator::CalcBucketFramePos(
     int ii, int jj, float z, Grid grid, Bucket* bucket
 ) {

--- a/soil_simulator/utils.hpp
+++ b/soil_simulator/utils.hpp
@@ -53,6 +53,17 @@ bool CheckBucketMovement(
 std::vector<float> CalcNormal(
     std::vector<float> a, std::vector<float> b, std::vector<float> c);
 
+/// \brief This function calculates the position of a considered cell in the
+///        bucket frame assuming that the bucket is in its reference psoition.
+///
+/// \param ii: Index of the considered cell in the X direction.
+/// \param jj: Index of the considered cell in the Y direction.
+/// \param z: Height of the considered position. [m]
+/// \param grid: Class that stores information related to the simulation grid.
+/// \param bucket: Class that stores information related to the bucket object.
+///
+/// \return Cartesian coordinate of the considered position in the reference
+///         bucket frame.
 std::vector<float> CalcBucketFramePos(
     int ii, int jj, float z, Grid grid, Bucket* bucket);
 

--- a/test/unit_tests/test_relax.cpp
+++ b/test/unit_tests/test_relax.cpp
@@ -7739,7 +7739,7 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     sim_out->body_soil_[3][10][15] = -0.5;
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, -0.3, grid, bucket);
     sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {0, 10, 14, pos0[0], pos0[1], pos0[2], 0.4});
+        soil_simulator::body_soil {0, 10, 14, pos0[0], pos0[1], pos0[2], 0.2});
     posA = soil_simulator::CalcBucketFramePos(10, 15, -0.6, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {2, 10, 15, posA[0], posA[1], posA[2], 0.1});

--- a/test/unit_tests/test_utils.cpp
+++ b/test/unit_tests/test_utils.cpp
@@ -303,6 +303,82 @@ TEST(UnitTestUtils, AngleToQuat) {
     EXPECT_NEAR(quat[3], 0.295169, 1e-5);
 }
 
+TEST(UnitTestUtils, CalcBucketFramePos) {
+    // Setting up the environment
+    soil_simulator::Grid grid(1.0, 1.0, 1.0, 0.1, 0.1);
+    std::vector<float> o_pos = {0.0, 0.0, 0.0};
+    std::vector<float> j_pos = {0.0, 0.0, 0.0};
+    std::vector<float> b_pos = {0.0, 0.0, -0.5};
+    std::vector<float> t_pos = {0.7, 0.0, -0.5};
+    soil_simulator::Bucket *bucket = new soil_simulator::Bucket(
+        o_pos, j_pos, b_pos, t_pos, 0.5);
+    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
+    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+
+    // -- Testing for simple translation (1) --
+    auto pos = soil_simulator::CalcBucketFramePos(
+        11, 11, 0.2, grid, bucket);
+    EXPECT_NEAR(pos[0], 0.1, 1e-5);
+    EXPECT_NEAR(pos[1], 0.1, 1e-5);
+    EXPECT_NEAR(pos[2], 0.2, 1e-5);
+
+    // -- Testing for simple translation (2) --
+    pos = soil_simulator::CalcBucketFramePos(
+        10, 12, -0.2, grid, bucket);
+    EXPECT_NEAR(pos[0], 0.0, 1e-5);
+    EXPECT_NEAR(pos[1], 0.2, 1e-5);
+    EXPECT_NEAR(pos[2], -0.2, 1e-5);
+
+    // -- Testing for simple translation (3) --
+    bucket->pos_ = std::vector<float> {-0.1, 0.2, 0.3};
+    pos = soil_simulator::CalcBucketFramePos(
+        10, 12, -0.2, grid, bucket);
+    EXPECT_NEAR(pos[0], 0.1, 1e-5);
+    EXPECT_NEAR(pos[1], 0.0, 1e-5);
+    EXPECT_NEAR(pos[2], -0.5, 1e-5);
+    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
+
+    // -- Testing for rotation by pi/2 around the Z axis --
+    bucket->ori_ = std::vector<float> {0.707107, 0.0, 0.0, -0.707107};
+    pos = soil_simulator::CalcBucketFramePos(
+        11, 12, 0.3, grid, bucket);
+    EXPECT_NEAR(pos[0], 0.2, 1e-5);
+    EXPECT_NEAR(pos[1], -0.1, 1e-5);
+    EXPECT_NEAR(pos[2], 0.3, 1e-5);
+    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+
+    // -- Testing for rotation by pi/2 around the Y axis --
+    bucket->ori_ = std::vector<float> {0.707107, 0.0, -0.707107, 0.0};
+    pos = soil_simulator::CalcBucketFramePos(
+        11, 12, 0.3, grid, bucket);
+    EXPECT_NEAR(pos[0], -0.3, 1e-5);
+    EXPECT_NEAR(pos[1], 0.2, 1e-5);
+    EXPECT_NEAR(pos[2], 0.1, 1e-5);
+    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+
+    // -- Testing for rotation by pi/2 around the X axis --
+    bucket->ori_ = std::vector<float> {0.707107, 0.707107, 0.0, 0.0};
+    pos = soil_simulator::CalcBucketFramePos(
+        11, 12, 0.3, grid, bucket);
+    EXPECT_NEAR(pos[0], 0.1, 1e-5);
+    EXPECT_NEAR(pos[1], -0.3, 1e-5);
+    EXPECT_NEAR(pos[2], 0.2, 1e-5);
+    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+
+    // -- Testing for rotation + translation  --
+    bucket->pos_ = std::vector<float> {-0.1, 0.2, 0.3};
+    bucket->ori_ = std::vector<float> {0.707107, 0.0, 0.0, -0.707107};
+    pos = soil_simulator::CalcBucketFramePos(
+        10, 12, -0.2, grid, bucket);
+    EXPECT_NEAR(pos[0], 0.0, 1e-5);
+    EXPECT_NEAR(pos[1], -0.1, 1e-5);
+    EXPECT_NEAR(pos[2], -0.5, 1e-5);
+    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
+    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+
+    delete bucket;
+}
+
 TEST(UnitTestUtils, CheckVolume) {
     // Setting dummy classes
     soil_simulator::Grid grid(1.0, 1.0, 1.0, 0.1, 0.1);


### PR DESCRIPTION
# Description
- Corrected spelling mistakes and improve comments/docstring
- Corrected in `UpdateBodySoil` the determination of `min_cell_height_diff`
- Corrected in `UpdateBodySoil` the determination of `sx` and `sy`
- Optimized a bit the code by moving things around
- Added docstring to the `CalcBucketFramePos` function
- Corrected a unit test for the `RelaxBodySoil` function
- Added unit tests for the `CalcBucketFramePos` function
- Fixed some issue in the `RelaxUnstableBodyCell` function