### PR TITLE
Bugfix: Sometimes CalcBucketPos has three bucket layers

### DIFF
--- a/soil_simulator/bucket_pos.cpp
+++ b/soil_simulator/bucket_pos.cpp
@@ -156,10 +156,10 @@ std::vector<std::vector<int>> soil_simulator::CalcRectanglePos(
     b_ind[1] = b[1] / grid.cell_size_xy_ + grid.half_length_y_;
     c_ind[1] = c[1] / grid.cell_size_xy_ + grid.half_length_y_;
     d_ind[1] = d[1] / grid.cell_size_xy_ + grid.half_length_y_;
-    a_ind[2] = a[2] / grid.cell_size_z_ + grid.half_length_z_;
-    b_ind[2] = b[2] / grid.cell_size_z_ + grid.half_length_z_;
-    c_ind[2] = c[2] / grid.cell_size_z_ + grid.half_length_z_;
-    d_ind[2] = d[2] / grid.cell_size_z_ + grid.half_length_z_;
+    a_ind[2] = a[2] / grid.cell_size_z_ + grid.half_length_z_ - 1.0;
+    b_ind[2] = b[2] / grid.cell_size_z_ + grid.half_length_z_ - 1.0;
+    c_ind[2] = c[2] / grid.cell_size_z_ + grid.half_length_z_ - 1.0;
+    d_ind[2] = d[2] / grid.cell_size_z_ + grid.half_length_z_ - 1.0;
 
     // Calculating the bounding box of the rectangle
     int area_min_x = static_cast<int>(std::floor(
@@ -210,7 +210,7 @@ std::vector<std::vector<int>> soil_simulator::CalcRectanglePos(
             if (in_rectangle[ii_s][jj_s] == true) {
                 // Cell is inside the rectangle area
                 // Calculating the height index of the rectangle at this corner
-                int kk = static_cast<int>(std::ceil(
+                int kk = static_cast<int>(std::floor(
                     a_ind[2] + c_ab[ii_s][jj_s] * ab_ind[2] +
                     c_ad[ii_s][jj_s] * ad_ind[2]));
 
@@ -386,9 +386,9 @@ std::vector<std::vector<int>> soil_simulator::CalcTrianglePos(
     a_ind[1] = a[1] / grid.cell_size_xy_ + grid.half_length_y_;
     b_ind[1] = b[1] / grid.cell_size_xy_ + grid.half_length_y_;
     c_ind[1] = c[1] / grid.cell_size_xy_ + grid.half_length_y_;
-    a_ind[2] = a[2] / grid.cell_size_z_ + grid.half_length_z_;
-    b_ind[2] = b[2] / grid.cell_size_z_ + grid.half_length_z_;
-    c_ind[2] = c[2] / grid.cell_size_z_ + grid.half_length_z_;
+    a_ind[2] = a[2] / grid.cell_size_z_ + grid.half_length_z_ - 1.0;
+    b_ind[2] = b[2] / grid.cell_size_z_ + grid.half_length_z_ - 1.0;
+    c_ind[2] = c[2] / grid.cell_size_z_ + grid.half_length_z_ - 1.0;
 
     // Calculating the bounding box of the triangle
     int area_min_x = static_cast<int>(std::floor(
@@ -439,7 +439,7 @@ std::vector<std::vector<int>> soil_simulator::CalcTrianglePos(
             if (in_triangle[ii_s][jj_s] == true) {
                 // Cell is inside the triangle area
                 // Calculating the height index of the triangle at this corner
-                int kk = static_cast<int>(std::ceil(
+                int kk = static_cast<int>(std::floor(
                     a_ind[2] + c_ab[ii_s][jj_s] * ab_ind[2] +
                     c_ac[ii_s][jj_s] * ac_ind[2]));
 
@@ -593,10 +593,10 @@ std::vector<std::vector<int>> soil_simulator::CalcLinePos(
     // Converting to indices
     float x1 = a[0] / grid.cell_size_xy_ + grid.half_length_x_;
     float y1 = a[1] / grid.cell_size_xy_ + grid.half_length_y_;
-    float z1 = a[2] / grid.cell_size_z_ + grid.half_length_z_;
+    float z1 = a[2] / grid.cell_size_z_ + grid.half_length_z_ - 1.0;
     float x2 = b[0] / grid.cell_size_xy_ + grid.half_length_x_;
     float y2 = b[1] / grid.cell_size_xy_ + grid.half_length_y_;
-    float z2 = b[2] / grid.cell_size_z_ + grid.half_length_z_;
+    float z2 = b[2] / grid.cell_size_z_ + grid.half_length_z_ - 1.0;
 
     // Determining direction of line
     int stepX = (x1 < x2) ? 1 : -1;
@@ -655,7 +655,7 @@ std::vector<std::vector<int>> soil_simulator::CalcLinePos(
     line_pos[0] = std::vector<int> {
         static_cast<int>(round(x1)),
         static_cast<int>(round(y1)),
-        static_cast<int>(std::ceil(z1))};
+        static_cast<int>(std::floor(z1))};
 
     // Iterating along the line until reaching the end
     while ((tMaxX < ab_norm) || (tMaxY < ab_norm) || (tMaxZ < ab_norm)) {
@@ -679,7 +679,7 @@ std::vector<std::vector<int>> soil_simulator::CalcLinePos(
         line_pos.push_back(std::vector<int> {
             static_cast<int>(round(x1)),
             static_cast<int>(round(y1)),
-            static_cast<int>(std::ceil(z1))});
+            static_cast<int>(std::floor(z1))});
     }
     return line_pos;
 }

--- a/soil_simulator/bucket_pos.cpp
+++ b/soil_simulator/bucket_pos.cpp
@@ -210,7 +210,7 @@ std::vector<std::vector<int>> soil_simulator::CalcRectanglePos(
             if (in_rectangle[ii_s][jj_s] == true) {
                 // Cell is inside the rectangle area
                 // Calculating the height index of the rectangle at this corner
-                int kk = static_cast<int>(std::floor(
+                int kk = static_cast<int>(std::ceil(
                     a_ind[2] + c_ab[ii_s][jj_s] * ab_ind[2] +
                     c_ad[ii_s][jj_s] * ad_ind[2]));
 
@@ -439,7 +439,7 @@ std::vector<std::vector<int>> soil_simulator::CalcTrianglePos(
             if (in_triangle[ii_s][jj_s] == true) {
                 // Cell is inside the triangle area
                 // Calculating the height index of the triangle at this corner
-                int kk = static_cast<int>(std::floor(
+                int kk = static_cast<int>(std::ceil(
                     a_ind[2] + c_ab[ii_s][jj_s] * ab_ind[2] +
                     c_ac[ii_s][jj_s] * ac_ind[2]));
 
@@ -655,7 +655,7 @@ std::vector<std::vector<int>> soil_simulator::CalcLinePos(
     line_pos[0] = std::vector<int> {
         static_cast<int>(round(x1)),
         static_cast<int>(round(y1)),
-        static_cast<int>(std::floor(z1))};
+        static_cast<int>(std::ceil(z1))};
 
     // Iterating along the line until reaching the end
     while ((tMaxX < ab_norm) || (tMaxY < ab_norm) || (tMaxZ < ab_norm)) {
@@ -679,7 +679,7 @@ std::vector<std::vector<int>> soil_simulator::CalcLinePos(
         line_pos.push_back(std::vector<int> {
             static_cast<int>(round(x1)),
             static_cast<int>(round(y1)),
-            static_cast<int>(std::floor(z1))});
+            static_cast<int>(std::ceil(z1))});
     }
     return line_pos;
 }

--- a/soil_simulator/bucket_pos.cpp
+++ b/soil_simulator/bucket_pos.cpp
@@ -790,8 +790,32 @@ void soil_simulator::IncludeNewBodyPos(
         sim_out->body_[3][ii][jj] = max_h;
     } else {
         // New position is not overlapping with the two existing positions
-        // This should not happen and indicates a problem in the workflow
-        throw std::runtime_error("Try to update body, but given position does"
-            "not overlap with two existing ones");
+        // This may be due to an edge case, in that case we try to fix the issue
+        // Calculating distance to the two bucket layers
+        float dist_0b = std::abs(sim_out->body_[0][ii][jj] - max_h);
+        float dist_0t = std::abs(min_h - sim_out->body_[1][ii][jj]);
+        float dist_2b = std::abs(sim_out->body_[2][ii][jj] - max_h);
+        float dist_2t = std::abs(min_h - sim_out->body_[3][ii][jj]);
+
+        // Checking what bucket layer is closer
+        if (std::min(dist_0b, dist_0t) < std::min(dist_2b, dist_2t)) {
+            // Merging with first bucket layer
+            if (dist_0b < dist_0t) {
+                // Merging down
+                sim_out->body_[0][ii][jj] = min_h;
+            } else {
+                // Merging up
+                sim_out->body_[1][ii][jj] = max_h;
+            }
+        } else {
+            // Merging with second bucket layer
+            if (dist_2b < dist_2t) {
+                // Merging down
+                sim_out->body_[2][ii][jj] = min_h;
+            } else {
+                // Merging up
+                sim_out->body_[3][ii][jj] = max_h;
+            }
+        }
     }
 }

--- a/soil_simulator/types.cpp
+++ b/soil_simulator/types.cpp
@@ -68,7 +68,7 @@ soil_simulator::Grid::Grid(
     for (auto ii = 1 ; ii < vect_y_.size() ; ii++)
         vect_y_[ii] = vect_y_[ii-1] + cell_size_xy;
 
-    vect_z_[0] = -grid_size_z;
+    vect_z_[0] = -grid_size_z + cell_size_z;
     for (auto ii = 1 ; ii < vect_z_.size() ; ii++)
         vect_z_[ii] = vect_z_[ii-1] + cell_size_z;
 }

--- a/test/unit_tests/test_bucket_pos.cpp
+++ b/test/unit_tests/test_bucket_pos.cpp
@@ -1564,10 +1564,12 @@ TEST(UnitTestBucketPos, IncludeNewBodyPos) {
     EXPECT_NEAR(sim_out->body_[2][5][5], 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_[3][5][5], 0.0, 1.e-5);
 
-    // -- Testing that incorrect request throws an error --
-    EXPECT_THROW(
-        soil_simulator::IncludeNewBodyPos(sim_out, 6, 9, 3.0, 3.1, 1e-5),
-        std::runtime_error);
+    // -- Testing to add a third bucket layers --
+    soil_simulator::IncludeNewBodyPos(sim_out, 6, 9, 3.0, 3.1, 1e-5);
+    EXPECT_NEAR(sim_out->body_[0][6][9], 0.7, 1.e-5);
+    EXPECT_NEAR(sim_out->body_[1][6][9], 3.1, 1.e-5);
+    EXPECT_NEAR(sim_out->body_[2][6][9], -0.4, 1.e-5);
+    EXPECT_NEAR(sim_out->body_[3][6][9], 0.6, 1.e-5);
 
     delete sim_out;
 }
@@ -1644,12 +1646,14 @@ TEST(UnitTestBucketPos, UpdateBody) {
     EXPECT_NEAR(sim_out->body_[2][6][6], 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_[3][6][6], 0.0, 1.e-5);
 
-    // -- Testing that incorrect request throws an error --
+    // -- Testing merging of layer when three bucket layers are present --
     std::vector<std::vector<int>> area_pos_4(1);
     area_pos_4[0] = std::vector<int> {10, 10, 13};
-    EXPECT_THROW(
-        soil_simulator::UpdateBody(area_pos_4, sim_out, grid, 1e-5),
-        std::runtime_error);
+    soil_simulator::UpdateBody(area_pos_4, sim_out, grid, 1e-5);
+    EXPECT_NEAR(sim_out->body_[0][10][10], -0.1, 1.e-5);
+    EXPECT_NEAR(sim_out->body_[1][10][10], 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_[2][10][10], 0.1, 1.e-5);
+    EXPECT_NEAR(sim_out->body_[3][10][10], 0.4, 1.e-5);
 
     delete sim_out;
 }

--- a/test/unit_tests/test_bucket_pos.cpp
+++ b/test/unit_tests/test_bucket_pos.cpp
@@ -21,17 +21,17 @@ TEST(UnitTestBucketPos, CalcLinePos) {
         a, b, grid);
 
     EXPECT_EQ(line_pos.size(), 11);
-    EXPECT_TRUE((line_pos[0] == std::vector<int> {10, 10, 10}));
-    EXPECT_TRUE((line_pos[1] == std::vector<int> {11, 10, 10}));
-    EXPECT_TRUE((line_pos[2] == std::vector<int> {12, 10, 10}));
-    EXPECT_TRUE((line_pos[3] == std::vector<int> {13, 10, 10}));
-    EXPECT_TRUE((line_pos[4] == std::vector<int> {14, 10, 10}));
-    EXPECT_TRUE((line_pos[5] == std::vector<int> {15, 10, 10}));
-    EXPECT_TRUE((line_pos[6] == std::vector<int> {16, 10, 10}));
-    EXPECT_TRUE((line_pos[7] == std::vector<int> {17, 10, 10}));
-    EXPECT_TRUE((line_pos[8] == std::vector<int> {18, 10, 10}));
-    EXPECT_TRUE((line_pos[9] == std::vector<int> {19, 10, 10}));
-    EXPECT_TRUE((line_pos[10] == std::vector<int> {20, 10, 10}));
+    EXPECT_TRUE((line_pos[0] == std::vector<int> {10, 10, 9}));
+    EXPECT_TRUE((line_pos[1] == std::vector<int> {11, 10, 9}));
+    EXPECT_TRUE((line_pos[2] == std::vector<int> {12, 10, 9}));
+    EXPECT_TRUE((line_pos[3] == std::vector<int> {13, 10, 9}));
+    EXPECT_TRUE((line_pos[4] == std::vector<int> {14, 10, 9}));
+    EXPECT_TRUE((line_pos[5] == std::vector<int> {15, 10, 9}));
+    EXPECT_TRUE((line_pos[6] == std::vector<int> {16, 10, 9}));
+    EXPECT_TRUE((line_pos[7] == std::vector<int> {17, 10, 9}));
+    EXPECT_TRUE((line_pos[8] == std::vector<int> {18, 10, 9}));
+    EXPECT_TRUE((line_pos[9] == std::vector<int> {19, 10, 9}));
+    EXPECT_TRUE((line_pos[10] == std::vector<int> {20, 10, 9}));
 
     // -- Testing that the rounding is done properly --
     a = {0.04 + 1e-5,  0.04 - 1e-5, -0.09 + 1e-5};
@@ -39,17 +39,17 @@ TEST(UnitTestBucketPos, CalcLinePos) {
     line_pos = soil_simulator::CalcLinePos(a, b, grid);
 
     EXPECT_EQ(line_pos.size(), 11);
-    EXPECT_TRUE((line_pos[0] == std::vector<int> {10, 10, 10}));
-    EXPECT_TRUE((line_pos[1] == std::vector<int> {11, 10, 10}));
-    EXPECT_TRUE((line_pos[2] == std::vector<int> {12, 10, 10}));
-    EXPECT_TRUE((line_pos[3] == std::vector<int> {13, 10, 10}));
-    EXPECT_TRUE((line_pos[4] == std::vector<int> {14, 10, 10}));
-    EXPECT_TRUE((line_pos[5] == std::vector<int> {15, 10, 10}));
-    EXPECT_TRUE((line_pos[6] == std::vector<int> {16, 10, 10}));
-    EXPECT_TRUE((line_pos[7] == std::vector<int> {17, 10, 10}));
-    EXPECT_TRUE((line_pos[8] == std::vector<int> {18, 10, 10}));
-    EXPECT_TRUE((line_pos[9] == std::vector<int> {19, 10, 10}));
-    EXPECT_TRUE((line_pos[10] == std::vector<int> {20, 10, 10}));
+    EXPECT_TRUE((line_pos[0] == std::vector<int> {10, 10, 9}));
+    EXPECT_TRUE((line_pos[1] == std::vector<int> {11, 10, 9}));
+    EXPECT_TRUE((line_pos[2] == std::vector<int> {12, 10, 9}));
+    EXPECT_TRUE((line_pos[3] == std::vector<int> {13, 10, 9}));
+    EXPECT_TRUE((line_pos[4] == std::vector<int> {14, 10, 9}));
+    EXPECT_TRUE((line_pos[5] == std::vector<int> {15, 10, 9}));
+    EXPECT_TRUE((line_pos[6] == std::vector<int> {16, 10, 9}));
+    EXPECT_TRUE((line_pos[7] == std::vector<int> {17, 10, 9}));
+    EXPECT_TRUE((line_pos[8] == std::vector<int> {18, 10, 9}));
+    EXPECT_TRUE((line_pos[9] == std::vector<int> {19, 10, 9}));
+    EXPECT_TRUE((line_pos[10] == std::vector<int> {20, 10, 9}));
 
     // -- Testing for a line following the Y axis --
     a = {0.0 - 1e-5, 0.0 + 1e-5, 0.0 - 1e-5};
@@ -57,17 +57,17 @@ TEST(UnitTestBucketPos, CalcLinePos) {
     line_pos = soil_simulator::CalcLinePos(a, b, grid);
 
     EXPECT_EQ(line_pos.size(), 11);
-    EXPECT_TRUE((line_pos[0] == std::vector<int> {10, 10, 10}));
-    EXPECT_TRUE((line_pos[1] == std::vector<int> {10, 11, 10}));
-    EXPECT_TRUE((line_pos[2] == std::vector<int> {10, 12, 10}));
-    EXPECT_TRUE((line_pos[3] == std::vector<int> {10, 13, 10}));
-    EXPECT_TRUE((line_pos[4] == std::vector<int> {10, 14, 10}));
-    EXPECT_TRUE((line_pos[5] == std::vector<int> {10, 15, 10}));
-    EXPECT_TRUE((line_pos[6] == std::vector<int> {10, 16, 10}));
-    EXPECT_TRUE((line_pos[7] == std::vector<int> {10, 17, 10}));
-    EXPECT_TRUE((line_pos[8] == std::vector<int> {10, 18, 10}));
-    EXPECT_TRUE((line_pos[9] == std::vector<int> {10, 19, 10}));
-    EXPECT_TRUE((line_pos[10] == std::vector<int> {10, 20, 10}));
+    EXPECT_TRUE((line_pos[0] == std::vector<int> {10, 10, 9}));
+    EXPECT_TRUE((line_pos[1] == std::vector<int> {10, 11, 9}));
+    EXPECT_TRUE((line_pos[2] == std::vector<int> {10, 12, 9}));
+    EXPECT_TRUE((line_pos[3] == std::vector<int> {10, 13, 9}));
+    EXPECT_TRUE((line_pos[4] == std::vector<int> {10, 14, 9}));
+    EXPECT_TRUE((line_pos[5] == std::vector<int> {10, 15, 9}));
+    EXPECT_TRUE((line_pos[6] == std::vector<int> {10, 16, 9}));
+    EXPECT_TRUE((line_pos[7] == std::vector<int> {10, 17, 9}));
+    EXPECT_TRUE((line_pos[8] == std::vector<int> {10, 18, 9}));
+    EXPECT_TRUE((line_pos[9] == std::vector<int> {10, 19, 9}));
+    EXPECT_TRUE((line_pos[10] == std::vector<int> {10, 20, 9}));
 
     // -- Testing for an arbitrary line (results obtained manually) --
     a = {0.34 + 1e-5, 0.56 + 1e-5, 0.0 - 1e-5};
@@ -76,15 +76,15 @@ TEST(UnitTestBucketPos, CalcLinePos) {
     line_pos.erase(unique(line_pos.begin(), line_pos.end()), line_pos.end());
 
     EXPECT_EQ(line_pos.size(), 9);
-    EXPECT_TRUE((line_pos[0] == std::vector<int> {13, 16, 10}));
-    EXPECT_TRUE((line_pos[1] == std::vector<int> {14, 16, 10}));
-    EXPECT_TRUE((line_pos[2] == std::vector<int> {14, 17, 10}));
-    EXPECT_TRUE((line_pos[3] == std::vector<int> {15, 17, 10}));
-    EXPECT_TRUE((line_pos[4] == std::vector<int> {15, 18, 10}));
-    EXPECT_TRUE((line_pos[5] == std::vector<int> {16, 18, 10}));
-    EXPECT_TRUE((line_pos[6] == std::vector<int> {16, 19, 10}));
-    EXPECT_TRUE((line_pos[7] == std::vector<int> {17, 19, 10}));
-    EXPECT_TRUE((line_pos[8] == std::vector<int> {17, 20, 10}));
+    EXPECT_TRUE((line_pos[0] == std::vector<int> {13, 16, 9}));
+    EXPECT_TRUE((line_pos[1] == std::vector<int> {14, 16, 9}));
+    EXPECT_TRUE((line_pos[2] == std::vector<int> {14, 17, 9}));
+    EXPECT_TRUE((line_pos[3] == std::vector<int> {15, 17, 9}));
+    EXPECT_TRUE((line_pos[4] == std::vector<int> {15, 18, 9}));
+    EXPECT_TRUE((line_pos[5] == std::vector<int> {16, 18, 9}));
+    EXPECT_TRUE((line_pos[6] == std::vector<int> {16, 19, 9}));
+    EXPECT_TRUE((line_pos[7] == std::vector<int> {17, 19, 9}));
+    EXPECT_TRUE((line_pos[8] == std::vector<int> {17, 20, 9}));
 
     // -- Testing for an arbitrary line in the XZ plane --
     a = {0.34 + 1e-8, 0.0 - 1e-8, 0.56 + 1e-8};
@@ -93,15 +93,15 @@ TEST(UnitTestBucketPos, CalcLinePos) {
     line_pos.erase(unique(line_pos.begin(), line_pos.end()), line_pos.end());
 
     EXPECT_EQ(line_pos.size(), 9);
-    EXPECT_TRUE((line_pos[0] == std::vector<int> {13, 10, 16}));
-    EXPECT_TRUE((line_pos[1] == std::vector<int> {14, 10, 16}));
-    EXPECT_TRUE((line_pos[2] == std::vector<int> {14, 10, 17}));
-    EXPECT_TRUE((line_pos[3] == std::vector<int> {15, 10, 17}));
-    EXPECT_TRUE((line_pos[4] == std::vector<int> {15, 10, 18}));
-    EXPECT_TRUE((line_pos[5] == std::vector<int> {16, 10, 18}));
-    EXPECT_TRUE((line_pos[6] == std::vector<int> {16, 10, 19}));
-    EXPECT_TRUE((line_pos[7] == std::vector<int> {17, 10, 19}));
-    EXPECT_TRUE((line_pos[8] == std::vector<int> {17, 10, 20}));
+    EXPECT_TRUE((line_pos[0] == std::vector<int> {13, 10, 15}));
+    EXPECT_TRUE((line_pos[1] == std::vector<int> {14, 10, 15}));
+    EXPECT_TRUE((line_pos[2] == std::vector<int> {14, 10, 16}));
+    EXPECT_TRUE((line_pos[3] == std::vector<int> {15, 10, 16}));
+    EXPECT_TRUE((line_pos[4] == std::vector<int> {15, 10, 17}));
+    EXPECT_TRUE((line_pos[5] == std::vector<int> {16, 10, 17}));
+    EXPECT_TRUE((line_pos[6] == std::vector<int> {16, 10, 18}));
+    EXPECT_TRUE((line_pos[7] == std::vector<int> {17, 10, 18}));
+    EXPECT_TRUE((line_pos[8] == std::vector<int> {17, 10, 19}));
 
     // -- Testing for the edge case where the line is a point --
     a = {0.5 - 1e-5, 0.5 - 1e-5, 0.5 - 1e-5};
@@ -110,7 +110,7 @@ TEST(UnitTestBucketPos, CalcLinePos) {
     line_pos.erase(unique(line_pos.begin(), line_pos.end()), line_pos.end());
 
     EXPECT_EQ(line_pos.size(), 1);
-    EXPECT_TRUE((line_pos[0] == std::vector<int> {15, 15, 15}));
+    EXPECT_TRUE((line_pos[0] == std::vector<int> {15, 15, 14}));
 
     // -- Testing for the edge case where the line is a point --
     a = {0.55 - 1e-5, 0.55 - 1e-5, 0.55 - 1e-5};
@@ -119,7 +119,7 @@ TEST(UnitTestBucketPos, CalcLinePos) {
     line_pos.erase(unique(line_pos.begin(), line_pos.end()), line_pos.end());
 
     EXPECT_EQ(line_pos.size(), 1);
-    EXPECT_TRUE((line_pos[0] == std::vector<int> {15, 15, 16}));
+    EXPECT_TRUE((line_pos[0] == std::vector<int> {15, 15, 15}));
 }
 
 TEST(UnitTestBucketPos, DecomposeVectorRectangle) {
@@ -625,42 +625,42 @@ TEST(UnitTestBucketPos, CalcRectanglePos) {
     // Checking the number of cells
     EXPECT_EQ(rect_pos.size(), 36);
     // Checking cells
-    EXPECT_TRUE((rect_pos[0] == std::vector<int> {10, 10, 10}));
-    EXPECT_TRUE((rect_pos[1] == std::vector<int> {10, 11, 10}));
-    EXPECT_TRUE((rect_pos[2] == std::vector<int> {10, 12, 10}));
-    EXPECT_TRUE((rect_pos[3] == std::vector<int> {10, 13, 10}));
-    EXPECT_TRUE((rect_pos[4] == std::vector<int> {10, 14, 10}));
-    EXPECT_TRUE((rect_pos[5] == std::vector<int> {10, 15, 10}));
-    EXPECT_TRUE((rect_pos[6] == std::vector<int> {11, 10, 10}));
-    EXPECT_TRUE((rect_pos[7] == std::vector<int> {11, 11, 10}));
-    EXPECT_TRUE((rect_pos[8] == std::vector<int> {11, 12, 10}));
-    EXPECT_TRUE((rect_pos[9] == std::vector<int> {11, 13, 10}));
-    EXPECT_TRUE((rect_pos[10] == std::vector<int> {11, 14, 10}));
-    EXPECT_TRUE((rect_pos[11] == std::vector<int> {11, 15, 10}));
-    EXPECT_TRUE((rect_pos[12] == std::vector<int> {12, 10, 10}));
-    EXPECT_TRUE((rect_pos[13] == std::vector<int> {12, 11, 10}));
-    EXPECT_TRUE((rect_pos[14] == std::vector<int> {12, 12, 10}));
-    EXPECT_TRUE((rect_pos[15] == std::vector<int> {12, 13, 10}));
-    EXPECT_TRUE((rect_pos[16] == std::vector<int> {12, 14, 10}));
-    EXPECT_TRUE((rect_pos[17] == std::vector<int> {12, 15, 10}));
-    EXPECT_TRUE((rect_pos[18] == std::vector<int> {13, 10, 10}));
-    EXPECT_TRUE((rect_pos[19] == std::vector<int> {13, 11, 10}));
-    EXPECT_TRUE((rect_pos[20] == std::vector<int> {13, 12, 10}));
-    EXPECT_TRUE((rect_pos[21] == std::vector<int> {13, 13, 10}));
-    EXPECT_TRUE((rect_pos[22] == std::vector<int> {13, 14, 10}));
-    EXPECT_TRUE((rect_pos[23] == std::vector<int> {13, 15, 10}));
-    EXPECT_TRUE((rect_pos[24] == std::vector<int> {14, 10, 10}));
-    EXPECT_TRUE((rect_pos[25] == std::vector<int> {14, 11, 10}));
-    EXPECT_TRUE((rect_pos[26] == std::vector<int> {14, 12, 10}));
-    EXPECT_TRUE((rect_pos[27] == std::vector<int> {14, 13, 10}));
-    EXPECT_TRUE((rect_pos[28] == std::vector<int> {14, 14, 10}));
-    EXPECT_TRUE((rect_pos[29] == std::vector<int> {14, 15, 10}));
-    EXPECT_TRUE((rect_pos[30] == std::vector<int> {15, 10, 10}));
-    EXPECT_TRUE((rect_pos[31] == std::vector<int> {15, 11, 10}));
-    EXPECT_TRUE((rect_pos[32] == std::vector<int> {15, 12, 10}));
-    EXPECT_TRUE((rect_pos[33] == std::vector<int> {15, 13, 10}));
-    EXPECT_TRUE((rect_pos[34] == std::vector<int> {15, 14, 10}));
-    EXPECT_TRUE((rect_pos[35] == std::vector<int> {15, 15, 10}));
+    EXPECT_TRUE((rect_pos[0] == std::vector<int> {10, 10, 9}));
+    EXPECT_TRUE((rect_pos[1] == std::vector<int> {10, 11, 9}));
+    EXPECT_TRUE((rect_pos[2] == std::vector<int> {10, 12, 9}));
+    EXPECT_TRUE((rect_pos[3] == std::vector<int> {10, 13, 9}));
+    EXPECT_TRUE((rect_pos[4] == std::vector<int> {10, 14, 9}));
+    EXPECT_TRUE((rect_pos[5] == std::vector<int> {10, 15, 9}));
+    EXPECT_TRUE((rect_pos[6] == std::vector<int> {11, 10, 9}));
+    EXPECT_TRUE((rect_pos[7] == std::vector<int> {11, 11, 9}));
+    EXPECT_TRUE((rect_pos[8] == std::vector<int> {11, 12, 9}));
+    EXPECT_TRUE((rect_pos[9] == std::vector<int> {11, 13, 9}));
+    EXPECT_TRUE((rect_pos[10] == std::vector<int> {11, 14, 9}));
+    EXPECT_TRUE((rect_pos[11] == std::vector<int> {11, 15, 9}));
+    EXPECT_TRUE((rect_pos[12] == std::vector<int> {12, 10, 9}));
+    EXPECT_TRUE((rect_pos[13] == std::vector<int> {12, 11, 9}));
+    EXPECT_TRUE((rect_pos[14] == std::vector<int> {12, 12, 9}));
+    EXPECT_TRUE((rect_pos[15] == std::vector<int> {12, 13, 9}));
+    EXPECT_TRUE((rect_pos[16] == std::vector<int> {12, 14, 9}));
+    EXPECT_TRUE((rect_pos[17] == std::vector<int> {12, 15, 9}));
+    EXPECT_TRUE((rect_pos[18] == std::vector<int> {13, 10, 9}));
+    EXPECT_TRUE((rect_pos[19] == std::vector<int> {13, 11, 9}));
+    EXPECT_TRUE((rect_pos[20] == std::vector<int> {13, 12, 9}));
+    EXPECT_TRUE((rect_pos[21] == std::vector<int> {13, 13, 9}));
+    EXPECT_TRUE((rect_pos[22] == std::vector<int> {13, 14, 9}));
+    EXPECT_TRUE((rect_pos[23] == std::vector<int> {13, 15, 9}));
+    EXPECT_TRUE((rect_pos[24] == std::vector<int> {14, 10, 9}));
+    EXPECT_TRUE((rect_pos[25] == std::vector<int> {14, 11, 9}));
+    EXPECT_TRUE((rect_pos[26] == std::vector<int> {14, 12, 9}));
+    EXPECT_TRUE((rect_pos[27] == std::vector<int> {14, 13, 9}));
+    EXPECT_TRUE((rect_pos[28] == std::vector<int> {14, 14, 9}));
+    EXPECT_TRUE((rect_pos[29] == std::vector<int> {14, 15, 9}));
+    EXPECT_TRUE((rect_pos[30] == std::vector<int> {15, 10, 9}));
+    EXPECT_TRUE((rect_pos[31] == std::vector<int> {15, 11, 9}));
+    EXPECT_TRUE((rect_pos[32] == std::vector<int> {15, 12, 9}));
+    EXPECT_TRUE((rect_pos[33] == std::vector<int> {15, 13, 9}));
+    EXPECT_TRUE((rect_pos[34] == std::vector<int> {15, 14, 9}));
+    EXPECT_TRUE((rect_pos[35] == std::vector<int> {15, 15, 9}));
 
     // -- Testing that the input order does not influence the results (1) --
     rect_pos = soil_simulator::CalcRectanglePos(a, d, c, b, grid, tol);
@@ -669,42 +669,42 @@ TEST(UnitTestBucketPos, CalcRectanglePos) {
     // Checking the number of cells
     EXPECT_EQ(rect_pos.size(), 36);
     // Checking cells
-    EXPECT_TRUE((rect_pos[0] == std::vector<int> {10, 10, 10}));
-    EXPECT_TRUE((rect_pos[1] == std::vector<int> {10, 11, 10}));
-    EXPECT_TRUE((rect_pos[2] == std::vector<int> {10, 12, 10}));
-    EXPECT_TRUE((rect_pos[3] == std::vector<int> {10, 13, 10}));
-    EXPECT_TRUE((rect_pos[4] == std::vector<int> {10, 14, 10}));
-    EXPECT_TRUE((rect_pos[5] == std::vector<int> {10, 15, 10}));
-    EXPECT_TRUE((rect_pos[6] == std::vector<int> {11, 10, 10}));
-    EXPECT_TRUE((rect_pos[7] == std::vector<int> {11, 11, 10}));
-    EXPECT_TRUE((rect_pos[8] == std::vector<int> {11, 12, 10}));
-    EXPECT_TRUE((rect_pos[9] == std::vector<int> {11, 13, 10}));
-    EXPECT_TRUE((rect_pos[10] == std::vector<int> {11, 14, 10}));
-    EXPECT_TRUE((rect_pos[11] == std::vector<int> {11, 15, 10}));
-    EXPECT_TRUE((rect_pos[12] == std::vector<int> {12, 10, 10}));
-    EXPECT_TRUE((rect_pos[13] == std::vector<int> {12, 11, 10}));
-    EXPECT_TRUE((rect_pos[14] == std::vector<int> {12, 12, 10}));
-    EXPECT_TRUE((rect_pos[15] == std::vector<int> {12, 13, 10}));
-    EXPECT_TRUE((rect_pos[16] == std::vector<int> {12, 14, 10}));
-    EXPECT_TRUE((rect_pos[17] == std::vector<int> {12, 15, 10}));
-    EXPECT_TRUE((rect_pos[18] == std::vector<int> {13, 10, 10}));
-    EXPECT_TRUE((rect_pos[19] == std::vector<int> {13, 11, 10}));
-    EXPECT_TRUE((rect_pos[20] == std::vector<int> {13, 12, 10}));
-    EXPECT_TRUE((rect_pos[21] == std::vector<int> {13, 13, 10}));
-    EXPECT_TRUE((rect_pos[22] == std::vector<int> {13, 14, 10}));
-    EXPECT_TRUE((rect_pos[23] == std::vector<int> {13, 15, 10}));
-    EXPECT_TRUE((rect_pos[24] == std::vector<int> {14, 10, 10}));
-    EXPECT_TRUE((rect_pos[25] == std::vector<int> {14, 11, 10}));
-    EXPECT_TRUE((rect_pos[26] == std::vector<int> {14, 12, 10}));
-    EXPECT_TRUE((rect_pos[27] == std::vector<int> {14, 13, 10}));
-    EXPECT_TRUE((rect_pos[28] == std::vector<int> {14, 14, 10}));
-    EXPECT_TRUE((rect_pos[29] == std::vector<int> {14, 15, 10}));
-    EXPECT_TRUE((rect_pos[30] == std::vector<int> {15, 10, 10}));
-    EXPECT_TRUE((rect_pos[31] == std::vector<int> {15, 11, 10}));
-    EXPECT_TRUE((rect_pos[32] == std::vector<int> {15, 12, 10}));
-    EXPECT_TRUE((rect_pos[33] == std::vector<int> {15, 13, 10}));
-    EXPECT_TRUE((rect_pos[34] == std::vector<int> {15, 14, 10}));
-    EXPECT_TRUE((rect_pos[35] == std::vector<int> {15, 15, 10}));
+    EXPECT_TRUE((rect_pos[0] == std::vector<int> {10, 10, 9}));
+    EXPECT_TRUE((rect_pos[1] == std::vector<int> {10, 11, 9}));
+    EXPECT_TRUE((rect_pos[2] == std::vector<int> {10, 12, 9}));
+    EXPECT_TRUE((rect_pos[3] == std::vector<int> {10, 13, 9}));
+    EXPECT_TRUE((rect_pos[4] == std::vector<int> {10, 14, 9}));
+    EXPECT_TRUE((rect_pos[5] == std::vector<int> {10, 15, 9}));
+    EXPECT_TRUE((rect_pos[6] == std::vector<int> {11, 10, 9}));
+    EXPECT_TRUE((rect_pos[7] == std::vector<int> {11, 11, 9}));
+    EXPECT_TRUE((rect_pos[8] == std::vector<int> {11, 12, 9}));
+    EXPECT_TRUE((rect_pos[9] == std::vector<int> {11, 13, 9}));
+    EXPECT_TRUE((rect_pos[10] == std::vector<int> {11, 14, 9}));
+    EXPECT_TRUE((rect_pos[11] == std::vector<int> {11, 15, 9}));
+    EXPECT_TRUE((rect_pos[12] == std::vector<int> {12, 10, 9}));
+    EXPECT_TRUE((rect_pos[13] == std::vector<int> {12, 11, 9}));
+    EXPECT_TRUE((rect_pos[14] == std::vector<int> {12, 12, 9}));
+    EXPECT_TRUE((rect_pos[15] == std::vector<int> {12, 13, 9}));
+    EXPECT_TRUE((rect_pos[16] == std::vector<int> {12, 14, 9}));
+    EXPECT_TRUE((rect_pos[17] == std::vector<int> {12, 15, 9}));
+    EXPECT_TRUE((rect_pos[18] == std::vector<int> {13, 10, 9}));
+    EXPECT_TRUE((rect_pos[19] == std::vector<int> {13, 11, 9}));
+    EXPECT_TRUE((rect_pos[20] == std::vector<int> {13, 12, 9}));
+    EXPECT_TRUE((rect_pos[21] == std::vector<int> {13, 13, 9}));
+    EXPECT_TRUE((rect_pos[22] == std::vector<int> {13, 14, 9}));
+    EXPECT_TRUE((rect_pos[23] == std::vector<int> {13, 15, 9}));
+    EXPECT_TRUE((rect_pos[24] == std::vector<int> {14, 10, 9}));
+    EXPECT_TRUE((rect_pos[25] == std::vector<int> {14, 11, 9}));
+    EXPECT_TRUE((rect_pos[26] == std::vector<int> {14, 12, 9}));
+    EXPECT_TRUE((rect_pos[27] == std::vector<int> {14, 13, 9}));
+    EXPECT_TRUE((rect_pos[28] == std::vector<int> {14, 14, 9}));
+    EXPECT_TRUE((rect_pos[29] == std::vector<int> {14, 15, 9}));
+    EXPECT_TRUE((rect_pos[30] == std::vector<int> {15, 10, 9}));
+    EXPECT_TRUE((rect_pos[31] == std::vector<int> {15, 11, 9}));
+    EXPECT_TRUE((rect_pos[32] == std::vector<int> {15, 12, 9}));
+    EXPECT_TRUE((rect_pos[33] == std::vector<int> {15, 13, 9}));
+    EXPECT_TRUE((rect_pos[34] == std::vector<int> {15, 14, 9}));
+    EXPECT_TRUE((rect_pos[35] == std::vector<int> {15, 15, 9}));
 
     // -- Testing that the input order does not influence the results (2) --
     rect_pos = soil_simulator::CalcRectanglePos(c, b, a, d, grid, tol);
@@ -713,42 +713,42 @@ TEST(UnitTestBucketPos, CalcRectanglePos) {
     // Checking the number of cells
     EXPECT_EQ(rect_pos.size(), 36);
     // Checking cells
-    EXPECT_TRUE((rect_pos[0] == std::vector<int> {10, 10, 10}));
-    EXPECT_TRUE((rect_pos[1] == std::vector<int> {10, 11, 10}));
-    EXPECT_TRUE((rect_pos[2] == std::vector<int> {10, 12, 10}));
-    EXPECT_TRUE((rect_pos[3] == std::vector<int> {10, 13, 10}));
-    EXPECT_TRUE((rect_pos[4] == std::vector<int> {10, 14, 10}));
-    EXPECT_TRUE((rect_pos[5] == std::vector<int> {10, 15, 10}));
-    EXPECT_TRUE((rect_pos[6] == std::vector<int> {11, 10, 10}));
-    EXPECT_TRUE((rect_pos[7] == std::vector<int> {11, 11, 10}));
-    EXPECT_TRUE((rect_pos[8] == std::vector<int> {11, 12, 10}));
-    EXPECT_TRUE((rect_pos[9] == std::vector<int> {11, 13, 10}));
-    EXPECT_TRUE((rect_pos[10] == std::vector<int> {11, 14, 10}));
-    EXPECT_TRUE((rect_pos[11] == std::vector<int> {11, 15, 10}));
-    EXPECT_TRUE((rect_pos[12] == std::vector<int> {12, 10, 10}));
-    EXPECT_TRUE((rect_pos[13] == std::vector<int> {12, 11, 10}));
-    EXPECT_TRUE((rect_pos[14] == std::vector<int> {12, 12, 10}));
-    EXPECT_TRUE((rect_pos[15] == std::vector<int> {12, 13, 10}));
-    EXPECT_TRUE((rect_pos[16] == std::vector<int> {12, 14, 10}));
-    EXPECT_TRUE((rect_pos[17] == std::vector<int> {12, 15, 10}));
-    EXPECT_TRUE((rect_pos[18] == std::vector<int> {13, 10, 10}));
-    EXPECT_TRUE((rect_pos[19] == std::vector<int> {13, 11, 10}));
-    EXPECT_TRUE((rect_pos[20] == std::vector<int> {13, 12, 10}));
-    EXPECT_TRUE((rect_pos[21] == std::vector<int> {13, 13, 10}));
-    EXPECT_TRUE((rect_pos[22] == std::vector<int> {13, 14, 10}));
-    EXPECT_TRUE((rect_pos[23] == std::vector<int> {13, 15, 10}));
-    EXPECT_TRUE((rect_pos[24] == std::vector<int> {14, 10, 10}));
-    EXPECT_TRUE((rect_pos[25] == std::vector<int> {14, 11, 10}));
-    EXPECT_TRUE((rect_pos[26] == std::vector<int> {14, 12, 10}));
-    EXPECT_TRUE((rect_pos[27] == std::vector<int> {14, 13, 10}));
-    EXPECT_TRUE((rect_pos[28] == std::vector<int> {14, 14, 10}));
-    EXPECT_TRUE((rect_pos[29] == std::vector<int> {14, 15, 10}));
-    EXPECT_TRUE((rect_pos[30] == std::vector<int> {15, 10, 10}));
-    EXPECT_TRUE((rect_pos[31] == std::vector<int> {15, 11, 10}));
-    EXPECT_TRUE((rect_pos[32] == std::vector<int> {15, 12, 10}));
-    EXPECT_TRUE((rect_pos[33] == std::vector<int> {15, 13, 10}));
-    EXPECT_TRUE((rect_pos[34] == std::vector<int> {15, 14, 10}));
-    EXPECT_TRUE((rect_pos[35] == std::vector<int> {15, 15, 10}));
+    EXPECT_TRUE((rect_pos[0] == std::vector<int> {10, 10, 9}));
+    EXPECT_TRUE((rect_pos[1] == std::vector<int> {10, 11, 9}));
+    EXPECT_TRUE((rect_pos[2] == std::vector<int> {10, 12, 9}));
+    EXPECT_TRUE((rect_pos[3] == std::vector<int> {10, 13, 9}));
+    EXPECT_TRUE((rect_pos[4] == std::vector<int> {10, 14, 9}));
+    EXPECT_TRUE((rect_pos[5] == std::vector<int> {10, 15, 9}));
+    EXPECT_TRUE((rect_pos[6] == std::vector<int> {11, 10, 9}));
+    EXPECT_TRUE((rect_pos[7] == std::vector<int> {11, 11, 9}));
+    EXPECT_TRUE((rect_pos[8] == std::vector<int> {11, 12, 9}));
+    EXPECT_TRUE((rect_pos[9] == std::vector<int> {11, 13, 9}));
+    EXPECT_TRUE((rect_pos[10] == std::vector<int> {11, 14, 9}));
+    EXPECT_TRUE((rect_pos[11] == std::vector<int> {11, 15, 9}));
+    EXPECT_TRUE((rect_pos[12] == std::vector<int> {12, 10, 9}));
+    EXPECT_TRUE((rect_pos[13] == std::vector<int> {12, 11, 9}));
+    EXPECT_TRUE((rect_pos[14] == std::vector<int> {12, 12, 9}));
+    EXPECT_TRUE((rect_pos[15] == std::vector<int> {12, 13, 9}));
+    EXPECT_TRUE((rect_pos[16] == std::vector<int> {12, 14, 9}));
+    EXPECT_TRUE((rect_pos[17] == std::vector<int> {12, 15, 9}));
+    EXPECT_TRUE((rect_pos[18] == std::vector<int> {13, 10, 9}));
+    EXPECT_TRUE((rect_pos[19] == std::vector<int> {13, 11, 9}));
+    EXPECT_TRUE((rect_pos[20] == std::vector<int> {13, 12, 9}));
+    EXPECT_TRUE((rect_pos[21] == std::vector<int> {13, 13, 9}));
+    EXPECT_TRUE((rect_pos[22] == std::vector<int> {13, 14, 9}));
+    EXPECT_TRUE((rect_pos[23] == std::vector<int> {13, 15, 9}));
+    EXPECT_TRUE((rect_pos[24] == std::vector<int> {14, 10, 9}));
+    EXPECT_TRUE((rect_pos[25] == std::vector<int> {14, 11, 9}));
+    EXPECT_TRUE((rect_pos[26] == std::vector<int> {14, 12, 9}));
+    EXPECT_TRUE((rect_pos[27] == std::vector<int> {14, 13, 9}));
+    EXPECT_TRUE((rect_pos[28] == std::vector<int> {14, 14, 9}));
+    EXPECT_TRUE((rect_pos[29] == std::vector<int> {14, 15, 9}));
+    EXPECT_TRUE((rect_pos[30] == std::vector<int> {15, 10, 9}));
+    EXPECT_TRUE((rect_pos[31] == std::vector<int> {15, 11, 9}));
+    EXPECT_TRUE((rect_pos[32] == std::vector<int> {15, 12, 9}));
+    EXPECT_TRUE((rect_pos[33] == std::vector<int> {15, 13, 9}));
+    EXPECT_TRUE((rect_pos[34] == std::vector<int> {15, 14, 9}));
+    EXPECT_TRUE((rect_pos[35] == std::vector<int> {15, 15, 9}));
 
     // -- Testing that the input order does not influence the results (3) --
     rect_pos = soil_simulator::CalcRectanglePos(b, c, d, a, grid, tol);
@@ -788,24 +788,24 @@ TEST(UnitTestBucketPos, CalcRectanglePos) {
     // Checking the number of cells
     EXPECT_EQ(rect_pos.size(), 18);
     // Checking cells
-    EXPECT_TRUE((rect_pos[0] == std::vector<int> {10, 10, 10}));
-    EXPECT_TRUE((rect_pos[1] == std::vector<int> {10, 11, 10}));
-    EXPECT_TRUE((rect_pos[2] == std::vector<int> {10, 12, 10}));
-    EXPECT_TRUE((rect_pos[3] == std::vector<int> {11, 10, 10}));
-    EXPECT_TRUE((rect_pos[4] == std::vector<int> {11, 11, 10}));
-    EXPECT_TRUE((rect_pos[5] == std::vector<int> {11, 12, 10}));
-    EXPECT_TRUE((rect_pos[6] == std::vector<int> {12, 10, 10}));
-    EXPECT_TRUE((rect_pos[7] == std::vector<int> {12, 11, 10}));
-    EXPECT_TRUE((rect_pos[8] == std::vector<int> {12, 12, 10}));
-    EXPECT_TRUE((rect_pos[9] == std::vector<int> {13, 10, 10}));
-    EXPECT_TRUE((rect_pos[10] == std::vector<int> {13, 11, 10}));
-    EXPECT_TRUE((rect_pos[11] == std::vector<int> {13, 12, 10}));
-    EXPECT_TRUE((rect_pos[12] == std::vector<int> {14, 10, 10}));
-    EXPECT_TRUE((rect_pos[13] == std::vector<int> {14, 11, 10}));
-    EXPECT_TRUE((rect_pos[14] == std::vector<int> {14, 12, 10}));
-    EXPECT_TRUE((rect_pos[15] == std::vector<int> {15, 10, 10}));
-    EXPECT_TRUE((rect_pos[16] == std::vector<int> {15, 11, 10}));
-    EXPECT_TRUE((rect_pos[17] == std::vector<int> {15, 12, 10}));
+    EXPECT_TRUE((rect_pos[0] == std::vector<int> {10, 10, 9}));
+    EXPECT_TRUE((rect_pos[1] == std::vector<int> {10, 11, 9}));
+    EXPECT_TRUE((rect_pos[2] == std::vector<int> {10, 12, 9}));
+    EXPECT_TRUE((rect_pos[3] == std::vector<int> {11, 10, 9}));
+    EXPECT_TRUE((rect_pos[4] == std::vector<int> {11, 11, 9}));
+    EXPECT_TRUE((rect_pos[5] == std::vector<int> {11, 12, 9}));
+    EXPECT_TRUE((rect_pos[6] == std::vector<int> {12, 10, 9}));
+    EXPECT_TRUE((rect_pos[7] == std::vector<int> {12, 11, 9}));
+    EXPECT_TRUE((rect_pos[8] == std::vector<int> {12, 12, 9}));
+    EXPECT_TRUE((rect_pos[9] == std::vector<int> {13, 10, 9}));
+    EXPECT_TRUE((rect_pos[10] == std::vector<int> {13, 11, 9}));
+    EXPECT_TRUE((rect_pos[11] == std::vector<int> {13, 12, 9}));
+    EXPECT_TRUE((rect_pos[12] == std::vector<int> {14, 10, 9}));
+    EXPECT_TRUE((rect_pos[13] == std::vector<int> {14, 11, 9}));
+    EXPECT_TRUE((rect_pos[14] == std::vector<int> {14, 12, 9}));
+    EXPECT_TRUE((rect_pos[15] == std::vector<int> {15, 10, 9}));
+    EXPECT_TRUE((rect_pos[16] == std::vector<int> {15, 11, 9}));
+    EXPECT_TRUE((rect_pos[17] == std::vector<int> {15, 12, 9}));
 
     // -- Testing that the input order does not influence the results --
     rect_pos = soil_simulator::CalcRectanglePos(a, d, c, b, grid, tol);
@@ -855,24 +855,24 @@ TEST(UnitTestBucketPos, CalcRectanglePos) {
     // Checking the number of cells
     EXPECT_EQ(rect_pos.size(), 18);
     // Checking cells
-    EXPECT_TRUE((rect_pos[0] == std::vector<int> {10, 10, 11}));
-    EXPECT_TRUE((rect_pos[1] == std::vector<int> {10, 10, 12}));
-    EXPECT_TRUE((rect_pos[2] == std::vector<int> {10, 10, 13}));
-    EXPECT_TRUE((rect_pos[3] == std::vector<int> {10, 10, 14}));
-    EXPECT_TRUE((rect_pos[4] == std::vector<int> {10, 10, 15}));
-    EXPECT_TRUE((rect_pos[5] == std::vector<int> {11, 10, 11}));
-    EXPECT_TRUE((rect_pos[6] == std::vector<int> {11, 10, 15}));
-    EXPECT_TRUE((rect_pos[7] == std::vector<int> {12, 10, 11}));
-    EXPECT_TRUE((rect_pos[8] == std::vector<int> {12, 10, 15}));
-    EXPECT_TRUE((rect_pos[9] == std::vector<int> {13, 10, 11}));
-    EXPECT_TRUE((rect_pos[10] == std::vector<int> {13, 10, 15}));
-    EXPECT_TRUE((rect_pos[11] == std::vector<int> {14, 10, 11}));
-    EXPECT_TRUE((rect_pos[12] == std::vector<int> {14, 10, 15}));
-    EXPECT_TRUE((rect_pos[13] == std::vector<int> {15, 10, 11}));
-    EXPECT_TRUE((rect_pos[14] == std::vector<int> {15, 10, 12}));
-    EXPECT_TRUE((rect_pos[15] == std::vector<int> {15, 10, 13}));
-    EXPECT_TRUE((rect_pos[16] == std::vector<int> {15, 10, 14}));
-    EXPECT_TRUE((rect_pos[17] == std::vector<int> {15, 10, 15}));
+    EXPECT_TRUE((rect_pos[0] == std::vector<int> {10, 10, 10}));
+    EXPECT_TRUE((rect_pos[1] == std::vector<int> {10, 10, 11}));
+    EXPECT_TRUE((rect_pos[2] == std::vector<int> {10, 10, 12}));
+    EXPECT_TRUE((rect_pos[3] == std::vector<int> {10, 10, 13}));
+    EXPECT_TRUE((rect_pos[4] == std::vector<int> {10, 10, 14}));
+    EXPECT_TRUE((rect_pos[5] == std::vector<int> {11, 10, 10}));
+    EXPECT_TRUE((rect_pos[6] == std::vector<int> {11, 10, 14}));
+    EXPECT_TRUE((rect_pos[7] == std::vector<int> {12, 10, 10}));
+    EXPECT_TRUE((rect_pos[8] == std::vector<int> {12, 10, 14}));
+    EXPECT_TRUE((rect_pos[9] == std::vector<int> {13, 10, 10}));
+    EXPECT_TRUE((rect_pos[10] == std::vector<int> {13, 10, 14}));
+    EXPECT_TRUE((rect_pos[11] == std::vector<int> {14, 10, 10}));
+    EXPECT_TRUE((rect_pos[12] == std::vector<int> {14, 10, 14}));
+    EXPECT_TRUE((rect_pos[13] == std::vector<int> {15, 10, 10}));
+    EXPECT_TRUE((rect_pos[14] == std::vector<int> {15, 10, 11}));
+    EXPECT_TRUE((rect_pos[15] == std::vector<int> {15, 10, 12}));
+    EXPECT_TRUE((rect_pos[16] == std::vector<int> {15, 10, 13}));
+    EXPECT_TRUE((rect_pos[17] == std::vector<int> {15, 10, 14}));
 
     // -- Testing that the input order does not influence the results --
     rect_pos = soil_simulator::CalcRectanglePos(a, d, c, b, grid, tol);
@@ -922,18 +922,18 @@ TEST(UnitTestBucketPos, CalcRectanglePos) {
     // Checking the number of cells
     EXPECT_EQ(rect_pos.size(), 12);
     // Checking cells
-    EXPECT_TRUE((rect_pos[0] == std::vector<int> {15, 10, 16}));
-    EXPECT_TRUE((rect_pos[1] == std::vector<int> {15, 11, 16}));
-    EXPECT_TRUE((rect_pos[2] == std::vector<int> {15, 12, 16}));
-    EXPECT_TRUE((rect_pos[3] == std::vector<int> {15, 13, 16}));
-    EXPECT_TRUE((rect_pos[4] == std::vector<int> {15, 14, 16}));
-    EXPECT_TRUE((rect_pos[5] == std::vector<int> {15, 15, 16}));
-    EXPECT_TRUE((rect_pos[6] == std::vector<int> {16, 10, 16}));
-    EXPECT_TRUE((rect_pos[7] == std::vector<int> {16, 11, 16}));
-    EXPECT_TRUE((rect_pos[8] == std::vector<int> {16, 12, 16}));
-    EXPECT_TRUE((rect_pos[9] == std::vector<int> {16, 13, 16}));
-    EXPECT_TRUE((rect_pos[10] == std::vector<int> {16, 14, 16}));
-    EXPECT_TRUE((rect_pos[11] == std::vector<int> {16, 15, 16}));
+    EXPECT_TRUE((rect_pos[0] == std::vector<int> {15, 10, 15}));
+    EXPECT_TRUE((rect_pos[1] == std::vector<int> {15, 11, 15}));
+    EXPECT_TRUE((rect_pos[2] == std::vector<int> {15, 12, 15}));
+    EXPECT_TRUE((rect_pos[3] == std::vector<int> {15, 13, 15}));
+    EXPECT_TRUE((rect_pos[4] == std::vector<int> {15, 14, 15}));
+    EXPECT_TRUE((rect_pos[5] == std::vector<int> {15, 15, 15}));
+    EXPECT_TRUE((rect_pos[6] == std::vector<int> {16, 10, 15}));
+    EXPECT_TRUE((rect_pos[7] == std::vector<int> {16, 11, 15}));
+    EXPECT_TRUE((rect_pos[8] == std::vector<int> {16, 12, 15}));
+    EXPECT_TRUE((rect_pos[9] == std::vector<int> {16, 13, 15}));
+    EXPECT_TRUE((rect_pos[10] == std::vector<int> {16, 14, 15}));
+    EXPECT_TRUE((rect_pos[11] == std::vector<int> {16, 15, 15}));
 
     // -- Testing that the input order does not influence the results --
     rect_pos = soil_simulator::CalcRectanglePos(a, d, c, b, grid, tol);
@@ -983,15 +983,15 @@ TEST(UnitTestBucketPos, CalcRectanglePos) {
     // Checking the number of cells
     EXPECT_EQ(rect_pos.size(), 9);
     // Checking cells
-    EXPECT_TRUE((rect_pos[0] == std::vector<int> {13, 16, 10}));
-    EXPECT_TRUE((rect_pos[1] == std::vector<int> {14, 16, 10}));
-    EXPECT_TRUE((rect_pos[2] == std::vector<int> {14, 17, 10}));
-    EXPECT_TRUE((rect_pos[3] == std::vector<int> {15, 17, 10}));
-    EXPECT_TRUE((rect_pos[4] == std::vector<int> {15, 18, 10}));
-    EXPECT_TRUE((rect_pos[5] == std::vector<int> {16, 18, 10}));
-    EXPECT_TRUE((rect_pos[6] == std::vector<int> {16, 19, 10}));
-    EXPECT_TRUE((rect_pos[7] == std::vector<int> {17, 19, 10}));
-    EXPECT_TRUE((rect_pos[8] == std::vector<int> {17, 20, 10}));
+    EXPECT_TRUE((rect_pos[0] == std::vector<int> {13, 16, 9}));
+    EXPECT_TRUE((rect_pos[1] == std::vector<int> {14, 16, 9}));
+    EXPECT_TRUE((rect_pos[2] == std::vector<int> {14, 17, 9}));
+    EXPECT_TRUE((rect_pos[3] == std::vector<int> {15, 17, 9}));
+    EXPECT_TRUE((rect_pos[4] == std::vector<int> {15, 18, 9}));
+    EXPECT_TRUE((rect_pos[5] == std::vector<int> {16, 18, 9}));
+    EXPECT_TRUE((rect_pos[6] == std::vector<int> {16, 19, 9}));
+    EXPECT_TRUE((rect_pos[7] == std::vector<int> {17, 19, 9}));
+    EXPECT_TRUE((rect_pos[8] == std::vector<int> {17, 20, 9}));
 
     // -- Testing for the edge case where the rectangle is a point --
     a = {0.5 - 1e-5, 0.5 - 1e-5, 0.5 - 1e-5};
@@ -1004,7 +1004,7 @@ TEST(UnitTestBucketPos, CalcRectanglePos) {
     // Checking the number of cells
     EXPECT_EQ(rect_pos.size(), 1);
     // Checking cells
-    EXPECT_TRUE((rect_pos[0] == std::vector<int> {15, 15, 15}));
+    EXPECT_TRUE((rect_pos[0] == std::vector<int> {15, 15, 14}));
 
     // -- Testing for edge case of a point on the edge of a cell --
     a = {0.55 - 1e-5, 0.55 - 1e-5, 0.5 - 1e-5};
@@ -1017,7 +1017,7 @@ TEST(UnitTestBucketPos, CalcRectanglePos) {
     // Checking the number of cells
     EXPECT_EQ(rect_pos.size(), 1);
     // Checking cells
-    EXPECT_TRUE((rect_pos[0] == std::vector<int> {15, 15, 15}));
+    EXPECT_TRUE((rect_pos[0] == std::vector<int> {15, 15, 14}));
 }
 
 TEST(UnitTestBucketPos, CalcTrianglePos) {
@@ -1042,82 +1042,82 @@ TEST(UnitTestBucketPos, CalcTrianglePos) {
     // Checking the number of cells
     EXPECT_EQ(tri_pos.size(), 76);
     // Checking cells
-    EXPECT_TRUE((tri_pos[0] == std::vector<int> {10, 10, 10}));
-    EXPECT_TRUE((tri_pos[1] == std::vector<int> {10, 11, 10}));
-    EXPECT_TRUE((tri_pos[2] == std::vector<int> {10, 12, 10}));
-    EXPECT_TRUE((tri_pos[3] == std::vector<int> {10, 13, 10}));
-    EXPECT_TRUE((tri_pos[4] == std::vector<int> {10, 14, 10}));
-    EXPECT_TRUE((tri_pos[5] == std::vector<int> {10, 15, 10}));
-    EXPECT_TRUE((tri_pos[6] == std::vector<int> {10, 16, 10}));
-    EXPECT_TRUE((tri_pos[7] == std::vector<int> {10, 17, 10}));
-    EXPECT_TRUE((tri_pos[8] == std::vector<int> {10, 18, 10}));
-    EXPECT_TRUE((tri_pos[9] == std::vector<int> {10, 19, 10}));
-    EXPECT_TRUE((tri_pos[10] == std::vector<int> {10, 20, 10}));
-    EXPECT_TRUE((tri_pos[11] == std::vector<int> {11, 10, 10}));
-    EXPECT_TRUE((tri_pos[12] == std::vector<int> {11, 11, 10}));
-    EXPECT_TRUE((tri_pos[13] == std::vector<int> {11, 12, 10}));
-    EXPECT_TRUE((tri_pos[14] == std::vector<int> {11, 13, 10}));
-    EXPECT_TRUE((tri_pos[15] == std::vector<int> {11, 14, 10}));
-    EXPECT_TRUE((tri_pos[16] == std::vector<int> {11, 15, 10}));
-    EXPECT_TRUE((tri_pos[17] == std::vector<int> {11, 16, 10}));
-    EXPECT_TRUE((tri_pos[18] == std::vector<int> {11, 17, 10}));
-    EXPECT_TRUE((tri_pos[19] == std::vector<int> {11, 18, 10}));
-    EXPECT_TRUE((tri_pos[20] == std::vector<int> {11, 19, 10}));
-    EXPECT_TRUE((tri_pos[21] == std::vector<int> {11, 20, 10}));
-    EXPECT_TRUE((tri_pos[22] == std::vector<int> {12, 10, 10}));
-    EXPECT_TRUE((tri_pos[23] == std::vector<int> {12, 11, 10}));
-    EXPECT_TRUE((tri_pos[24] == std::vector<int> {12, 12, 10}));
-    EXPECT_TRUE((tri_pos[25] == std::vector<int> {12, 13, 10}));
-    EXPECT_TRUE((tri_pos[26] == std::vector<int> {12, 14, 10}));
-    EXPECT_TRUE((tri_pos[27] == std::vector<int> {12, 15, 10}));
-    EXPECT_TRUE((tri_pos[28] == std::vector<int> {12, 16, 10}));
-    EXPECT_TRUE((tri_pos[29] == std::vector<int> {12, 17, 10}));
-    EXPECT_TRUE((tri_pos[30] == std::vector<int> {12, 18, 10}));
-    EXPECT_TRUE((tri_pos[31] == std::vector<int> {12, 19, 10}));
-    EXPECT_TRUE((tri_pos[32] == std::vector<int> {13, 10, 10}));
-    EXPECT_TRUE((tri_pos[33] == std::vector<int> {13, 11, 10}));
-    EXPECT_TRUE((tri_pos[34] == std::vector<int> {13, 12, 10}));
-    EXPECT_TRUE((tri_pos[35] == std::vector<int> {13, 13, 10}));
-    EXPECT_TRUE((tri_pos[36] == std::vector<int> {13, 14, 10}));
-    EXPECT_TRUE((tri_pos[37] == std::vector<int> {13, 15, 10}));
-    EXPECT_TRUE((tri_pos[38] == std::vector<int> {13, 16, 10}));
-    EXPECT_TRUE((tri_pos[39] == std::vector<int> {13, 17, 10}));
-    EXPECT_TRUE((tri_pos[40] == std::vector<int> {13, 18, 10}));
-    EXPECT_TRUE((tri_pos[41] == std::vector<int> {14, 10, 10}));
-    EXPECT_TRUE((tri_pos[42] == std::vector<int> {14, 11, 10}));
-    EXPECT_TRUE((tri_pos[43] == std::vector<int> {14, 12, 10}));
-    EXPECT_TRUE((tri_pos[44] == std::vector<int> {14, 13, 10}));
-    EXPECT_TRUE((tri_pos[45] == std::vector<int> {14, 14, 10}));
-    EXPECT_TRUE((tri_pos[46] == std::vector<int> {14, 15, 10}));
-    EXPECT_TRUE((tri_pos[47] == std::vector<int> {14, 16, 10}));
-    EXPECT_TRUE((tri_pos[48] == std::vector<int> {14, 17, 10}));
-    EXPECT_TRUE((tri_pos[49] == std::vector<int> {15, 10, 10}));
-    EXPECT_TRUE((tri_pos[50] == std::vector<int> {15, 11, 10}));
-    EXPECT_TRUE((tri_pos[51] == std::vector<int> {15, 12, 10}));
-    EXPECT_TRUE((tri_pos[52] == std::vector<int> {15, 13, 10}));
-    EXPECT_TRUE((tri_pos[53] == std::vector<int> {15, 14, 10}));
-    EXPECT_TRUE((tri_pos[54] == std::vector<int> {15, 15, 10}));
-    EXPECT_TRUE((tri_pos[55] == std::vector<int> {15, 16, 10}));
-    EXPECT_TRUE((tri_pos[56] == std::vector<int> {16, 10, 10}));
-    EXPECT_TRUE((tri_pos[57] == std::vector<int> {16, 11, 10}));
-    EXPECT_TRUE((tri_pos[58] == std::vector<int> {16, 12, 10}));
-    EXPECT_TRUE((tri_pos[59] == std::vector<int> {16, 13, 10}));
-    EXPECT_TRUE((tri_pos[60] == std::vector<int> {16, 14, 10}));
-    EXPECT_TRUE((tri_pos[61] == std::vector<int> {16, 15, 10}));
-    EXPECT_TRUE((tri_pos[62] == std::vector<int> {17, 10, 10}));
-    EXPECT_TRUE((tri_pos[63] == std::vector<int> {17, 11, 10}));
-    EXPECT_TRUE((tri_pos[64] == std::vector<int> {17, 12, 10}));
-    EXPECT_TRUE((tri_pos[65] == std::vector<int> {17, 13, 10}));
-    EXPECT_TRUE((tri_pos[66] == std::vector<int> {17, 14, 10}));
-    EXPECT_TRUE((tri_pos[67] == std::vector<int> {18, 10, 10}));
-    EXPECT_TRUE((tri_pos[68] == std::vector<int> {18, 11, 10}));
-    EXPECT_TRUE((tri_pos[69] == std::vector<int> {18, 12, 10}));
-    EXPECT_TRUE((tri_pos[70] == std::vector<int> {18, 13, 10}));
-    EXPECT_TRUE((tri_pos[71] == std::vector<int> {19, 10, 10}));
-    EXPECT_TRUE((tri_pos[72] == std::vector<int> {19, 11, 10}));
-    EXPECT_TRUE((tri_pos[73] == std::vector<int> {19, 12, 10}));
-    EXPECT_TRUE((tri_pos[74] == std::vector<int> {20, 10, 10}));
-    EXPECT_TRUE((tri_pos[75] == std::vector<int> {20, 11, 10}));
+    EXPECT_TRUE((tri_pos[0] == std::vector<int> {10, 10, 9}));
+    EXPECT_TRUE((tri_pos[1] == std::vector<int> {10, 11, 9}));
+    EXPECT_TRUE((tri_pos[2] == std::vector<int> {10, 12, 9}));
+    EXPECT_TRUE((tri_pos[3] == std::vector<int> {10, 13, 9}));
+    EXPECT_TRUE((tri_pos[4] == std::vector<int> {10, 14, 9}));
+    EXPECT_TRUE((tri_pos[5] == std::vector<int> {10, 15, 9}));
+    EXPECT_TRUE((tri_pos[6] == std::vector<int> {10, 16, 9}));
+    EXPECT_TRUE((tri_pos[7] == std::vector<int> {10, 17, 9}));
+    EXPECT_TRUE((tri_pos[8] == std::vector<int> {10, 18, 9}));
+    EXPECT_TRUE((tri_pos[9] == std::vector<int> {10, 19, 9}));
+    EXPECT_TRUE((tri_pos[10] == std::vector<int> {10, 20, 9}));
+    EXPECT_TRUE((tri_pos[11] == std::vector<int> {11, 10, 9}));
+    EXPECT_TRUE((tri_pos[12] == std::vector<int> {11, 11, 9}));
+    EXPECT_TRUE((tri_pos[13] == std::vector<int> {11, 12, 9}));
+    EXPECT_TRUE((tri_pos[14] == std::vector<int> {11, 13, 9}));
+    EXPECT_TRUE((tri_pos[15] == std::vector<int> {11, 14, 9}));
+    EXPECT_TRUE((tri_pos[16] == std::vector<int> {11, 15, 9}));
+    EXPECT_TRUE((tri_pos[17] == std::vector<int> {11, 16, 9}));
+    EXPECT_TRUE((tri_pos[18] == std::vector<int> {11, 17, 9}));
+    EXPECT_TRUE((tri_pos[19] == std::vector<int> {11, 18, 9}));
+    EXPECT_TRUE((tri_pos[20] == std::vector<int> {11, 19, 9}));
+    EXPECT_TRUE((tri_pos[21] == std::vector<int> {11, 20, 9}));
+    EXPECT_TRUE((tri_pos[22] == std::vector<int> {12, 10, 9}));
+    EXPECT_TRUE((tri_pos[23] == std::vector<int> {12, 11, 9}));
+    EXPECT_TRUE((tri_pos[24] == std::vector<int> {12, 12, 9}));
+    EXPECT_TRUE((tri_pos[25] == std::vector<int> {12, 13, 9}));
+    EXPECT_TRUE((tri_pos[26] == std::vector<int> {12, 14, 9}));
+    EXPECT_TRUE((tri_pos[27] == std::vector<int> {12, 15, 9}));
+    EXPECT_TRUE((tri_pos[28] == std::vector<int> {12, 16, 9}));
+    EXPECT_TRUE((tri_pos[29] == std::vector<int> {12, 17, 9}));
+    EXPECT_TRUE((tri_pos[30] == std::vector<int> {12, 18, 9}));
+    EXPECT_TRUE((tri_pos[31] == std::vector<int> {12, 19, 9}));
+    EXPECT_TRUE((tri_pos[32] == std::vector<int> {13, 10, 9}));
+    EXPECT_TRUE((tri_pos[33] == std::vector<int> {13, 11, 9}));
+    EXPECT_TRUE((tri_pos[34] == std::vector<int> {13, 12, 9}));
+    EXPECT_TRUE((tri_pos[35] == std::vector<int> {13, 13, 9}));
+    EXPECT_TRUE((tri_pos[36] == std::vector<int> {13, 14, 9}));
+    EXPECT_TRUE((tri_pos[37] == std::vector<int> {13, 15, 9}));
+    EXPECT_TRUE((tri_pos[38] == std::vector<int> {13, 16, 9}));
+    EXPECT_TRUE((tri_pos[39] == std::vector<int> {13, 17, 9}));
+    EXPECT_TRUE((tri_pos[40] == std::vector<int> {13, 18, 9}));
+    EXPECT_TRUE((tri_pos[41] == std::vector<int> {14, 10, 9}));
+    EXPECT_TRUE((tri_pos[42] == std::vector<int> {14, 11, 9}));
+    EXPECT_TRUE((tri_pos[43] == std::vector<int> {14, 12, 9}));
+    EXPECT_TRUE((tri_pos[44] == std::vector<int> {14, 13, 9}));
+    EXPECT_TRUE((tri_pos[45] == std::vector<int> {14, 14, 9}));
+    EXPECT_TRUE((tri_pos[46] == std::vector<int> {14, 15, 9}));
+    EXPECT_TRUE((tri_pos[47] == std::vector<int> {14, 16, 9}));
+    EXPECT_TRUE((tri_pos[48] == std::vector<int> {14, 17, 9}));
+    EXPECT_TRUE((tri_pos[49] == std::vector<int> {15, 10, 9}));
+    EXPECT_TRUE((tri_pos[50] == std::vector<int> {15, 11, 9}));
+    EXPECT_TRUE((tri_pos[51] == std::vector<int> {15, 12, 9}));
+    EXPECT_TRUE((tri_pos[52] == std::vector<int> {15, 13, 9}));
+    EXPECT_TRUE((tri_pos[53] == std::vector<int> {15, 14, 9}));
+    EXPECT_TRUE((tri_pos[54] == std::vector<int> {15, 15, 9}));
+    EXPECT_TRUE((tri_pos[55] == std::vector<int> {15, 16, 9}));
+    EXPECT_TRUE((tri_pos[56] == std::vector<int> {16, 10, 9}));
+    EXPECT_TRUE((tri_pos[57] == std::vector<int> {16, 11, 9}));
+    EXPECT_TRUE((tri_pos[58] == std::vector<int> {16, 12, 9}));
+    EXPECT_TRUE((tri_pos[59] == std::vector<int> {16, 13, 9}));
+    EXPECT_TRUE((tri_pos[60] == std::vector<int> {16, 14, 9}));
+    EXPECT_TRUE((tri_pos[61] == std::vector<int> {16, 15, 9}));
+    EXPECT_TRUE((tri_pos[62] == std::vector<int> {17, 10, 9}));
+    EXPECT_TRUE((tri_pos[63] == std::vector<int> {17, 11, 9}));
+    EXPECT_TRUE((tri_pos[64] == std::vector<int> {17, 12, 9}));
+    EXPECT_TRUE((tri_pos[65] == std::vector<int> {17, 13, 9}));
+    EXPECT_TRUE((tri_pos[66] == std::vector<int> {17, 14, 9}));
+    EXPECT_TRUE((tri_pos[67] == std::vector<int> {18, 10, 9}));
+    EXPECT_TRUE((tri_pos[68] == std::vector<int> {18, 11, 9}));
+    EXPECT_TRUE((tri_pos[69] == std::vector<int> {18, 12, 9}));
+    EXPECT_TRUE((tri_pos[70] == std::vector<int> {18, 13, 9}));
+    EXPECT_TRUE((tri_pos[71] == std::vector<int> {19, 10, 9}));
+    EXPECT_TRUE((tri_pos[72] == std::vector<int> {19, 11, 9}));
+    EXPECT_TRUE((tri_pos[73] == std::vector<int> {19, 12, 9}));
+    EXPECT_TRUE((tri_pos[74] == std::vector<int> {20, 10, 9}));
+    EXPECT_TRUE((tri_pos[75] == std::vector<int> {20, 11, 9}));
 
     // -- Testing that the input order does not influence the results (1) --
     tri_pos = soil_simulator::CalcTrianglePos(b, a, c, grid, tol);
@@ -1126,82 +1126,82 @@ TEST(UnitTestBucketPos, CalcTrianglePos) {
     // Checking the number of cells
     EXPECT_EQ(tri_pos.size(), 76);
     // Checking cells
-    EXPECT_TRUE((tri_pos[0] == std::vector<int> {10, 10, 10}));
-    EXPECT_TRUE((tri_pos[1] == std::vector<int> {10, 11, 10}));
-    EXPECT_TRUE((tri_pos[2] == std::vector<int> {10, 12, 10}));
-    EXPECT_TRUE((tri_pos[3] == std::vector<int> {10, 13, 10}));
-    EXPECT_TRUE((tri_pos[4] == std::vector<int> {10, 14, 10}));
-    EXPECT_TRUE((tri_pos[5] == std::vector<int> {10, 15, 10}));
-    EXPECT_TRUE((tri_pos[6] == std::vector<int> {10, 16, 10}));
-    EXPECT_TRUE((tri_pos[7] == std::vector<int> {10, 17, 10}));
-    EXPECT_TRUE((tri_pos[8] == std::vector<int> {10, 18, 10}));
-    EXPECT_TRUE((tri_pos[9] == std::vector<int> {10, 19, 10}));
-    EXPECT_TRUE((tri_pos[10] == std::vector<int> {10, 20, 10}));
-    EXPECT_TRUE((tri_pos[11] == std::vector<int> {11, 10, 10}));
-    EXPECT_TRUE((tri_pos[12] == std::vector<int> {11, 11, 10}));
-    EXPECT_TRUE((tri_pos[13] == std::vector<int> {11, 12, 10}));
-    EXPECT_TRUE((tri_pos[14] == std::vector<int> {11, 13, 10}));
-    EXPECT_TRUE((tri_pos[15] == std::vector<int> {11, 14, 10}));
-    EXPECT_TRUE((tri_pos[16] == std::vector<int> {11, 15, 10}));
-    EXPECT_TRUE((tri_pos[17] == std::vector<int> {11, 16, 10}));
-    EXPECT_TRUE((tri_pos[18] == std::vector<int> {11, 17, 10}));
-    EXPECT_TRUE((tri_pos[19] == std::vector<int> {11, 18, 10}));
-    EXPECT_TRUE((tri_pos[20] == std::vector<int> {11, 19, 10}));
-    EXPECT_TRUE((tri_pos[21] == std::vector<int> {11, 20, 10}));
-    EXPECT_TRUE((tri_pos[22] == std::vector<int> {12, 10, 10}));
-    EXPECT_TRUE((tri_pos[23] == std::vector<int> {12, 11, 10}));
-    EXPECT_TRUE((tri_pos[24] == std::vector<int> {12, 12, 10}));
-    EXPECT_TRUE((tri_pos[25] == std::vector<int> {12, 13, 10}));
-    EXPECT_TRUE((tri_pos[26] == std::vector<int> {12, 14, 10}));
-    EXPECT_TRUE((tri_pos[27] == std::vector<int> {12, 15, 10}));
-    EXPECT_TRUE((tri_pos[28] == std::vector<int> {12, 16, 10}));
-    EXPECT_TRUE((tri_pos[29] == std::vector<int> {12, 17, 10}));
-    EXPECT_TRUE((tri_pos[30] == std::vector<int> {12, 18, 10}));
-    EXPECT_TRUE((tri_pos[31] == std::vector<int> {12, 19, 10}));
-    EXPECT_TRUE((tri_pos[32] == std::vector<int> {13, 10, 10}));
-    EXPECT_TRUE((tri_pos[33] == std::vector<int> {13, 11, 10}));
-    EXPECT_TRUE((tri_pos[34] == std::vector<int> {13, 12, 10}));
-    EXPECT_TRUE((tri_pos[35] == std::vector<int> {13, 13, 10}));
-    EXPECT_TRUE((tri_pos[36] == std::vector<int> {13, 14, 10}));
-    EXPECT_TRUE((tri_pos[37] == std::vector<int> {13, 15, 10}));
-    EXPECT_TRUE((tri_pos[38] == std::vector<int> {13, 16, 10}));
-    EXPECT_TRUE((tri_pos[39] == std::vector<int> {13, 17, 10}));
-    EXPECT_TRUE((tri_pos[40] == std::vector<int> {13, 18, 10}));
-    EXPECT_TRUE((tri_pos[41] == std::vector<int> {14, 10, 10}));
-    EXPECT_TRUE((tri_pos[42] == std::vector<int> {14, 11, 10}));
-    EXPECT_TRUE((tri_pos[43] == std::vector<int> {14, 12, 10}));
-    EXPECT_TRUE((tri_pos[44] == std::vector<int> {14, 13, 10}));
-    EXPECT_TRUE((tri_pos[45] == std::vector<int> {14, 14, 10}));
-    EXPECT_TRUE((tri_pos[46] == std::vector<int> {14, 15, 10}));
-    EXPECT_TRUE((tri_pos[47] == std::vector<int> {14, 16, 10}));
-    EXPECT_TRUE((tri_pos[48] == std::vector<int> {14, 17, 10}));
-    EXPECT_TRUE((tri_pos[49] == std::vector<int> {15, 10, 10}));
-    EXPECT_TRUE((tri_pos[50] == std::vector<int> {15, 11, 10}));
-    EXPECT_TRUE((tri_pos[51] == std::vector<int> {15, 12, 10}));
-    EXPECT_TRUE((tri_pos[52] == std::vector<int> {15, 13, 10}));
-    EXPECT_TRUE((tri_pos[53] == std::vector<int> {15, 14, 10}));
-    EXPECT_TRUE((tri_pos[54] == std::vector<int> {15, 15, 10}));
-    EXPECT_TRUE((tri_pos[55] == std::vector<int> {15, 16, 10}));
-    EXPECT_TRUE((tri_pos[56] == std::vector<int> {16, 10, 10}));
-    EXPECT_TRUE((tri_pos[57] == std::vector<int> {16, 11, 10}));
-    EXPECT_TRUE((tri_pos[58] == std::vector<int> {16, 12, 10}));
-    EXPECT_TRUE((tri_pos[59] == std::vector<int> {16, 13, 10}));
-    EXPECT_TRUE((tri_pos[60] == std::vector<int> {16, 14, 10}));
-    EXPECT_TRUE((tri_pos[61] == std::vector<int> {16, 15, 10}));
-    EXPECT_TRUE((tri_pos[62] == std::vector<int> {17, 10, 10}));
-    EXPECT_TRUE((tri_pos[63] == std::vector<int> {17, 11, 10}));
-    EXPECT_TRUE((tri_pos[64] == std::vector<int> {17, 12, 10}));
-    EXPECT_TRUE((tri_pos[65] == std::vector<int> {17, 13, 10}));
-    EXPECT_TRUE((tri_pos[66] == std::vector<int> {17, 14, 10}));
-    EXPECT_TRUE((tri_pos[67] == std::vector<int> {18, 10, 10}));
-    EXPECT_TRUE((tri_pos[68] == std::vector<int> {18, 11, 10}));
-    EXPECT_TRUE((tri_pos[69] == std::vector<int> {18, 12, 10}));
-    EXPECT_TRUE((tri_pos[70] == std::vector<int> {18, 13, 10}));
-    EXPECT_TRUE((tri_pos[71] == std::vector<int> {19, 10, 10}));
-    EXPECT_TRUE((tri_pos[72] == std::vector<int> {19, 11, 10}));
-    EXPECT_TRUE((tri_pos[73] == std::vector<int> {19, 12, 10}));
-    EXPECT_TRUE((tri_pos[74] == std::vector<int> {20, 10, 10}));
-    EXPECT_TRUE((tri_pos[75] == std::vector<int> {20, 11, 10}));
+    EXPECT_TRUE((tri_pos[0] == std::vector<int> {10, 10, 9}));
+    EXPECT_TRUE((tri_pos[1] == std::vector<int> {10, 11, 9}));
+    EXPECT_TRUE((tri_pos[2] == std::vector<int> {10, 12, 9}));
+    EXPECT_TRUE((tri_pos[3] == std::vector<int> {10, 13, 9}));
+    EXPECT_TRUE((tri_pos[4] == std::vector<int> {10, 14, 9}));
+    EXPECT_TRUE((tri_pos[5] == std::vector<int> {10, 15, 9}));
+    EXPECT_TRUE((tri_pos[6] == std::vector<int> {10, 16, 9}));
+    EXPECT_TRUE((tri_pos[7] == std::vector<int> {10, 17, 9}));
+    EXPECT_TRUE((tri_pos[8] == std::vector<int> {10, 18, 9}));
+    EXPECT_TRUE((tri_pos[9] == std::vector<int> {10, 19, 9}));
+    EXPECT_TRUE((tri_pos[10] == std::vector<int> {10, 20, 9}));
+    EXPECT_TRUE((tri_pos[11] == std::vector<int> {11, 10, 9}));
+    EXPECT_TRUE((tri_pos[12] == std::vector<int> {11, 11, 9}));
+    EXPECT_TRUE((tri_pos[13] == std::vector<int> {11, 12, 9}));
+    EXPECT_TRUE((tri_pos[14] == std::vector<int> {11, 13, 9}));
+    EXPECT_TRUE((tri_pos[15] == std::vector<int> {11, 14, 9}));
+    EXPECT_TRUE((tri_pos[16] == std::vector<int> {11, 15, 9}));
+    EXPECT_TRUE((tri_pos[17] == std::vector<int> {11, 16, 9}));
+    EXPECT_TRUE((tri_pos[18] == std::vector<int> {11, 17, 9}));
+    EXPECT_TRUE((tri_pos[19] == std::vector<int> {11, 18, 9}));
+    EXPECT_TRUE((tri_pos[20] == std::vector<int> {11, 19, 9}));
+    EXPECT_TRUE((tri_pos[21] == std::vector<int> {11, 20, 9}));
+    EXPECT_TRUE((tri_pos[22] == std::vector<int> {12, 10, 9}));
+    EXPECT_TRUE((tri_pos[23] == std::vector<int> {12, 11, 9}));
+    EXPECT_TRUE((tri_pos[24] == std::vector<int> {12, 12, 9}));
+    EXPECT_TRUE((tri_pos[25] == std::vector<int> {12, 13, 9}));
+    EXPECT_TRUE((tri_pos[26] == std::vector<int> {12, 14, 9}));
+    EXPECT_TRUE((tri_pos[27] == std::vector<int> {12, 15, 9}));
+    EXPECT_TRUE((tri_pos[28] == std::vector<int> {12, 16, 9}));
+    EXPECT_TRUE((tri_pos[29] == std::vector<int> {12, 17, 9}));
+    EXPECT_TRUE((tri_pos[30] == std::vector<int> {12, 18, 9}));
+    EXPECT_TRUE((tri_pos[31] == std::vector<int> {12, 19, 9}));
+    EXPECT_TRUE((tri_pos[32] == std::vector<int> {13, 10, 9}));
+    EXPECT_TRUE((tri_pos[33] == std::vector<int> {13, 11, 9}));
+    EXPECT_TRUE((tri_pos[34] == std::vector<int> {13, 12, 9}));
+    EXPECT_TRUE((tri_pos[35] == std::vector<int> {13, 13, 9}));
+    EXPECT_TRUE((tri_pos[36] == std::vector<int> {13, 14, 9}));
+    EXPECT_TRUE((tri_pos[37] == std::vector<int> {13, 15, 9}));
+    EXPECT_TRUE((tri_pos[38] == std::vector<int> {13, 16, 9}));
+    EXPECT_TRUE((tri_pos[39] == std::vector<int> {13, 17, 9}));
+    EXPECT_TRUE((tri_pos[40] == std::vector<int> {13, 18, 9}));
+    EXPECT_TRUE((tri_pos[41] == std::vector<int> {14, 10, 9}));
+    EXPECT_TRUE((tri_pos[42] == std::vector<int> {14, 11, 9}));
+    EXPECT_TRUE((tri_pos[43] == std::vector<int> {14, 12, 9}));
+    EXPECT_TRUE((tri_pos[44] == std::vector<int> {14, 13, 9}));
+    EXPECT_TRUE((tri_pos[45] == std::vector<int> {14, 14, 9}));
+    EXPECT_TRUE((tri_pos[46] == std::vector<int> {14, 15, 9}));
+    EXPECT_TRUE((tri_pos[47] == std::vector<int> {14, 16, 9}));
+    EXPECT_TRUE((tri_pos[48] == std::vector<int> {14, 17, 9}));
+    EXPECT_TRUE((tri_pos[49] == std::vector<int> {15, 10, 9}));
+    EXPECT_TRUE((tri_pos[50] == std::vector<int> {15, 11, 9}));
+    EXPECT_TRUE((tri_pos[51] == std::vector<int> {15, 12, 9}));
+    EXPECT_TRUE((tri_pos[52] == std::vector<int> {15, 13, 9}));
+    EXPECT_TRUE((tri_pos[53] == std::vector<int> {15, 14, 9}));
+    EXPECT_TRUE((tri_pos[54] == std::vector<int> {15, 15, 9}));
+    EXPECT_TRUE((tri_pos[55] == std::vector<int> {15, 16, 9}));
+    EXPECT_TRUE((tri_pos[56] == std::vector<int> {16, 10, 9}));
+    EXPECT_TRUE((tri_pos[57] == std::vector<int> {16, 11, 9}));
+    EXPECT_TRUE((tri_pos[58] == std::vector<int> {16, 12, 9}));
+    EXPECT_TRUE((tri_pos[59] == std::vector<int> {16, 13, 9}));
+    EXPECT_TRUE((tri_pos[60] == std::vector<int> {16, 14, 9}));
+    EXPECT_TRUE((tri_pos[61] == std::vector<int> {16, 15, 9}));
+    EXPECT_TRUE((tri_pos[62] == std::vector<int> {17, 10, 9}));
+    EXPECT_TRUE((tri_pos[63] == std::vector<int> {17, 11, 9}));
+    EXPECT_TRUE((tri_pos[64] == std::vector<int> {17, 12, 9}));
+    EXPECT_TRUE((tri_pos[65] == std::vector<int> {17, 13, 9}));
+    EXPECT_TRUE((tri_pos[66] == std::vector<int> {17, 14, 9}));
+    EXPECT_TRUE((tri_pos[67] == std::vector<int> {18, 10, 9}));
+    EXPECT_TRUE((tri_pos[68] == std::vector<int> {18, 11, 9}));
+    EXPECT_TRUE((tri_pos[69] == std::vector<int> {18, 12, 9}));
+    EXPECT_TRUE((tri_pos[70] == std::vector<int> {18, 13, 9}));
+    EXPECT_TRUE((tri_pos[71] == std::vector<int> {19, 10, 9}));
+    EXPECT_TRUE((tri_pos[72] == std::vector<int> {19, 11, 9}));
+    EXPECT_TRUE((tri_pos[73] == std::vector<int> {19, 12, 9}));
+    EXPECT_TRUE((tri_pos[74] == std::vector<int> {20, 10, 9}));
+    EXPECT_TRUE((tri_pos[75] == std::vector<int> {20, 11, 9}));
 
     // -- Testing that the input order does not influence the results (2) --
     tri_pos = soil_simulator::CalcTrianglePos(c, a, b, grid, tol);
@@ -1210,82 +1210,82 @@ TEST(UnitTestBucketPos, CalcTrianglePos) {
     // Checking the number of cells
     EXPECT_EQ(tri_pos.size(), 76);
     // Checking cells
-    EXPECT_TRUE((tri_pos[0] == std::vector<int> {10, 10, 10}));
-    EXPECT_TRUE((tri_pos[1] == std::vector<int> {10, 11, 10}));
-    EXPECT_TRUE((tri_pos[2] == std::vector<int> {10, 12, 10}));
-    EXPECT_TRUE((tri_pos[3] == std::vector<int> {10, 13, 10}));
-    EXPECT_TRUE((tri_pos[4] == std::vector<int> {10, 14, 10}));
-    EXPECT_TRUE((tri_pos[5] == std::vector<int> {10, 15, 10}));
-    EXPECT_TRUE((tri_pos[6] == std::vector<int> {10, 16, 10}));
-    EXPECT_TRUE((tri_pos[7] == std::vector<int> {10, 17, 10}));
-    EXPECT_TRUE((tri_pos[8] == std::vector<int> {10, 18, 10}));
-    EXPECT_TRUE((tri_pos[9] == std::vector<int> {10, 19, 10}));
-    EXPECT_TRUE((tri_pos[10] == std::vector<int> {10, 20, 10}));
-    EXPECT_TRUE((tri_pos[11] == std::vector<int> {11, 10, 10}));
-    EXPECT_TRUE((tri_pos[12] == std::vector<int> {11, 11, 10}));
-    EXPECT_TRUE((tri_pos[13] == std::vector<int> {11, 12, 10}));
-    EXPECT_TRUE((tri_pos[14] == std::vector<int> {11, 13, 10}));
-    EXPECT_TRUE((tri_pos[15] == std::vector<int> {11, 14, 10}));
-    EXPECT_TRUE((tri_pos[16] == std::vector<int> {11, 15, 10}));
-    EXPECT_TRUE((tri_pos[17] == std::vector<int> {11, 16, 10}));
-    EXPECT_TRUE((tri_pos[18] == std::vector<int> {11, 17, 10}));
-    EXPECT_TRUE((tri_pos[19] == std::vector<int> {11, 18, 10}));
-    EXPECT_TRUE((tri_pos[20] == std::vector<int> {11, 19, 10}));
-    EXPECT_TRUE((tri_pos[21] == std::vector<int> {11, 20, 10}));
-    EXPECT_TRUE((tri_pos[22] == std::vector<int> {12, 10, 10}));
-    EXPECT_TRUE((tri_pos[23] == std::vector<int> {12, 11, 10}));
-    EXPECT_TRUE((tri_pos[24] == std::vector<int> {12, 12, 10}));
-    EXPECT_TRUE((tri_pos[25] == std::vector<int> {12, 13, 10}));
-    EXPECT_TRUE((tri_pos[26] == std::vector<int> {12, 14, 10}));
-    EXPECT_TRUE((tri_pos[27] == std::vector<int> {12, 15, 10}));
-    EXPECT_TRUE((tri_pos[28] == std::vector<int> {12, 16, 10}));
-    EXPECT_TRUE((tri_pos[29] == std::vector<int> {12, 17, 10}));
-    EXPECT_TRUE((tri_pos[30] == std::vector<int> {12, 18, 10}));
-    EXPECT_TRUE((tri_pos[31] == std::vector<int> {12, 19, 10}));
-    EXPECT_TRUE((tri_pos[32] == std::vector<int> {13, 10, 10}));
-    EXPECT_TRUE((tri_pos[33] == std::vector<int> {13, 11, 10}));
-    EXPECT_TRUE((tri_pos[34] == std::vector<int> {13, 12, 10}));
-    EXPECT_TRUE((tri_pos[35] == std::vector<int> {13, 13, 10}));
-    EXPECT_TRUE((tri_pos[36] == std::vector<int> {13, 14, 10}));
-    EXPECT_TRUE((tri_pos[37] == std::vector<int> {13, 15, 10}));
-    EXPECT_TRUE((tri_pos[38] == std::vector<int> {13, 16, 10}));
-    EXPECT_TRUE((tri_pos[39] == std::vector<int> {13, 17, 10}));
-    EXPECT_TRUE((tri_pos[40] == std::vector<int> {13, 18, 10}));
-    EXPECT_TRUE((tri_pos[41] == std::vector<int> {14, 10, 10}));
-    EXPECT_TRUE((tri_pos[42] == std::vector<int> {14, 11, 10}));
-    EXPECT_TRUE((tri_pos[43] == std::vector<int> {14, 12, 10}));
-    EXPECT_TRUE((tri_pos[44] == std::vector<int> {14, 13, 10}));
-    EXPECT_TRUE((tri_pos[45] == std::vector<int> {14, 14, 10}));
-    EXPECT_TRUE((tri_pos[46] == std::vector<int> {14, 15, 10}));
-    EXPECT_TRUE((tri_pos[47] == std::vector<int> {14, 16, 10}));
-    EXPECT_TRUE((tri_pos[48] == std::vector<int> {14, 17, 10}));
-    EXPECT_TRUE((tri_pos[49] == std::vector<int> {15, 10, 10}));
-    EXPECT_TRUE((tri_pos[50] == std::vector<int> {15, 11, 10}));
-    EXPECT_TRUE((tri_pos[51] == std::vector<int> {15, 12, 10}));
-    EXPECT_TRUE((tri_pos[52] == std::vector<int> {15, 13, 10}));
-    EXPECT_TRUE((tri_pos[53] == std::vector<int> {15, 14, 10}));
-    EXPECT_TRUE((tri_pos[54] == std::vector<int> {15, 15, 10}));
-    EXPECT_TRUE((tri_pos[55] == std::vector<int> {15, 16, 10}));
-    EXPECT_TRUE((tri_pos[56] == std::vector<int> {16, 10, 10}));
-    EXPECT_TRUE((tri_pos[57] == std::vector<int> {16, 11, 10}));
-    EXPECT_TRUE((tri_pos[58] == std::vector<int> {16, 12, 10}));
-    EXPECT_TRUE((tri_pos[59] == std::vector<int> {16, 13, 10}));
-    EXPECT_TRUE((tri_pos[60] == std::vector<int> {16, 14, 10}));
-    EXPECT_TRUE((tri_pos[61] == std::vector<int> {16, 15, 10}));
-    EXPECT_TRUE((tri_pos[62] == std::vector<int> {17, 10, 10}));
-    EXPECT_TRUE((tri_pos[63] == std::vector<int> {17, 11, 10}));
-    EXPECT_TRUE((tri_pos[64] == std::vector<int> {17, 12, 10}));
-    EXPECT_TRUE((tri_pos[65] == std::vector<int> {17, 13, 10}));
-    EXPECT_TRUE((tri_pos[66] == std::vector<int> {17, 14, 10}));
-    EXPECT_TRUE((tri_pos[67] == std::vector<int> {18, 10, 10}));
-    EXPECT_TRUE((tri_pos[68] == std::vector<int> {18, 11, 10}));
-    EXPECT_TRUE((tri_pos[69] == std::vector<int> {18, 12, 10}));
-    EXPECT_TRUE((tri_pos[70] == std::vector<int> {18, 13, 10}));
-    EXPECT_TRUE((tri_pos[71] == std::vector<int> {19, 10, 10}));
-    EXPECT_TRUE((tri_pos[72] == std::vector<int> {19, 11, 10}));
-    EXPECT_TRUE((tri_pos[73] == std::vector<int> {19, 12, 10}));
-    EXPECT_TRUE((tri_pos[74] == std::vector<int> {20, 10, 10}));
-    EXPECT_TRUE((tri_pos[75] == std::vector<int> {20, 11, 10}));
+    EXPECT_TRUE((tri_pos[0] == std::vector<int> {10, 10, 9}));
+    EXPECT_TRUE((tri_pos[1] == std::vector<int> {10, 11, 9}));
+    EXPECT_TRUE((tri_pos[2] == std::vector<int> {10, 12, 9}));
+    EXPECT_TRUE((tri_pos[3] == std::vector<int> {10, 13, 9}));
+    EXPECT_TRUE((tri_pos[4] == std::vector<int> {10, 14, 9}));
+    EXPECT_TRUE((tri_pos[5] == std::vector<int> {10, 15, 9}));
+    EXPECT_TRUE((tri_pos[6] == std::vector<int> {10, 16, 9}));
+    EXPECT_TRUE((tri_pos[7] == std::vector<int> {10, 17, 9}));
+    EXPECT_TRUE((tri_pos[8] == std::vector<int> {10, 18, 9}));
+    EXPECT_TRUE((tri_pos[9] == std::vector<int> {10, 19, 9}));
+    EXPECT_TRUE((tri_pos[10] == std::vector<int> {10, 20, 9}));
+    EXPECT_TRUE((tri_pos[11] == std::vector<int> {11, 10, 9}));
+    EXPECT_TRUE((tri_pos[12] == std::vector<int> {11, 11, 9}));
+    EXPECT_TRUE((tri_pos[13] == std::vector<int> {11, 12, 9}));
+    EXPECT_TRUE((tri_pos[14] == std::vector<int> {11, 13, 9}));
+    EXPECT_TRUE((tri_pos[15] == std::vector<int> {11, 14, 9}));
+    EXPECT_TRUE((tri_pos[16] == std::vector<int> {11, 15, 9}));
+    EXPECT_TRUE((tri_pos[17] == std::vector<int> {11, 16, 9}));
+    EXPECT_TRUE((tri_pos[18] == std::vector<int> {11, 17, 9}));
+    EXPECT_TRUE((tri_pos[19] == std::vector<int> {11, 18, 9}));
+    EXPECT_TRUE((tri_pos[20] == std::vector<int> {11, 19, 9}));
+    EXPECT_TRUE((tri_pos[21] == std::vector<int> {11, 20, 9}));
+    EXPECT_TRUE((tri_pos[22] == std::vector<int> {12, 10, 9}));
+    EXPECT_TRUE((tri_pos[23] == std::vector<int> {12, 11, 9}));
+    EXPECT_TRUE((tri_pos[24] == std::vector<int> {12, 12, 9}));
+    EXPECT_TRUE((tri_pos[25] == std::vector<int> {12, 13, 9}));
+    EXPECT_TRUE((tri_pos[26] == std::vector<int> {12, 14, 9}));
+    EXPECT_TRUE((tri_pos[27] == std::vector<int> {12, 15, 9}));
+    EXPECT_TRUE((tri_pos[28] == std::vector<int> {12, 16, 9}));
+    EXPECT_TRUE((tri_pos[29] == std::vector<int> {12, 17, 9}));
+    EXPECT_TRUE((tri_pos[30] == std::vector<int> {12, 18, 9}));
+    EXPECT_TRUE((tri_pos[31] == std::vector<int> {12, 19, 9}));
+    EXPECT_TRUE((tri_pos[32] == std::vector<int> {13, 10, 9}));
+    EXPECT_TRUE((tri_pos[33] == std::vector<int> {13, 11, 9}));
+    EXPECT_TRUE((tri_pos[34] == std::vector<int> {13, 12, 9}));
+    EXPECT_TRUE((tri_pos[35] == std::vector<int> {13, 13, 9}));
+    EXPECT_TRUE((tri_pos[36] == std::vector<int> {13, 14, 9}));
+    EXPECT_TRUE((tri_pos[37] == std::vector<int> {13, 15, 9}));
+    EXPECT_TRUE((tri_pos[38] == std::vector<int> {13, 16, 9}));
+    EXPECT_TRUE((tri_pos[39] == std::vector<int> {13, 17, 9}));
+    EXPECT_TRUE((tri_pos[40] == std::vector<int> {13, 18, 9}));
+    EXPECT_TRUE((tri_pos[41] == std::vector<int> {14, 10, 9}));
+    EXPECT_TRUE((tri_pos[42] == std::vector<int> {14, 11, 9}));
+    EXPECT_TRUE((tri_pos[43] == std::vector<int> {14, 12, 9}));
+    EXPECT_TRUE((tri_pos[44] == std::vector<int> {14, 13, 9}));
+    EXPECT_TRUE((tri_pos[45] == std::vector<int> {14, 14, 9}));
+    EXPECT_TRUE((tri_pos[46] == std::vector<int> {14, 15, 9}));
+    EXPECT_TRUE((tri_pos[47] == std::vector<int> {14, 16, 9}));
+    EXPECT_TRUE((tri_pos[48] == std::vector<int> {14, 17, 9}));
+    EXPECT_TRUE((tri_pos[49] == std::vector<int> {15, 10, 9}));
+    EXPECT_TRUE((tri_pos[50] == std::vector<int> {15, 11, 9}));
+    EXPECT_TRUE((tri_pos[51] == std::vector<int> {15, 12, 9}));
+    EXPECT_TRUE((tri_pos[52] == std::vector<int> {15, 13, 9}));
+    EXPECT_TRUE((tri_pos[53] == std::vector<int> {15, 14, 9}));
+    EXPECT_TRUE((tri_pos[54] == std::vector<int> {15, 15, 9}));
+    EXPECT_TRUE((tri_pos[55] == std::vector<int> {15, 16, 9}));
+    EXPECT_TRUE((tri_pos[56] == std::vector<int> {16, 10, 9}));
+    EXPECT_TRUE((tri_pos[57] == std::vector<int> {16, 11, 9}));
+    EXPECT_TRUE((tri_pos[58] == std::vector<int> {16, 12, 9}));
+    EXPECT_TRUE((tri_pos[59] == std::vector<int> {16, 13, 9}));
+    EXPECT_TRUE((tri_pos[60] == std::vector<int> {16, 14, 9}));
+    EXPECT_TRUE((tri_pos[61] == std::vector<int> {16, 15, 9}));
+    EXPECT_TRUE((tri_pos[62] == std::vector<int> {17, 10, 9}));
+    EXPECT_TRUE((tri_pos[63] == std::vector<int> {17, 11, 9}));
+    EXPECT_TRUE((tri_pos[64] == std::vector<int> {17, 12, 9}));
+    EXPECT_TRUE((tri_pos[65] == std::vector<int> {17, 13, 9}));
+    EXPECT_TRUE((tri_pos[66] == std::vector<int> {17, 14, 9}));
+    EXPECT_TRUE((tri_pos[67] == std::vector<int> {18, 10, 9}));
+    EXPECT_TRUE((tri_pos[68] == std::vector<int> {18, 11, 9}));
+    EXPECT_TRUE((tri_pos[69] == std::vector<int> {18, 12, 9}));
+    EXPECT_TRUE((tri_pos[70] == std::vector<int> {18, 13, 9}));
+    EXPECT_TRUE((tri_pos[71] == std::vector<int> {19, 10, 9}));
+    EXPECT_TRUE((tri_pos[72] == std::vector<int> {19, 11, 9}));
+    EXPECT_TRUE((tri_pos[73] == std::vector<int> {19, 12, 9}));
+    EXPECT_TRUE((tri_pos[74] == std::vector<int> {20, 10, 9}));
+    EXPECT_TRUE((tri_pos[75] == std::vector<int> {20, 11, 9}));
 
     // -- Testing that the input order does not influence the results (3) --
     tri_pos = soil_simulator::CalcTrianglePos(a, c, b, grid, tol);
@@ -1314,43 +1314,43 @@ TEST(UnitTestBucketPos, CalcTrianglePos) {
     // Checking the number of cells
     EXPECT_EQ(tri_pos.size(), 37);
     // Checking cells
-    EXPECT_TRUE((tri_pos[0] == std::vector<int> {10, 10, 11}));
-    EXPECT_TRUE((tri_pos[1] == std::vector<int> {10, 10, 12}));
-    EXPECT_TRUE((tri_pos[2] == std::vector<int> {10, 10, 13}));
-    EXPECT_TRUE((tri_pos[3] == std::vector<int> {10, 10, 14}));
-    EXPECT_TRUE((tri_pos[4] == std::vector<int> {10, 10, 15}));
-    EXPECT_TRUE((tri_pos[5] == std::vector<int> {10, 10, 16}));
-    EXPECT_TRUE((tri_pos[6] == std::vector<int> {10, 10, 17}));
-    EXPECT_TRUE((tri_pos[7] == std::vector<int> {10, 10, 18}));
-    EXPECT_TRUE((tri_pos[8] == std::vector<int> {10, 10, 19}));
-    EXPECT_TRUE((tri_pos[9] == std::vector<int> {10, 10, 20}));
-    EXPECT_TRUE((tri_pos[10] == std::vector<int> {11, 10, 11}));
-    EXPECT_TRUE((tri_pos[11] == std::vector<int> {11, 10, 19}));
-    EXPECT_TRUE((tri_pos[12] == std::vector<int> {11, 10, 20}));
-    EXPECT_TRUE((tri_pos[13] == std::vector<int> {12, 10, 11}));
-    EXPECT_TRUE((tri_pos[14] == std::vector<int> {12, 10, 18}));
-    EXPECT_TRUE((tri_pos[15] == std::vector<int> {12, 10, 19}));
-    EXPECT_TRUE((tri_pos[16] == std::vector<int> {13, 10, 11}));
-    EXPECT_TRUE((tri_pos[17] == std::vector<int> {13, 10, 17}));
-    EXPECT_TRUE((tri_pos[18] == std::vector<int> {13, 10, 18}));
-    EXPECT_TRUE((tri_pos[19] == std::vector<int> {14, 10, 11}));
-    EXPECT_TRUE((tri_pos[20] == std::vector<int> {14, 10, 16}));
-    EXPECT_TRUE((tri_pos[21] == std::vector<int> {14, 10, 17}));
-    EXPECT_TRUE((tri_pos[22] == std::vector<int> {15, 10, 11}));
-    EXPECT_TRUE((tri_pos[23] == std::vector<int> {15, 10, 15}));
-    EXPECT_TRUE((tri_pos[24] == std::vector<int> {15, 10, 16}));
-    EXPECT_TRUE((tri_pos[25] == std::vector<int> {16, 10, 11}));
-    EXPECT_TRUE((tri_pos[26] == std::vector<int> {16, 10, 14}));
-    EXPECT_TRUE((tri_pos[27] == std::vector<int> {16, 10, 15}));
-    EXPECT_TRUE((tri_pos[28] == std::vector<int> {17, 10, 11}));
-    EXPECT_TRUE((tri_pos[29] == std::vector<int> {17, 10, 13}));
-    EXPECT_TRUE((tri_pos[30] == std::vector<int> {17, 10, 14}));
-    EXPECT_TRUE((tri_pos[31] == std::vector<int> {18, 10, 11}));
-    EXPECT_TRUE((tri_pos[32] == std::vector<int> {18, 10, 12}));
-    EXPECT_TRUE((tri_pos[33] == std::vector<int> {18, 10, 13}));
-    EXPECT_TRUE((tri_pos[34] == std::vector<int> {19, 10, 11}));
-    EXPECT_TRUE((tri_pos[35] == std::vector<int> {19, 10, 12}));
-    EXPECT_TRUE((tri_pos[36] == std::vector<int> {20, 10, 11}));
+    EXPECT_TRUE((tri_pos[0] == std::vector<int> {10, 10, 10}));
+    EXPECT_TRUE((tri_pos[1] == std::vector<int> {10, 10, 11}));
+    EXPECT_TRUE((tri_pos[2] == std::vector<int> {10, 10, 12}));
+    EXPECT_TRUE((tri_pos[3] == std::vector<int> {10, 10, 13}));
+    EXPECT_TRUE((tri_pos[4] == std::vector<int> {10, 10, 14}));
+    EXPECT_TRUE((tri_pos[5] == std::vector<int> {10, 10, 15}));
+    EXPECT_TRUE((tri_pos[6] == std::vector<int> {10, 10, 16}));
+    EXPECT_TRUE((tri_pos[7] == std::vector<int> {10, 10, 17}));
+    EXPECT_TRUE((tri_pos[8] == std::vector<int> {10, 10, 18}));
+    EXPECT_TRUE((tri_pos[9] == std::vector<int> {10, 10, 19}));
+    EXPECT_TRUE((tri_pos[10] == std::vector<int> {11, 10, 10}));
+    EXPECT_TRUE((tri_pos[11] == std::vector<int> {11, 10, 18}));
+    EXPECT_TRUE((tri_pos[12] == std::vector<int> {11, 10, 19}));
+    EXPECT_TRUE((tri_pos[13] == std::vector<int> {12, 10, 10}));
+    EXPECT_TRUE((tri_pos[14] == std::vector<int> {12, 10, 17}));
+    EXPECT_TRUE((tri_pos[15] == std::vector<int> {12, 10, 18}));
+    EXPECT_TRUE((tri_pos[16] == std::vector<int> {13, 10, 10}));
+    EXPECT_TRUE((tri_pos[17] == std::vector<int> {13, 10, 16}));
+    EXPECT_TRUE((tri_pos[18] == std::vector<int> {13, 10, 17}));
+    EXPECT_TRUE((tri_pos[19] == std::vector<int> {14, 10, 10}));
+    EXPECT_TRUE((tri_pos[20] == std::vector<int> {14, 10, 15}));
+    EXPECT_TRUE((tri_pos[21] == std::vector<int> {14, 10, 16}));
+    EXPECT_TRUE((tri_pos[22] == std::vector<int> {15, 10, 10}));
+    EXPECT_TRUE((tri_pos[23] == std::vector<int> {15, 10, 14}));
+    EXPECT_TRUE((tri_pos[24] == std::vector<int> {15, 10, 15}));
+    EXPECT_TRUE((tri_pos[25] == std::vector<int> {16, 10, 10}));
+    EXPECT_TRUE((tri_pos[26] == std::vector<int> {16, 10, 13}));
+    EXPECT_TRUE((tri_pos[27] == std::vector<int> {16, 10, 14}));
+    EXPECT_TRUE((tri_pos[28] == std::vector<int> {17, 10, 10}));
+    EXPECT_TRUE((tri_pos[29] == std::vector<int> {17, 10, 12}));
+    EXPECT_TRUE((tri_pos[30] == std::vector<int> {17, 10, 13}));
+    EXPECT_TRUE((tri_pos[31] == std::vector<int> {18, 10, 10}));
+    EXPECT_TRUE((tri_pos[32] == std::vector<int> {18, 10, 11}));
+    EXPECT_TRUE((tri_pos[33] == std::vector<int> {18, 10, 12}));
+    EXPECT_TRUE((tri_pos[34] == std::vector<int> {19, 10, 10}));
+    EXPECT_TRUE((tri_pos[35] == std::vector<int> {19, 10, 11}));
+    EXPECT_TRUE((tri_pos[36] == std::vector<int> {20, 10, 10}));
 
     // -- Testing that the input order does not influence the results --
     tri_pos = soil_simulator::CalcTrianglePos(b, a, c, grid, tol);
@@ -1389,16 +1389,16 @@ TEST(UnitTestBucketPos, CalcTrianglePos) {
     // Checking the number of cells
     EXPECT_EQ(tri_pos.size(), 10);
     // Checking cells
-    EXPECT_TRUE((tri_pos[0] == std::vector<int> {15, 10, 16}));
-    EXPECT_TRUE((tri_pos[1] == std::vector<int> {15, 11, 16}));
-    EXPECT_TRUE((tri_pos[2] == std::vector<int> {15, 12, 16}));
-    EXPECT_TRUE((tri_pos[3] == std::vector<int> {15, 13, 16}));
-    EXPECT_TRUE((tri_pos[4] == std::vector<int> {16, 10, 16}));
-    EXPECT_TRUE((tri_pos[5] == std::vector<int> {16, 11, 16}));
-    EXPECT_TRUE((tri_pos[6] == std::vector<int> {16, 12, 16}));
-    EXPECT_TRUE((tri_pos[7] == std::vector<int> {16, 13, 16}));
-    EXPECT_TRUE((tri_pos[8] == std::vector<int> {16, 14, 16}));
-    EXPECT_TRUE((tri_pos[9] == std::vector<int> {16, 15, 16}));
+    EXPECT_TRUE((tri_pos[0] == std::vector<int> {15, 10, 15}));
+    EXPECT_TRUE((tri_pos[1] == std::vector<int> {15, 11, 15}));
+    EXPECT_TRUE((tri_pos[2] == std::vector<int> {15, 12, 15}));
+    EXPECT_TRUE((tri_pos[3] == std::vector<int> {15, 13, 15}));
+    EXPECT_TRUE((tri_pos[4] == std::vector<int> {16, 10, 15}));
+    EXPECT_TRUE((tri_pos[5] == std::vector<int> {16, 11, 15}));
+    EXPECT_TRUE((tri_pos[6] == std::vector<int> {16, 12, 15}));
+    EXPECT_TRUE((tri_pos[7] == std::vector<int> {16, 13, 15}));
+    EXPECT_TRUE((tri_pos[8] == std::vector<int> {16, 14, 15}));
+    EXPECT_TRUE((tri_pos[9] == std::vector<int> {16, 15, 15}));
 
     // -- Testing that the input order does not influence the results --
     tri_pos = soil_simulator::CalcTrianglePos(b, a, c, grid, tol);
@@ -1437,15 +1437,15 @@ TEST(UnitTestBucketPos, CalcTrianglePos) {
     // Checking the number of cells
     EXPECT_EQ(tri_pos.size(), 9);
     // Checking cells
-    EXPECT_TRUE((tri_pos[0] == std::vector<int> {13, 16, 10}));
-    EXPECT_TRUE((tri_pos[1] == std::vector<int> {14, 16, 10}));
-    EXPECT_TRUE((tri_pos[2] == std::vector<int> {14, 17, 10}));
-    EXPECT_TRUE((tri_pos[3] == std::vector<int> {15, 17, 10}));
-    EXPECT_TRUE((tri_pos[4] == std::vector<int> {15, 18, 10}));
-    EXPECT_TRUE((tri_pos[5] == std::vector<int> {16, 18, 10}));
-    EXPECT_TRUE((tri_pos[6] == std::vector<int> {16, 19, 10}));
-    EXPECT_TRUE((tri_pos[7] == std::vector<int> {17, 19, 10}));
-    EXPECT_TRUE((tri_pos[8] == std::vector<int> {17, 20, 10}));
+    EXPECT_TRUE((tri_pos[0] == std::vector<int> {13, 16, 9}));
+    EXPECT_TRUE((tri_pos[1] == std::vector<int> {14, 16, 9}));
+    EXPECT_TRUE((tri_pos[2] == std::vector<int> {14, 17, 9}));
+    EXPECT_TRUE((tri_pos[3] == std::vector<int> {15, 17, 9}));
+    EXPECT_TRUE((tri_pos[4] == std::vector<int> {15, 18, 9}));
+    EXPECT_TRUE((tri_pos[5] == std::vector<int> {16, 18, 9}));
+    EXPECT_TRUE((tri_pos[6] == std::vector<int> {16, 19, 9}));
+    EXPECT_TRUE((tri_pos[7] == std::vector<int> {17, 19, 9}));
+    EXPECT_TRUE((tri_pos[8] == std::vector<int> {17, 20, 9}));
 
     // -- Testing for the edge case where the triangle is a point --
     a = {0.5 - 1e-5, 0.5 - 1e-5, 0.5 - 1e-5};
@@ -1457,7 +1457,7 @@ TEST(UnitTestBucketPos, CalcTrianglePos) {
     // Checking the number of cells
     EXPECT_EQ(tri_pos.size(), 1);
     // Checking cells
-    EXPECT_TRUE((tri_pos[0] == std::vector<int> {15, 15, 15}));
+    EXPECT_TRUE((tri_pos[0] == std::vector<int> {15, 15, 14}));
 }
 
 TEST(UnitTestBucketPos, IncludeNewBodyPos) {
@@ -1579,15 +1579,15 @@ TEST(UnitTestBucketPos, UpdateBody) {
 
     // -- Testing for a first bucket wall --
     std::vector<std::vector<int>> area_pos(9);
-    area_pos[0] = std::vector<int> {5, 5, 10};
-    area_pos[1] = std::vector<int> {5, 5, 14};
-    area_pos[2] = std::vector<int> {6, 6, 16};
-    area_pos[3] = std::vector<int> {7, 11, 10};
-    area_pos[4] = std::vector<int> {7, 11, 11};
-    area_pos[5] = std::vector<int> {7, 12, 11};
-    area_pos[6] = std::vector<int> {7, 12, 12};
-    area_pos[7] = std::vector<int> {7, 13, 10};
-    area_pos[8] = std::vector<int> {10, 10, 10};
+    area_pos[0] = std::vector<int> {5, 5, 9};
+    area_pos[1] = std::vector<int> {5, 5, 13};
+    area_pos[2] = std::vector<int> {6, 6, 15};
+    area_pos[3] = std::vector<int> {7, 11, 9};
+    area_pos[4] = std::vector<int> {7, 11, 10};
+    area_pos[5] = std::vector<int> {7, 12, 10};
+    area_pos[6] = std::vector<int> {7, 12, 11};
+    area_pos[7] = std::vector<int> {7, 13, 9};
+    area_pos[8] = std::vector<int> {10, 10, 9};
     soil_simulator::UpdateBody(area_pos, sim_out, grid, 1e-5);
     EXPECT_NEAR(sim_out->body_[0][5][5], -0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_[1][5][5], 0.4, 1.e-5);
@@ -1604,16 +1604,16 @@ TEST(UnitTestBucketPos, UpdateBody) {
 
     // -- Testing for a second bucket wall --
     std::vector<std::vector<int>> area_pos_2(10);
-    area_pos_2[0] = std::vector<int> {4, 4, 10};
-    area_pos_2[1] = std::vector<int> {5, 5, 14};
-    area_pos_2[2] = std::vector<int> {6, 6, 9};
-    area_pos_2[3] = std::vector<int> {7, 11, 11};
-    area_pos_2[4] = std::vector<int> {7, 11, 14};
-    area_pos_2[5] = std::vector<int> {7, 12, 8};
-    area_pos_2[6] = std::vector<int> {7, 12, 11};
-    area_pos_2[7] = std::vector<int> {7, 13, 8};
-    area_pos_2[8] = std::vector<int> {7, 13, 13};
-    area_pos_2[9] = std::vector<int> {10, 10, 12};
+    area_pos_2[0] = std::vector<int> {4, 4, 9};
+    area_pos_2[1] = std::vector<int> {5, 5, 13};
+    area_pos_2[2] = std::vector<int> {6, 6, 8};
+    area_pos_2[3] = std::vector<int> {7, 11, 10};
+    area_pos_2[4] = std::vector<int> {7, 11, 13};
+    area_pos_2[5] = std::vector<int> {7, 12, 7};
+    area_pos_2[6] = std::vector<int> {7, 12, 10};
+    area_pos_2[7] = std::vector<int> {7, 13, 7};
+    area_pos_2[8] = std::vector<int> {7, 13, 12};
+    area_pos_2[9] = std::vector<int> {10, 10, 11};
     soil_simulator::UpdateBody(area_pos_2, sim_out, grid, 1e-5);
     EXPECT_NEAR(sim_out->body_[0][4][4], -0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_[1][4][4], 0.0, 1.e-5);
@@ -1636,8 +1636,8 @@ TEST(UnitTestBucketPos, UpdateBody) {
 
     // -- Testing for a third bucket wall --
     std::vector<std::vector<int>> area_pos_3(2);
-    area_pos_3[0] = std::vector<int> {6, 6, 7};
-    area_pos_3[1] = std::vector<int> {6, 6, 18};
+    area_pos_3[0] = std::vector<int> {6, 6, 6};
+    area_pos_3[1] = std::vector<int> {6, 6, 17};
     soil_simulator::UpdateBody(area_pos_3, sim_out, grid, 1e-5);
     EXPECT_NEAR(sim_out->body_[0][6][6], -0.4, 1.e-5);
     EXPECT_NEAR(sim_out->body_[1][6][6], 0.8, 1.e-5);
@@ -1646,7 +1646,7 @@ TEST(UnitTestBucketPos, UpdateBody) {
 
     // -- Testing that incorrect request throws an error --
     std::vector<std::vector<int>> area_pos_4(1);
-    area_pos_4[0] = std::vector<int> {10, 10, 14};
+    area_pos_4[0] = std::vector<int> {10, 10, 13};
     EXPECT_THROW(
         soil_simulator::UpdateBody(area_pos_4, sim_out, grid, 1e-5),
         std::runtime_error);

--- a/test/unit_tests/test_types.cpp
+++ b/test/unit_tests/test_types.cpp
@@ -25,7 +25,7 @@ TEST(UnitTestTypes, Grid) {
     for (auto ii = 0 ; ii < grid.vect_y_.size() ; ii++)
         EXPECT_NEAR(grid.vect_y_[ii], -4.0 + ii * 0.05, 1e-5);
     for (auto ii = 0 ; ii < grid.vect_z_.size() ; ii++)
-        EXPECT_NEAR(grid.vect_z_[ii], -4.0 + ii * 0.01, 1e-5);
+        EXPECT_NEAR(grid.vect_z_[ii], -4.0 + (ii + 1) * 0.01, 1e-5);
 
     // -- Testing that exceptions are properly sent --
     EXPECT_THROW(


### PR DESCRIPTION
# Description
- Fixed issue that vertical height start below the grid => lower all z index by one
- Fixed issue when three bucket layers are detected

# Note
The presence of three bucket layers seems to not be a bug but expected considering the current implementation.
The issue is that a cell is considered as a bucket cell even if only a tiny part of the bucket is included. So for some specific inclination of the bucket, it may cause issue close to a vertex, in particular close to the teeth when the bucket is almost vertical.
The new implementation has been tested with MuJoCo, and the results show that every time there are three bucket layers, there is a maximum gap between two bucket layer of 1.5 the maximum cell size, which is fairly low.