### PR TITLE
Refactor unit tests: Add utility function to reset outputs (1)

### DIFF
--- a/test/unit_tests/CMakeLists.txt
+++ b/test/unit_tests/CMakeLists.txt
@@ -17,6 +17,8 @@ target_sources(unit_tests
         ${CMAKE_CURRENT_SOURCE_DIR}/test_body_soil.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test_intersecting_cells.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test_relax.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/utility.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/utility.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../../soil_simulator/soil_dynamics.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../../soil_simulator/types.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../../soil_simulator/types.hpp

--- a/test/unit_tests/test_body_soil.cpp
+++ b/test/unit_tests/test_body_soil.cpp
@@ -5,6 +5,7 @@ Copyright, 2023, Vilella Kenny.
 */
 #include "gtest/gtest.h"
 #include "soil_simulator/body_soil.hpp"
+#include "test/unit_tests/utility.hpp"
 
 TEST(UnitTestBodySoil, UpdateBodySoil) {
     // Setting up the environment
@@ -42,22 +43,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
-    sim_out->body_[0][11][10] = 0.0;
-    sim_out->body_[1][11][10] = 0.0;
-    sim_out->body_soil_[0][11][10] = 0.0;
-    sim_out->body_soil_[1][11][10] = 0.0;
-    // Checking that everything is resetted
-    for (auto ii = 0; ii < sim_out->body_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->body_[0].size(); jj++)
-            for (auto kk = 0; kk < sim_out->body_[0][0].size(); kk++) {
-                EXPECT_NEAR(sim_out->body_[ii][jj][kk], 0.0, 1.e-5);
-                EXPECT_NEAR(sim_out->body_soil_[ii][jj][kk], 0.0, 1.e-5);
-            }
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1.e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 11, 10}}, {{0, 11, 10}});
 
     // -- Testing for a simple lateral translation (2) --
     pos = std::vector<float> {grid.cell_size_xy_, 0.0, 0.0};
@@ -82,22 +69,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
-    sim_out->body_[0][11][10] = 0.0;
-    sim_out->body_[1][11][10] = 0.0;
-    sim_out->body_soil_[0][11][10] = 0.0;
-    sim_out->body_soil_[1][11][10] = 0.0;
-    // Checking that everything is resetted
-    for (auto ii = 0; ii < sim_out->body_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->body_[0].size(); jj++)
-            for (auto kk = 0; kk < sim_out->body_[0][0].size(); kk++) {
-                EXPECT_NEAR(sim_out->body_[ii][jj][kk], 0.0, 1.e-5);
-                EXPECT_NEAR(sim_out->body_soil_[ii][jj][kk], 0.0, 1.e-5);
-            }
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1.e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 11, 10}}, {{0, 11, 10}});
 
     // -- Testing for a simple lateral translation (3) --
     pos = std::vector<float> {grid.cell_size_xy_, 0.0, 0.0};
@@ -122,22 +95,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
-    sim_out->body_[2][11][10] = 0.0;
-    sim_out->body_[3][11][10] = 0.0;
-    sim_out->body_soil_[2][11][10] = 0.0;
-    sim_out->body_soil_[3][11][10] = 0.0;
-    // Checking that everything is resetted
-    for (auto ii = 0; ii < sim_out->body_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->body_[0].size(); jj++)
-            for (auto kk = 0; kk < sim_out->body_[0][0].size(); kk++) {
-                EXPECT_NEAR(sim_out->body_[ii][jj][kk], 0.0, 1.e-5);
-                EXPECT_NEAR(sim_out->body_soil_[ii][jj][kk], 0.0, 1.e-5);
-            }
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1.e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{2, 11, 10}}, {{2, 11, 10}});
 
     // -- Testing for a simple lateral translation (4) --
     pos = std::vector<float> {grid.cell_size_xy_, 0.0, 0.0};
@@ -162,22 +121,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
-    sim_out->body_[2][11][10] = 0.0;
-    sim_out->body_[3][11][10] = 0.0;
-    sim_out->body_soil_[2][11][10] = 0.0;
-    sim_out->body_soil_[3][11][10] = 0.0;
-    // Checking that everything is resetted
-    for (auto ii = 0; ii < sim_out->body_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->body_[0].size(); jj++)
-            for (auto kk = 0; kk < sim_out->body_[0][0].size(); kk++) {
-                EXPECT_NEAR(sim_out->body_[ii][jj][kk], 0.0, 1.e-5);
-                EXPECT_NEAR(sim_out->body_soil_[ii][jj][kk], 0.0, 1.e-5);
-            }
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1.e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{2, 11, 10}}, {{2, 11, 10}});
 
     // -- Testing for a simple rotation from (11, 10) to (10, 11) --
     pos = std::vector<float> {0.0, 0.0, 0.0};
@@ -202,22 +147,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
-    sim_out->body_[0][10][11] = 0.0;
-    sim_out->body_[1][10][11] = 0.0;
-    sim_out->body_soil_[0][10][11] = 0.0;
-    sim_out->body_soil_[1][10][11] = 0.0;
-    // Checking that everything is resetted
-    for (auto ii = 0; ii < sim_out->body_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->body_[0].size(); jj++)
-            for (auto kk = 0; kk < sim_out->body_[0][0].size(); kk++) {
-                EXPECT_NEAR(sim_out->body_[ii][jj][kk], 0.0, 1.e-5);
-                EXPECT_NEAR(sim_out->body_soil_[ii][jj][kk], 0.0, 1.e-5);
-            }
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1.e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 10, 11}}, {{0, 10, 11}});
 
     // -- Testing for a simple rotation from (11, 10) to (11, 11) --
     pos = std::vector<float> {0.0, 0.0, 0.0};
@@ -242,22 +173,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
-    sim_out->body_[0][11][11] = 0.0;
-    sim_out->body_[1][11][11] = 0.0;
-    sim_out->body_soil_[0][11][11] = 0.0;
-    sim_out->body_soil_[1][11][11] = 0.0;
-    // Checking that everything is resetted
-    for (auto ii = 0; ii < sim_out->body_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->body_[0].size(); jj++)
-            for (auto kk = 0; kk < sim_out->body_[0][0].size(); kk++) {
-                EXPECT_NEAR(sim_out->body_[ii][jj][kk], 0.0, 1.e-5);
-                EXPECT_NEAR(sim_out->body_soil_[ii][jj][kk], 0.0, 1.e-5);
-            }
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1.e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 11, 11}}, {{0, 11, 11}});
 
     // -- Testing for a rotation + translation from (11, 10) to (12, 11) --
     pos = std::vector<float> {grid.cell_size_xy_, 0.0, 0.0};
@@ -282,22 +199,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
-    sim_out->body_[0][12][11] = 0.0;
-    sim_out->body_[1][12][11] = 0.0;
-    sim_out->body_soil_[0][12][11] = 0.0;
-    sim_out->body_soil_[1][12][11] = 0.0;
-    // Checking that everything is resetted
-    for (auto ii = 0; ii < sim_out->body_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->body_[0].size(); jj++)
-            for (auto kk = 0; kk < sim_out->body_[0][0].size(); kk++) {
-                EXPECT_NEAR(sim_out->body_[ii][jj][kk], 0.0, 1.e-5);
-                EXPECT_NEAR(sim_out->body_soil_[ii][jj][kk], 0.0, 1.e-5);
-            }
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1.e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 12, 11}}, {{0, 12, 11}});
 
     // -- Testing for a large transformation --
     pos = std::vector<float> {0.0, 0.0, 0.0};
@@ -312,19 +215,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
-    sim_out->terrain_[9][10] = 0.0;
-    // Checking that everything is resetted
-    for (auto ii = 0; ii < sim_out->body_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->body_[0].size(); jj++)
-            for (auto kk = 0; kk < sim_out->body_[0][0].size(); kk++) {
-                EXPECT_NEAR(sim_out->body_[ii][jj][kk], 0.0, 1.e-5);
-                EXPECT_NEAR(sim_out->body_soil_[ii][jj][kk], 0.0, 1.e-5);
-            }
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1.e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{9, 10}}, {}, {});
 
     // -- Testing when two body_soil move to the same position (1) --
     pos = std::vector<float> {0.0, 0.0, 0.0};
@@ -360,22 +252,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
-    sim_out->body_[0][10][10] = 0.0;
-    sim_out->body_[1][10][10] = 0.0;
-    sim_out->body_soil_[0][10][10] = 0.0;
-    sim_out->body_soil_[1][10][10] = 0.0;
-    // Checking that everything is resetted
-    for (auto ii = 0; ii < sim_out->body_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->body_[0].size(); jj++)
-            for (auto kk = 0; kk < sim_out->body_[0][0].size(); kk++) {
-                EXPECT_NEAR(sim_out->body_[ii][jj][kk], 0.0, 1.e-5);
-                EXPECT_NEAR(sim_out->body_soil_[ii][jj][kk], 0.0, 1.e-5);
-            }
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1.e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 10, 10}}, {{0, 10, 10}});
 
     // -- Testing when two body_soil move to the same position (2) --
     pos = std::vector<float> {0.0, 0.0, 0.0};
@@ -411,22 +289,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
-    sim_out->body_[0][10][10] = 0.0;
-    sim_out->body_[1][10][10] = 0.0;
-    sim_out->body_soil_[0][10][10] = 0.0;
-    sim_out->body_soil_[1][10][10] = 0.0;
-    // Checking that everything is resetted
-    for (auto ii = 0; ii < sim_out->body_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->body_[0].size(); jj++)
-            for (auto kk = 0; kk < sim_out->body_[0][0].size(); kk++) {
-                EXPECT_NEAR(sim_out->body_[ii][jj][kk], 0.0, 1.e-5);
-                EXPECT_NEAR(sim_out->body_soil_[ii][jj][kk], 0.0, 1.e-5);
-            }
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1.e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 10, 10}}, {{0, 10, 10}});
 
     // -- Testing when two body_soil move to the same position (3) --
     pos = std::vector<float> {0.0, 0.0, 0.0};
@@ -462,22 +326,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
-    sim_out->body_[2][10][10] = 0.0;
-    sim_out->body_[3][10][10] = 0.0;
-    sim_out->body_soil_[2][10][10] = 0.0;
-    sim_out->body_soil_[3][10][10] = 0.0;
-    // Checking that everything is resetted
-    for (auto ii = 0; ii < sim_out->body_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->body_[0].size(); jj++)
-            for (auto kk = 0; kk < sim_out->body_[0][0].size(); kk++) {
-                EXPECT_NEAR(sim_out->body_[ii][jj][kk], 0.0, 1.e-5);
-                EXPECT_NEAR(sim_out->body_soil_[ii][jj][kk], 0.0, 1.e-5);
-            }
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1.e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{2, 10, 10}}, {{2, 10, 10}});
 
     // ---------------------------------------------------------------------- //
     // The tests below are specific to the current implementation and may     //
@@ -497,22 +347,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][10], 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 0);
     // Resetting values
-    sim_out->body_[0][10][10] = 0.0;
-    sim_out->body_[1][10][10] = 0.0;
-    sim_out->body_soil_[0][10][10] = 0.0;
-    sim_out->body_soil_[1][10][10] = 0.0;
-    // Checking that everything is resetted
-    for (auto ii = 0; ii < sim_out->body_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->body_[0].size(); jj++)
-            for (auto kk = 0; kk < sim_out->body_[0][0].size(); kk++) {
-                EXPECT_NEAR(sim_out->body_[ii][jj][kk], 0.0, 1.e-5);
-                EXPECT_NEAR(sim_out->body_soil_[ii][jj][kk], 0.0, 1.e-5);
-            }
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1.e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 10, 10}}, {{0, 10, 10}});
 
     // -- Testing that h_soil is properly rounded --
     sim_out->body_[0][10][10] = 0.0;
@@ -533,22 +369,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     // Resetting values
-    sim_out->body_[0][10][10] = 0.0;
-    sim_out->body_[1][10][10] = 0.0;
-    sim_out->body_soil_[0][10][10] = 0.0;
-    sim_out->body_soil_[1][10][10] = 0.0;
-    // Checking that everything is resetted
-    for (auto ii = 0; ii < sim_out->body_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->body_[0].size(); jj++)
-            for (auto kk = 0; kk < sim_out->body_[0][0].size(); kk++) {
-                EXPECT_NEAR(sim_out->body_[ii][jj][kk], 0.0, 1.e-5);
-                EXPECT_NEAR(sim_out->body_soil_[ii][jj][kk], 0.0, 1.e-5);
-            }
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1.e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 10, 10}}, {{0, 10, 10}});
 
     // -- Testing that order where directions are checked is correct (1) --
     pos = std::vector<float> {grid.cell_size_xy_, 0.01, 0.0};
@@ -706,27 +528,13 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 10);
     EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 9);
     // Resetting values
-    sim_out->body_soil_[0][10][9] = 0.0;
-    sim_out->body_soil_[1][10][9] = 0.0;
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
-    for (auto ii = 10; ii < 13; ii++)
-        for (auto jj = 9; jj < 12; jj++) {
-            sim_out->body_[0][ii][jj] = 0.0;
-            sim_out->body_[1][ii][jj] = 0.0;
-        }
-    // Checking that everything is resetted
-    for (auto ii = 0; ii < sim_out->body_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->body_[0].size(); jj++)
-            for (auto kk = 0; kk < sim_out->body_[0][0].size(); kk++) {
-                EXPECT_NEAR(sim_out->body_[ii][jj][kk], 0.0, 1.e-5);
-                EXPECT_NEAR(sim_out->body_soil_[ii][jj][kk], 0.0, 1.e-5);
-            }
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1.e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    std::vector<std::vector<int>> body_pos = {
+        {0, 10, 9}, {0, 10, 10}, {0, 10, 11}, {0, 11, 9}, {0, 11, 10},
+        {0, 11, 11}, {0, 12, 9}, {0, 12, 10}, {0, 12, 11}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, body_pos, {{0, 10, 9}});
 
     // -- Testing that order where directions are checked is correct (2) --
     pos = std::vector<float> {-0.01, -grid.cell_size_xy_, 0.0};
@@ -884,27 +692,13 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 11);
     EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 10);
     // Resetting values
-    sim_out->body_soil_[0][11][10] = 0.0;
-    sim_out->body_soil_[1][11][10] = 0.0;
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
-    for (auto ii = 9; ii < 12; ii++)
-        for (auto jj = 8; jj < 11; jj++) {
-            sim_out->body_[0][ii][jj] = 0.0;
-            sim_out->body_[1][ii][jj] = 0.0;
-        }
-    // Checking that everything is resetted
-    for (auto ii = 0; ii < sim_out->body_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->body_[0].size(); jj++)
-            for (auto kk = 0; kk < sim_out->body_[0][0].size(); kk++) {
-                EXPECT_NEAR(sim_out->body_[ii][jj][kk], 0.0, 1.e-5);
-                EXPECT_NEAR(sim_out->body_soil_[ii][jj][kk], 0.0, 1.e-5);
-            }
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1.e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    body_pos = {
+        {0, 9, 8}, {0, 9, 9}, {0, 9, 10}, {0, 10, 8}, {0, 10, 9},
+        {0, 10, 10}, {0, 11, 8}, {0, 11, 9}, {0, 11, 10}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, body_pos, {{0, 11, 10}});
 
     // -- Testing that soil is moved if close enough (1) --
     pos = std::vector<float> {grid.cell_size_xy_, 0.01, 0.0};
@@ -928,27 +722,13 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 10);
     EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 9);
     // Resetting values
-    sim_out->body_soil_[0][10][9] = 0.0;
-    sim_out->body_soil_[1][10][9] = 0.0;
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
-    for (auto ii = 10; ii < 13; ii++)
-        for (auto jj = 9; jj < 12; jj++) {
-            sim_out->body_[0][ii][jj] = 0.0;
-            sim_out->body_[1][ii][jj] = 0.0;
-        }
-    // Checking that everything is resetted
-    for (auto ii = 0; ii < sim_out->body_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->body_[0].size(); jj++)
-            for (auto kk = 0; kk < sim_out->body_[0][0].size(); kk++) {
-                EXPECT_NEAR(sim_out->body_[ii][jj][kk], 0.0, 1.e-5);
-                EXPECT_NEAR(sim_out->body_soil_[ii][jj][kk], 0.0, 1.e-5);
-            }
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1.e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    body_pos = {
+        {0, 10, 9}, {0, 10, 10}, {0, 10, 11}, {0, 11, 9}, {0, 11, 10},
+        {0, 11, 11}, {0, 12, 9}, {0, 12, 10}, {0, 12, 11}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, body_pos, {{0, 10, 9}});
 
     // -- Testing that soil is moved if close enough (2) --
     pos = std::vector<float> {grid.cell_size_xy_, 0.01, 0.0};
@@ -972,27 +752,13 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 11);
     EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 9);
     // Resetting values
-    sim_out->body_soil_[0][11][9] = 0.0;
-    sim_out->body_soil_[1][11][9] = 0.0;
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
-    for (auto ii = 10; ii < 13; ii++)
-        for (auto jj = 9; jj < 12; jj++) {
-            sim_out->body_[0][ii][jj] = 0.0;
-            sim_out->body_[1][ii][jj] = 0.0;
-        }
-    // Checking that everything is resetted
-    for (auto ii = 0; ii < sim_out->body_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->body_[0].size(); jj++)
-            for (auto kk = 0; kk < sim_out->body_[0][0].size(); kk++) {
-                EXPECT_NEAR(sim_out->body_[ii][jj][kk], 0.0, 1.e-5);
-                EXPECT_NEAR(sim_out->body_soil_[ii][jj][kk], 0.0, 1.e-5);
-            }
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1.e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    body_pos = {
+        {0, 10, 9}, {0, 10, 10}, {0, 10, 11}, {0, 11, 9}, {0, 11, 10},
+        {0, 11, 11}, {0, 12, 9}, {0, 12, 10}, {0, 12, 11}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, body_pos, {{0, 11, 9}});
 
     delete sim_out;
     delete bucket;

--- a/test/unit_tests/test_bucket_pos.cpp
+++ b/test/unit_tests/test_bucket_pos.cpp
@@ -5,6 +5,7 @@ Copyright, 2023, Vilella Kenny.
 */
 #include "gtest/gtest.h"
 #include "soil_simulator/bucket_pos.hpp"
+#include "test/unit_tests/utility.hpp"
 
 TEST(UnitTestBucketPos, CalcLinePos) {
     // Note that this function does not account for the case where the line
@@ -1692,13 +1693,11 @@ TEST(UnitTestBucketPos, CalcBucketPos) {
     EXPECT_EQ(sim_out->bucket_area_[1][0], 6);
     EXPECT_EQ(sim_out->bucket_area_[1][1], 14);
     // Checking that other cells have not been modified
-    for (auto ii = 0; ii < sim_out->body_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->body_[0].size(); jj++)
-            for (auto kk = 0; kk < sim_out->body_[0][0].size(); kk++) {
-                if (!(((ii == 0) || (ii == 1)) &&
-                    (kk == 10) && (jj < 16) && (jj > 9)))
-                    EXPECT_NEAR(sim_out->body_[ii][jj][kk], 0.0, 1.e-5);
-            }
+    std::vector<std::vector<int>> body_pos = {
+        {0, 10, 10}, {0, 11, 10}, {0, 12, 10}, {0, 13, 10}, {0, 14, 10},
+        {0, 15, 10}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, body_pos, {});
 
     // -- Testing for a bucket in the XY plane --
     b_pos = {0.5, 0.0, -0.01};
@@ -1722,6 +1721,16 @@ TEST(UnitTestBucketPos, CalcBucketPos) {
     EXPECT_EQ(sim_out->bucket_area_[0][1], 19);
     EXPECT_EQ(sim_out->bucket_area_[1][0], 4);
     EXPECT_EQ(sim_out->bucket_area_[1][1], 16);
+    // Checking that other cells have not been modified
+    body_pos = {
+        {0, 10, 8}, {0, 10, 9}, {0, 10, 10}, {0, 10, 11}, {0, 10, 12},
+        {0, 11, 8}, {0, 11, 9}, {0, 11, 10}, {0, 11, 11}, {0, 11, 12},
+        {0, 12, 8}, {0, 12, 9}, {0, 12, 10}, {0, 12, 11}, {0, 12, 12},
+        {0, 13, 8}, {0, 13, 9}, {0, 13, 10}, {0, 13, 11}, {0, 13, 12},
+        {0, 14, 8}, {0, 14, 9}, {0, 14, 10}, {0, 14, 11}, {0, 14, 12},
+        {0, 15, 8}, {0, 15, 9}, {0, 15, 10}, {0, 15, 11}, {0, 15, 12}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, body_pos, {});
 
     // -- Testing for a bucket in a dummy position --
     b_pos = {0.0, 0.0, -0.5};
@@ -1753,13 +1762,16 @@ TEST(UnitTestBucketPos, CalcBucketPos) {
     EXPECT_EQ(sim_out->bucket_area_[0][1], 14);
     EXPECT_EQ(sim_out->bucket_area_[1][0], 4);
     EXPECT_EQ(sim_out->bucket_area_[1][1], 16);
-    for (auto ii = 0; ii < sim_out->body_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->body_[0].size(); jj++)
-            for (auto kk = 0; kk < sim_out->body_[0][0].size(); kk++) {
-                if (!(((ii == 0) || (ii == 1)) &&
-                    (jj < 11) && (jj > 4) && (kk < 13) && (kk > 7)))
-                    EXPECT_NEAR(sim_out->body_[ii][jj][kk], 0.0, 1.e-5);
-            }
+    // Checking that other cells have not been modified
+    body_pos = {
+        {0, 5, 8}, {0, 5, 9}, {0, 5, 10}, {0, 5, 11}, {0, 5, 12},
+        {0, 6, 8}, {0, 6, 9}, {0, 6, 10}, {0, 6, 11}, {0, 6, 12},
+        {0, 7, 8}, {0, 7, 9}, {0, 7, 10}, {0, 7, 11}, {0, 7, 12},
+        {0, 8, 8}, {0, 8, 9}, {0, 8, 10}, {0, 8, 11}, {0, 8, 12},
+        {0, 9, 8}, {0, 9, 9}, {0, 9, 10}, {0, 9, 11}, {0, 9, 12},
+        {0, 10, 8}, {0, 10, 9}, {0, 10, 10}, {0, 10, 11}, {0, 10, 12}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, body_pos, {});
 
     delete bucket;
     delete sim_out;

--- a/test/unit_tests/test_bucket_pos.cpp
+++ b/test/unit_tests/test_bucket_pos.cpp
@@ -1692,7 +1692,7 @@ TEST(UnitTestBucketPos, CalcBucketPos) {
     EXPECT_EQ(sim_out->bucket_area_[0][1], 19);
     EXPECT_EQ(sim_out->bucket_area_[1][0], 6);
     EXPECT_EQ(sim_out->bucket_area_[1][1], 14);
-    // Checking that other cells have not been modified
+    // Resetting values
     std::vector<std::vector<int>> body_pos = {
         {0, 10, 10}, {0, 11, 10}, {0, 12, 10}, {0, 13, 10}, {0, 14, 10},
         {0, 15, 10}};
@@ -1721,7 +1721,7 @@ TEST(UnitTestBucketPos, CalcBucketPos) {
     EXPECT_EQ(sim_out->bucket_area_[0][1], 19);
     EXPECT_EQ(sim_out->bucket_area_[1][0], 4);
     EXPECT_EQ(sim_out->bucket_area_[1][1], 16);
-    // Checking that other cells have not been modified
+    // Resetting values
     body_pos = {
         {0, 10, 8}, {0, 10, 9}, {0, 10, 10}, {0, 10, 11}, {0, 10, 12},
         {0, 11, 8}, {0, 11, 9}, {0, 11, 10}, {0, 11, 11}, {0, 11, 12},
@@ -1762,7 +1762,7 @@ TEST(UnitTestBucketPos, CalcBucketPos) {
     EXPECT_EQ(sim_out->bucket_area_[0][1], 14);
     EXPECT_EQ(sim_out->bucket_area_[1][0], 4);
     EXPECT_EQ(sim_out->bucket_area_[1][1], 16);
-    // Checking that other cells have not been modified
+    // Resetting values
     body_pos = {
         {0, 5, 8}, {0, 5, 9}, {0, 5, 10}, {0, 5, 11}, {0, 5, 12},
         {0, 6, 8}, {0, 6, 9}, {0, 6, 10}, {0, 6, 11}, {0, 6, 12},

--- a/test/unit_tests/test_intersecting_cells.cpp
+++ b/test/unit_tests/test_intersecting_cells.cpp
@@ -7,6 +7,7 @@ Copyright, 2023, Vilella Kenny.
 #include "gtest/gtest.h"
 #include "soil_simulator/intersecting_cells.hpp"
 #include "soil_simulator/utils.hpp"
+#include "test/unit_tests/utility.hpp"
 
 TEST(UnitTestIntersectingCells, MoveBodySoil) {
     // Setting up the environment
@@ -20,89 +21,75 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     soil_simulator::SimOut *sim_out = new soil_simulator::SimOut(grid);
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
-    sim_out->body_[0][10][15] = 0.3;
-    sim_out->body_[1][10][15] = 0.7;
-    sim_out->body_[2][10][15] = -0.2;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.7;
-    sim_out->body_soil_[1][10][15] = 0.9;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.9;
     auto pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.7, grid, bucket);
     auto pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.0, grid, bucket);
 
+    // Setting lambda function to set initial state
+    auto SetInitState = [&]() 
+    {
+        sim_out->body_[0][10][15] = 0.3;
+        sim_out->body_[1][10][15] = 0.7;
+        sim_out->body_[2][10][15] = -0.2;
+        sim_out->body_[3][10][15] = 0.0;
+        sim_out->body_soil_[0][10][15] = 0.7;
+        sim_out->body_soil_[1][10][15] = 0.9;
+        sim_out->body_soil_[2][10][15] = 0.0;
+        sim_out->body_soil_[3][10][15] = 0.9;
+        sim_out->body_soil_pos_.push_back(soil_simulator::body_soil
+            {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.2});
+        sim_out->body_soil_pos_.push_back(soil_simulator::body_soil
+            {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.9});
+    };
 
     // -- Testing when soil is avalanching on the terrain --
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.2});
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.9});
+    SetInitState();
     auto [ind, ii, jj, h_soil, wall_presence] = soil_simulator::MoveBodySoil(
         sim_out, 2, 10, 15, 0.3, 5, 7, 0.6, false, grid, bucket, 1e-5);
     EXPECT_EQ(wall_presence, false);
     EXPECT_NEAR(h_soil, 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[5][7], 0.6, 1e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[5][7] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{5, 7}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when soil is avalanching below the first bucket layer --
+    SetInitState();
     sim_out->body_[0][5][7] = 0.1;
     sim_out->body_[1][5][7] = 0.2;
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.2});
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.9});
     std::tie(ind, ii, jj, h_soil, wall_presence) = soil_simulator::MoveBodySoil(
         sim_out, 2, 10, 15, 0.3, 5, 7, 0.6, false, grid, bucket, 1e-5);
     EXPECT_EQ(wall_presence, false);
     EXPECT_NEAR(h_soil, 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[5][7], 0.6, 1e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[5][7] = 0.0;
-    sim_out->body_[0][5][7] = 0.0;
-    sim_out->body_[1][5][7] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{5, 7}}, {{0, 5, 7}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when the first bucket layer is blocking the movement --
+    SetInitState();
     sim_out->body_[0][5][7] = 0.0;
     sim_out->body_[1][5][7] = 0.3;
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.2});
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.9});
     std::tie(ind, ii, jj, h_soil, wall_presence) = soil_simulator::MoveBodySoil(
         sim_out, 2, 10, 15, 0.3, 5, 7, 0.6, false, grid, bucket, 1e-5);
     EXPECT_EQ(wall_presence, true);
     EXPECT_NEAR(h_soil, 0.6, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[5][7], 0.0, 1e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->body_[0][5][7] = 0.0;
-    sim_out->body_[1][5][7] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 5, 7}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when there is a lot of soil on first bucket layer --
     // -- Soil is avalanching on first bucket layer                 --
+    SetInitState();
     sim_out->body_[0][5][7] = 0.0;
     sim_out->body_[1][5][7] = 0.1;
     sim_out->body_soil_[0][5][7] = 0.1;
     sim_out->body_soil_[1][5][7] = 0.4;
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.2});
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.9});
     auto posA = soil_simulator::CalcBucketFramePos(5, 7, 0.1, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 5, 7, posA[0], posA[1], posA[2], 0.3});
@@ -110,7 +97,6 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
         sim_out, 2, 10, 15, 0.3, 5, 7, 0.6, false, grid, bucket, 1e-5);
     EXPECT_EQ(wall_presence, false);
     EXPECT_NEAR(h_soil, 0.0, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[5][7], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][5][7], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][5][7], 1.0, 1e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
@@ -121,29 +107,20 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.6, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->body_[0][5][7] = 0.0;
-    sim_out->body_[1][5][7] = 0.0;
-    sim_out->body_soil_[0][5][7] = 0.0;
-    sim_out->body_soil_[1][5][7] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 5, 7}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 5, 7}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when soil is fully avalanching on first bucket layer --
+    SetInitState();
     sim_out->body_[0][5][7] = 0.0;
     sim_out->body_[1][5][7] = 0.2;
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.2});
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.9});
     posA = soil_simulator::CalcBucketFramePos(5, 7, 0.2, grid, bucket);
     std::tie(ind, ii, jj, h_soil, wall_presence) = soil_simulator::MoveBodySoil(
         sim_out, 2, 10, 15, 0.3, 5, 7, 0.6, false, grid, bucket, 1e-5);
     EXPECT_EQ(wall_presence, false);
     EXPECT_NEAR(h_soil, 0.0, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[5][7], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][5][7], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][5][7], 0.8, 1e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
@@ -154,25 +131,17 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.6, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->body_[0][5][7] = 0.0;
-    sim_out->body_[1][5][7] = 0.0;
-    sim_out->body_soil_[0][5][7] = 0.0;
-    sim_out->body_soil_[1][5][7] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 5, 7}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 5, 7}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when soil is fully avalanching on first bucket soil layer --
+    SetInitState();
     sim_out->body_[0][5][7] = 0.0;
     sim_out->body_[1][5][7] = 0.1;
     sim_out->body_soil_[0][5][7] = 0.1;
     sim_out->body_soil_[1][5][7] = 0.2;
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.2});
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.9});
     posA = soil_simulator::CalcBucketFramePos(5, 7, 0.1, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 5, 7, posA[0], posA[1], posA[2], 0.1});
@@ -180,7 +149,6 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
         sim_out, 2, 10, 15, 0.3, 5, 7, 0.6, false, grid, bucket, 1e-5);
     EXPECT_EQ(wall_presence, false);
     EXPECT_NEAR(h_soil, 0.0, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[5][7], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][5][7], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][5][7], 0.8, 1e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
@@ -191,47 +159,32 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.6, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->body_[0][5][7] = 0.0;
-    sim_out->body_[1][5][7] = 0.0;
-    sim_out->body_soil_[0][5][7] = 0.0;
-    sim_out->body_soil_[1][5][7] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 5, 7}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 5, 7}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when soil is avalanching below the second bucket layer --
+    SetInitState();
     sim_out->body_[2][5][7] = 0.3;
     sim_out->body_[3][5][7] = 0.6;
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.2});
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.9});
     std::tie(ind, ii, jj, h_soil, wall_presence) = soil_simulator::MoveBodySoil(
         sim_out, 2, 10, 15, 0.3, 5, 7, 0.6, false, grid, bucket, 1e-5);
     EXPECT_EQ(wall_presence, false);
     EXPECT_NEAR(h_soil, 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[5][7], 0.6, 1e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->body_[2][5][7] = 0.0;
-    sim_out->body_[3][5][7] = 0.0;
-    sim_out->terrain_[5][7] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{5, 7}}, {{2, 5, 7}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when the second bucket layer is blocking the movement --
+    SetInitState();
     sim_out->body_[2][5][7] = 0.0;
     sim_out->body_[3][5][7] = 0.6;
     sim_out->body_soil_[2][5][7] = 0.6;
     sim_out->body_soil_[3][5][7] = 0.7;
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.2});
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.9});
     posA = soil_simulator::CalcBucketFramePos(5, 7, 0.6, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {2, 5, 7, posA[0], posA[1], posA[2], 0.1});
@@ -242,26 +195,18 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][5][7], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][5][7], 0.7, 1e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->body_[2][5][7] = 0.0;
-    sim_out->body_[3][5][7] = 0.0;
-    sim_out->body_soil_[2][5][7] = 0.0;
-    sim_out->body_soil_[3][5][7] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{2, 5, 7}, {0, 10, 15}, {2, 10, 15}},
+        {{2, 5, 7}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when there is a lot of soil on second bucket layer --
     // -- but soil is still avalanching on it                        --
+    SetInitState();
     sim_out->body_[2][5][7] = -0.2;
     sim_out->body_[3][5][7] = 0.0;
     sim_out->body_soil_[2][5][7] = 0.0;
     sim_out->body_soil_[3][5][7] = 0.3;
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.2});
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.9});
     posA = soil_simulator::CalcBucketFramePos(5, 7, 0.0, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {2, 5, 7, posA[0], posA[1], posA[2], 0.3});
@@ -279,23 +224,15 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.6, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->body_[2][5][7] = 0.0;
-    sim_out->body_[3][5][7] = 0.0;
-    sim_out->body_soil_[2][5][7] = 0.0;
-    sim_out->body_soil_[3][5][7] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{2, 5, 7}, {0, 10, 15}, {2, 10, 15}},
+        {{2, 5, 7}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when soil is fully avalanching on second bucket layer --
+    SetInitState();
     sim_out->body_[2][5][7] = -0.2;
     sim_out->body_[3][5][7] = 0.0;
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.2});
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.9});
     posA = soil_simulator::CalcBucketFramePos(5, 7, 0.0, grid, bucket);
     std::tie(ind, ii, jj, h_soil, wall_presence) = soil_simulator::MoveBodySoil(
         sim_out, 2, 10, 15, 0.3, 5, 7, 0.6, false, grid, bucket, 1e-5);
@@ -311,25 +248,17 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.6, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->body_[2][5][7] = 0.0;
-    sim_out->body_[3][5][7] = 0.0;
-    sim_out->body_soil_[2][5][7] = 0.0;
-    sim_out->body_soil_[3][5][7] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{2, 5, 7}, {0, 10, 15}, {2, 10, 15}},
+        {{2, 5, 7}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when soil is fully avalanching on second bucket soil layer --
+    SetInitState();
     sim_out->body_[2][5][7] = -0.2;
     sim_out->body_[3][5][7] = 0.0;
     sim_out->body_soil_[2][5][7] = 0.0;
     sim_out->body_soil_[3][5][7] = 0.2;
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.2});
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.9});
     posA = soil_simulator::CalcBucketFramePos(5, 7, 0.0, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {2, 5, 7, posA[0], posA[1], posA[2], 0.2});
@@ -347,27 +276,19 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.6, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->body_[2][5][7] = 0.0;
-    sim_out->body_[3][5][7] = 0.0;
-    sim_out->body_soil_[2][5][7] = 0.0;
-    sim_out->body_soil_[3][5][7] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{2, 5, 7}, {0, 10, 15}, {2, 10, 15}},
+        {{2, 5, 7}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when two bucket layers and soil fully filling the space (1) --
+    SetInitState();
     sim_out->body_[0][5][7] = 0.0;
     sim_out->body_[1][5][7] = 0.1;
     sim_out->body_[2][5][7] = 0.2;
     sim_out->body_[3][5][7] = 0.4;
     sim_out->body_soil_[0][5][7] = 0.1;
     sim_out->body_soil_[1][5][7] = 0.2;
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.2});
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.9});
     posA = soil_simulator::CalcBucketFramePos(5, 7, 0.2, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 5, 7, posA[0], posA[1], posA[2], 0.2});
@@ -381,29 +302,19 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[0][5][7], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][5][7], 0.2, 1e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->body_[0][5][7] = 0.0;
-    sim_out->body_[1][5][7] = 0.0;
-    sim_out->body_[2][5][7] = 0.0;
-    sim_out->body_[3][5][7] = 0.0;
-    sim_out->body_soil_[0][5][7] = 0.0;
-    sim_out->body_soil_[1][5][7] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 5, 7}, {2, 5, 7}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 5, 7}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when two bucket layers and soil fully filling the space (2) --
+    SetInitState();
     sim_out->body_[0][5][7] = 0.6;
     sim_out->body_[1][5][7] = 0.7;
     sim_out->body_[2][5][7] = 0.0;
     sim_out->body_[3][5][7] = 0.1;
     sim_out->body_soil_[2][5][7] = 0.1;
     sim_out->body_soil_[3][5][7] = 0.6;
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.2});
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.9});
     posA = soil_simulator::CalcBucketFramePos(5, 7, 0.1, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {2, 5, 7, posA[0], posA[1], posA[2], 0.5});
@@ -417,28 +328,18 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][5][7], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][5][7], 0.6, 1e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->body_[0][5][7] = 0.0;
-    sim_out->body_[1][5][7] = 0.0;
-    sim_out->body_[2][5][7] = 0.0;
-    sim_out->body_[3][5][7] = 0.0;
-    sim_out->body_soil_[2][5][7] = 0.0;
-    sim_out->body_soil_[3][5][7] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 5, 7}, {2, 5, 7}, {0, 10, 15}, {2, 10, 15}},
+        {{2, 5, 7}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when two bucket layers and soil is fully avalanching --
     // -- on bucket (1)                                                --
+    SetInitState();
     sim_out->body_[0][5][7] = 0.0;
     sim_out->body_[1][5][7] = 0.2;
     sim_out->body_[2][5][7] = 0.8;
     sim_out->body_[3][5][7] = 0.9;
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.2});
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.9});
     posA = soil_simulator::CalcBucketFramePos(5, 7, 0.2, grid, bucket);
     std::tie(ind, ii, jj, h_soil, wall_presence) = soil_simulator::MoveBodySoil(
         sim_out, 2, 10, 15, 0.3, 5, 7, 0.6, false, grid, bucket, 1e-5);
@@ -454,28 +355,18 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.6, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->body_[0][5][7] = 0.0;
-    sim_out->body_[1][5][7] = 0.0;
-    sim_out->body_[2][5][7] = 0.0;
-    sim_out->body_[3][5][7] = 0.0;
-    sim_out->body_soil_[0][5][7] = 0.0;
-    sim_out->body_soil_[1][5][7] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 5, 7}, {2, 5, 7}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 5, 7}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when two bucket layers and soil is fully avalanching --
     // -- on bucket (2)                                                --
+    SetInitState();
     sim_out->body_[0][5][7] = 0.8;
     sim_out->body_[1][5][7] = 0.9;
     sim_out->body_[2][5][7] = -0.1;
     sim_out->body_[3][5][7] = 0.0;
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.2});
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.9});
     posA = soil_simulator::CalcBucketFramePos(5, 7, 0.0, grid, bucket);
     std::tie(ind, ii, jj, h_soil, wall_presence) = soil_simulator::MoveBodySoil(
         sim_out, 2, 10, 15, 0.3, 5, 7, 0.6, false, grid, bucket, 1e-5);
@@ -491,30 +382,20 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.6, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->body_[0][5][7] = 0.0;
-    sim_out->body_[1][5][7] = 0.0;
-    sim_out->body_[2][5][7] = 0.0;
-    sim_out->body_[3][5][7] = 0.0;
-    sim_out->body_soil_[2][5][7] = 0.0;
-    sim_out->body_soil_[3][5][7] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 5, 7}, {2, 5, 7}, {0, 10, 15}, {2, 10, 15}},
+        {{2, 5, 7}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when two bucket layers and soil is fully avalanching --
     // -- on bucket soil (1)                                           --
+    SetInitState();
     sim_out->body_[0][5][7] = 0.0;
     sim_out->body_[1][5][7] = 0.1;
     sim_out->body_[2][5][7] = 0.9;
     sim_out->body_[3][5][7] = 1.0;
     sim_out->body_soil_[0][5][7] = 0.1;
     sim_out->body_soil_[1][5][7] = 0.2;
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.2});
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.9});
     posA = soil_simulator::CalcBucketFramePos(5, 7, 0.1, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 5, 7, posA[0], posA[1], posA[2], 0.1});
@@ -532,30 +413,20 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.6, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->body_[0][5][7] = 0.0;
-    sim_out->body_[1][5][7] = 0.0;
-    sim_out->body_[2][5][7] = 0.0;
-    sim_out->body_[3][5][7] = 0.0;
-    sim_out->body_soil_[0][5][7] = 0.0;
-    sim_out->body_soil_[1][5][7] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 5, 7}, {2, 5, 7}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 5, 7}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when two bucket layers and soil is fully avalanching --
     // -- on bucket soil (2)                                           --
+    SetInitState();
     sim_out->body_[0][5][7] = 0.8;
     sim_out->body_[1][5][7] = 0.9;
     sim_out->body_[2][5][7] = -0.1;
     sim_out->body_[3][5][7] = 0.0;
     sim_out->body_soil_[2][5][7] = 0.0;
     sim_out->body_soil_[3][5][7] = 0.2;
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.2});
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.9});
     posA = soil_simulator::CalcBucketFramePos(5, 7, 0.0, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {2, 5, 7, posA[0], posA[1], posA[2], 0.2});
@@ -573,30 +444,20 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.6, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->body_[0][5][7] = 0.0;
-    sim_out->body_[1][5][7] = 0.0;
-    sim_out->body_[2][5][7] = 0.0;
-    sim_out->body_[3][5][7] = 0.0;
-    sim_out->body_soil_[2][5][7] = 0.0;
-    sim_out->body_soil_[3][5][7] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 5, 7}, {2, 5, 7}, {0, 10, 15}, {2, 10, 15}},
+        {{2, 5, 7}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when two bucket layers and soil is fully avalanching --
     // -- on bucket soil (3)                                           --
+    SetInitState();
     sim_out->body_[0][5][7] = 0.0;
     sim_out->body_[1][5][7] = 0.2;
     sim_out->body_[2][5][7] = 0.9;
     sim_out->body_[3][5][7] = 1.;
     sim_out->body_soil_[0][5][7] = 0.2;
     sim_out->body_soil_[1][5][7] = 0.3;
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.2});
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.9});
     posA = soil_simulator::CalcBucketFramePos(5, 7, 0.2, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 5, 7, posA[0], posA[1], posA[2], 0.1});
@@ -614,30 +475,20 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.6, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->body_[0][5][7] = 0.0;
-    sim_out->body_[1][5][7] = 0.0;
-    sim_out->body_[2][5][7] = 0.0;
-    sim_out->body_[3][5][7] = 0.0;
-    sim_out->body_soil_[0][5][7] = 0.0;
-    sim_out->body_soil_[1][5][7] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 5, 7}, {2, 5, 7}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 5, 7}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when two bucket layers and soil is fully avalanching --
     // -- on bucket soil (4)                                           --
+    SetInitState();
     sim_out->body_[0][5][7] = 0.9;
     sim_out->body_[1][5][7] = 1.0;
     sim_out->body_[2][5][7] = 0.0;
     sim_out->body_[3][5][7] = 0.1;
     sim_out->body_soil_[2][5][7] = 0.1;
     sim_out->body_soil_[3][5][7] = 0.6;
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.2});
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.9});
     posA = soil_simulator::CalcBucketFramePos(5, 7, 0.1, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {2, 5, 7, posA[0], posA[1], posA[2], 0.5});
@@ -655,28 +506,18 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->body_[0][5][7] = 0.0;
-    sim_out->body_[1][5][7] = 0.0;
-    sim_out->body_[2][5][7] = 0.0;
-    sim_out->body_[3][5][7] = 0.0;
-    sim_out->body_soil_[2][5][7] = 0.0;
-    sim_out->body_soil_[3][5][7] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 5, 7}, {2, 5, 7}, {0, 10, 15}, {2, 10, 15}},
+        {{2, 5, 7}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when two bucket layers and soil is partially avalanching --
     // -- on bucket (1)                                                    --
+    SetInitState();
     sim_out->body_[0][5][7] = 0.0;
     sim_out->body_[1][5][7] = 0.1;
     sim_out->body_[2][5][7] = 0.4;
     sim_out->body_[3][5][7] = 0.9;
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.2});
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.9});
     posA = soil_simulator::CalcBucketFramePos(5, 7, 0.1, grid, bucket);
     std::tie(ind, ii, jj, h_soil, wall_presence) = soil_simulator::MoveBodySoil(
         sim_out, 2, 10, 15, 0.3, 5, 7, 0.6, false, grid, bucket, 1e-5);
@@ -695,28 +536,18 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->body_[0][5][7] = 0.0;
-    sim_out->body_[1][5][7] = 0.0;
-    sim_out->body_[2][5][7] = 0.0;
-    sim_out->body_[3][5][7] = 0.0;
-    sim_out->body_soil_[0][5][7] = 0.0;
-    sim_out->body_soil_[1][5][7] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 5, 7}, {2, 5, 7}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 5, 7}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when two bucket layers and soil is partially avalanching --
     // -- on bucket (2)                                                    --
+    SetInitState();
     sim_out->body_[0][5][7] = 0.3;
     sim_out->body_[1][5][7] = 0.9;
     sim_out->body_[2][5][7] = -0.1;
     sim_out->body_[3][5][7] = 0.2;
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.2});
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.9});
     posA = soil_simulator::CalcBucketFramePos(5, 7, 0.2, grid, bucket);
     std::tie(ind, ii, jj, h_soil, wall_presence) = soil_simulator::MoveBodySoil(
         sim_out, 2, 10, 15, 0.3, 5, 7, 0.6, false, grid, bucket, 1e-5);
@@ -735,30 +566,20 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->body_[0][5][7] = 0.0;
-    sim_out->body_[1][5][7] = 0.0;
-    sim_out->body_[2][5][7] = 0.0;
-    sim_out->body_[3][5][7] = 0.0;
-    sim_out->body_soil_[2][5][7] = 0.0;
-    sim_out->body_soil_[3][5][7] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 5, 7}, {2, 5, 7}, {0, 10, 15}, {2, 10, 15}},
+        {{2, 5, 7}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when two bucket layers and soil is partially avalanching --
     // -- on bucket soil (1)                                               --
+    SetInitState();
     sim_out->body_[0][5][7] = 0.0;
     sim_out->body_[1][5][7] = 0.1;
     sim_out->body_[2][5][7] = 0.4;
     sim_out->body_[3][5][7] = 0.5;
     sim_out->body_soil_[0][5][7] = 0.1;
     sim_out->body_soil_[1][5][7] = 0.2;
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.2});
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.9});
     posA = soil_simulator::CalcBucketFramePos(5, 7, 0.1, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 5, 7, posA[0], posA[1], posA[2], 0.1});
@@ -779,30 +600,20 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->body_[0][5][7] = 0.0;
-    sim_out->body_[1][5][7] = 0.0;
-    sim_out->body_[2][5][7] = 0.0;
-    sim_out->body_[3][5][7] = 0.0;
-    sim_out->body_soil_[0][5][7] = 0.0;
-    sim_out->body_soil_[1][5][7] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 5, 7}, {2, 5, 7}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 5, 7}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when two bucket layers and soil is partially avalanching --
     // -- on bucket soil (2)                                               --
+    SetInitState();
     sim_out->body_[0][5][7] = 0.6;
     sim_out->body_[1][5][7] = 0.9;
     sim_out->body_[2][5][7] = -0.1;
     sim_out->body_[3][5][7] = 0.0;
     sim_out->body_soil_[2][5][7] = 0.0;
     sim_out->body_soil_[3][5][7] = 0.2;
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.2});
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.9});
     posA = soil_simulator::CalcBucketFramePos(5, 7, 0.0, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {2, 5, 7, posA[0], posA[1], posA[2], 0.2});
@@ -823,30 +634,20 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.4, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->body_[0][5][7] = 0.0;
-    sim_out->body_[1][5][7] = 0.0;
-    sim_out->body_[2][5][7] = 0.0;
-    sim_out->body_[3][5][7] = 0.0;
-    sim_out->body_soil_[2][5][7] = 0.0;
-    sim_out->body_soil_[3][5][7] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 5, 7}, {2, 5, 7}, {0, 10, 15}, {2, 10, 15}},
+        {{2, 5, 7}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when two bucket layers and soil is partially avalanching --
     // -- on bucket soil (3)                                               --
+    SetInitState();
     sim_out->body_[0][5][7] = 0.0;
     sim_out->body_[1][5][7] = 0.2;
     sim_out->body_[2][5][7] = 0.4;
     sim_out->body_[3][5][7] = 0.5;
     sim_out->body_soil_[0][5][7] = 0.2;
     sim_out->body_soil_[1][5][7] = 0.3;
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.2});
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.9});
     posA = soil_simulator::CalcBucketFramePos(5, 7, 0.2, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 5, 7, posA[0], posA[1], posA[2], 0.1});
@@ -867,30 +668,20 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->body_[0][5][7] = 0.0;
-    sim_out->body_[1][5][7] = 0.0;
-    sim_out->body_[2][5][7] = 0.0;
-    sim_out->body_[3][5][7] = 0.0;
-    sim_out->body_soil_[0][5][7] = 0.0;
-    sim_out->body_soil_[1][5][7] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 5, 7}, {2, 5, 7}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 5, 7}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when two bucket layers and soil is partially avalanching --
     // -- on bucket soil (4)                                               --
+    SetInitState();
     sim_out->body_[0][5][7] = 0.7;
     sim_out->body_[1][5][7] = 0.8;
     sim_out->body_[2][5][7] = 0.0;
     sim_out->body_[3][5][7] = 0.1;
     sim_out->body_soil_[2][5][7] = 0.1;
     sim_out->body_soil_[3][5][7] = 0.6;
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.2});
-    sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.9});
     posA = soil_simulator::CalcBucketFramePos(5, 7, 0.1, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {2, 5, 7, posA[0], posA[1], posA[2], 0.5});
@@ -911,17 +702,10 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->body_[0][5][7] = 0.0;
-    sim_out->body_[1][5][7] = 0.0;
-    sim_out->body_[2][5][7] = 0.0;
-    sim_out->body_[3][5][7] = 0.0;
-    sim_out->body_soil_[2][5][7] = 0.0;
-    sim_out->body_soil_[3][5][7] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 5, 7}, {2, 5, 7}, {0, 10, 15}, {2, 10, 15}},
+        {{2, 5, 7}, {0, 10, 15}, {2, 10, 15}});
 
     delete bucket;
     delete sim_out;
@@ -965,20 +749,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->terrain_[11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{11, 15}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when soil is avalanching on the terrain (2) --
     // -- Second bucket layer at bottom                       --
@@ -1005,20 +779,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->terrain_[11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{11, 15}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when soil is avalanching on the terrain (3) --
     // -- Bucket undergroumd                                  --
@@ -1045,20 +809,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->terrain_[11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{11, 15}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when soil is avalanching below the first bucket layer (1) --
     soil_simulator::rng.seed(1234);
@@ -1086,22 +840,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->terrain_[11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{11, 15}}, {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when soil is avalanching below the first bucket layer (2) --
     soil_simulator::rng.seed(1234);
@@ -1129,22 +871,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->terrain_[11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{11, 15}}, {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when soil is avalanching below the first bucket layer (3) --
     soil_simulator::rng.seed(1234);
@@ -1172,22 +902,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->terrain_[11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{11, 15}}, {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when soil is avalanching below the first bucket layer --
     // -- despite the lack of available space                           --
@@ -1224,24 +942,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    sim_out->terrain_[11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{11, 15}}, {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}});
 
     // -- Testing when soil is avalanching below the second bucket layer (1) --
     soil_simulator::rng.seed(1234);
@@ -1269,22 +973,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->terrain_[11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{11, 15}}, {{0, 10, 15}, {2, 10, 15}, {2, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when soil is avalanching below the second bucket layer (2) --
     soil_simulator::rng.seed(1234);
@@ -1312,22 +1004,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->terrain_[11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{11, 15}}, {{0, 10, 15}, {2, 10, 15}, {2, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when soil is avalanching below the second bucket layer (3) --
     soil_simulator::rng.seed(1234);
@@ -1355,22 +1035,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->terrain_[11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{11, 15}}, {{0, 10, 15}, {2, 10, 15}, {2, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when soil is avalanching below the second bucket layer --
     // -- despite the lack of available space                            --
@@ -1400,22 +1068,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->terrain_[11][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->terrain_[11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{11, 15}}, {{0, 10, 15}, {2, 10, 15}, {2, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing when soil is fully avalanching on first bucket layer (1) --
     soil_simulator::rng.seed(1234);
@@ -1443,7 +1099,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.5, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
     EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
@@ -1453,23 +1108,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}});
 
     // -- Testing when soil is fully avalanching on first bucket layer (2) --
     soil_simulator::rng.seed(1234);
@@ -1497,7 +1139,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.5, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
     EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
@@ -1507,23 +1148,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}});
 
     // -- Testing when soil is fully avalanching on second bucket layer (1) --
     soil_simulator::rng.seed(1234);
@@ -1551,7 +1179,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.5, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
     EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
@@ -1561,23 +1188,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 10, 15}, {2, 10, 15}, {2, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {2, 11, 15}});
 
     // -- Testing when soil is fully avalanching on second bucket layer (2) --
     soil_simulator::rng.seed(1234);
@@ -1605,7 +1219,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.5, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
     EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
@@ -1615,23 +1228,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 10, 15}, {2, 10, 15}, {2, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {2, 11, 15}});
 
     // -- Testing when soil is fully avalanching on first bucket soil --
     // -- layer (1)                                                   --
@@ -1664,7 +1264,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.5, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
     EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
@@ -1674,23 +1273,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}});
 
     // -- Testing when soil is fully avalanching on first bucket soil --
     // -- layer (2)                                                   --
@@ -1723,7 +1309,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.5, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
     EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
@@ -1733,23 +1318,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}});
 
     // -- Testing when soil is fully avalanching on second bucket soil --
     // -- layer (1)                                                    --
@@ -1782,7 +1354,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.5, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
     EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
@@ -1792,23 +1363,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 10, 15}, {2, 10, 15}, {2, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {2, 11, 15}});
 
     // -- Testing when soil is fully avalanching on the second bucket soil --
     // -- layer (2)                                                        --
@@ -1841,7 +1399,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.5, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
     EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
@@ -1851,23 +1408,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 10, 15}, {2, 10, 15}, {2, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {2, 11, 15}});
 
     // -- Testing when there are two bucket layers and soil is fully --
     // -- avalanching on the first bucket layer (1)                  --
@@ -1898,7 +1442,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.5, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
     EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
@@ -1908,25 +1451,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}});
 
     // -- Testing when there are two bucket layers and soil is fully --
     // -- avalanching on the first bucket layer (2)                  --
@@ -1957,7 +1485,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.5, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
     EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
@@ -1967,25 +1494,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}});
 
     // -- Testing when there are two bucket layers and soil is fully --
     // -- avalanching on the second bucket layer (1)                 --
@@ -2016,7 +1528,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.5, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
     EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
@@ -2026,25 +1537,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {2, 11, 15}});
 
     // -- Testing when there are two bucket layers and soil is fully --
     // -- avalanching on the second bucket layer (2)                 --
@@ -2075,7 +1571,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.5, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
     EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
@@ -2085,25 +1580,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {2, 11, 15}});
 
     // -- Testing when there are two bucket layers and soil is fully --
     // -- avalanching on the first bucket soil layer (1)             --
@@ -2138,7 +1618,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.5, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
     EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
@@ -2148,25 +1627,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}});
 
     // -- Testing when there are two bucket layers and soil is fully --
     // -- avalanching on the first bucket soil layer (2)             --
@@ -2201,7 +1665,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.5, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
     EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
@@ -2211,25 +1674,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}});
 
     // -- Testing when there are two bucket layers and soil is fully --
     // -- avalanching on the second bucket soil layer (1)            --
@@ -2264,7 +1712,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.5, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
     EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
@@ -2274,25 +1721,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {2, 11, 15}});
 
     // -- Testing when there are two bucket layers and soil is fully --
     // -- avalanching on the second bucket soil layer (2)            --
@@ -2327,7 +1759,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.5, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
     EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
@@ -2337,25 +1768,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {2, 11, 15}});
 
     // -- Testing when there are two bucket layers and soil is partially    --
     // -- avalanching on the first bucket layer and then on the terrain (1) --
@@ -2386,7 +1802,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.4, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
@@ -2397,26 +1812,11 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[12][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}});
 
     // -- Testing when there are two bucket layers and soil is partially    --
     // -- avalanching on the first bucket layer and then on the terrain (2) --
@@ -2447,7 +1847,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.4, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
@@ -2458,26 +1857,11 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[12][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}});
 
     // -- Testing when there are two bucket layers and soil is partially     --
     // -- avalanching on the second bucket layer and then on the terrain (1) --
@@ -2508,7 +1892,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.4, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
@@ -2519,26 +1902,11 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[12][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {2, 11, 15}});
 
     // -- Testing when there are two bucket layers and soil is partially     --
     // -- avalanching on the second bucket layer and then on the terrain (2) --
@@ -2569,7 +1937,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.4, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
@@ -2580,26 +1947,11 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[12][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {2, 11, 15}});
 
     // -- Testing when there are two bucket layers and soil is partially --
     // -- avalanching on first bucket soil layer and then on terrain (1) --
@@ -2634,7 +1986,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.4, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
@@ -2645,26 +1996,11 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->terrain_[12][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}});
 
     // -- Testing when there are two bucket layers and soil is partially --
     // -- avalanching on first bucket soil layer and then on terrain (2) --
@@ -2699,7 +2035,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.9, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
@@ -2710,26 +2045,11 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->terrain_[12][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}});
 
     // -- Testing when there are two bucket layers and soil is partially  --
     // -- avalanching on second bucket soil layer and then on terrain (1) --
@@ -2764,7 +2084,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.4, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
@@ -2775,26 +2094,11 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->terrain_[12][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {2, 11, 15}});
 
     // -- Testing when there are two bucket layers and soil is partially  --
     // -- avalanching on second bucket soil layer and then on terrain (2) --
@@ -2829,7 +2133,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.9, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
@@ -2840,26 +2143,11 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->terrain_[12][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {2, 11, 15}});
 
     // -- Testing when there are two bucket layers and the soil is partially --
     // -- avalanching on the first bucket soil layer, then the soil is       --
@@ -2911,7 +2199,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.9, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][12][15], 0.4, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][12][15], 0.8, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 0);
@@ -2922,32 +2209,11 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 6);
-    sim_out->terrain_[12][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_[0][12][15] = 0.0;
-    sim_out->body_[1][12][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][12][15] = 0.0;
-    sim_out->body_soil_[1][12][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {0, 12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {0, 12, 15}});
 
     // -- Testing when there are two bucket layers and the soil is partially --
     // -- avalanching on the second bucket soil layer, then the soil is      --
@@ -2999,7 +2265,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.8, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][12][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][12][15], 0.8, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 2);
@@ -3010,32 +2275,11 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 6);
-    sim_out->terrain_[12][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_[0][12][15] = 0.0;
-    sim_out->body_[1][12][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][12][15] = 0.0;
-    sim_out->body_soil_[1][12][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {0, 12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {0, 12, 15}});
 
     // -- Testing when there are two bucket layers and the soil on the first  --
     // -- bucket layer is blocking the movement, then the soil is avalanching --
@@ -3087,36 +2331,14 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.9, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][12][15], 0.4, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 0.8, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 5);
-    sim_out->terrain_[12][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_[2][12][15] = 0.0;
-    sim_out->body_[3][12][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    sim_out->body_soil_[2][12][15] = 0.0;
-    sim_out->body_soil_[3][12][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {2, 12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {2, 12, 15}});
 
     // -- Testing when there are two bucket layers and the soil on the second --
     // -- bucket layer is blocking the movement, then the soil is avalanching --
@@ -3168,36 +2390,14 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][12][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 0.8, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 5);
-    sim_out->terrain_[12][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_[2][12][15] = 0.0;
-    sim_out->body_[3][12][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    sim_out->body_soil_[2][12][15] = 0.0;
-    sim_out->body_soil_[3][12][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {2, 12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {2, 12, 15}});
 
     // -- Testing when there are two bucket layers and the soil is partially  --
     // -- avalanching on the first bucket layer, then the soil is avalanching --
@@ -3249,7 +2449,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.9, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][12][15], 0.4, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][12][15], 0.8, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 0);
@@ -3260,32 +2459,11 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 6);
-    sim_out->terrain_[12][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_[0][12][15] = 0.0;
-    sim_out->body_[1][12][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][12][15] = 0.0;
-    sim_out->body_soil_[1][12][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {0, 12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {0, 12, 15}});
 
     // -- Testing when there are two bucket layers and the soil is partially --
     // -- avalanching on the second bucket layer, then the soil is           --
@@ -3337,7 +2515,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.9, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][12][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][12][15], 0.8, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 2);
@@ -3348,32 +2525,11 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 6);
-    sim_out->terrain_[12][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_[0][12][15] = 0.0;
-    sim_out->body_[1][12][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][12][15] = 0.0;
-    sim_out->body_soil_[1][12][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {0, 12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {0, 12, 15}});
 
     // -- Testing when there are two bucket layers and the soil is partially  --
     // -- avalanching on the first bucket layer, then the soil is avalanching --
@@ -3425,7 +2581,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.9, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][12][15], 0.4, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 0.8, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 0);
@@ -3436,32 +2591,11 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 6);
-    sim_out->terrain_[12][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_[2][12][15] = 0.0;
-    sim_out->body_[3][12][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    sim_out->body_soil_[2][12][15] = 0.0;
-    sim_out->body_soil_[3][12][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {2, 12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {2, 12, 15}});
 
     // -- Testing when there are two bucket layers and the soil is partially --
     // -- avalanching on the second bucket layer, then the soil is           --
@@ -3513,7 +2647,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][12][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 0.8, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.4, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 2);
@@ -3524,32 +2657,11 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 6);
-    sim_out->terrain_[12][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_[2][12][15] = 0.0;
-    sim_out->body_[3][12][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    sim_out->body_soil_[2][12][15] = 0.0;
-    sim_out->body_soil_[3][12][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {2, 12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {2, 12, 15}});
 
     // -- Testing when there is a lot of soil on the first bucket layer but --
     // -- soil is still avalanching on it                                   --
@@ -3582,7 +2694,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 1.1, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
     EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
@@ -3592,24 +2703,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->terrain_[12][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}});
 
     // -- Testing when there is a lot of soil on the second bucket layer but --
     // -- soil is still avalanching on it                                    --
@@ -3642,7 +2739,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.8, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
     EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
@@ -3652,24 +2748,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->terrain_[12][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 10, 15}, {2, 10, 15}, {2, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {2, 11, 15}});
 
     // -- Testing when there are two bucket layers and the soil on the first  --
     // -- bucket layer is blocking the movement, then the soil is avalanching --
@@ -3721,8 +2803,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.9, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][12][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][12][15], 0.7, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[12][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 0);
     EXPECT_EQ(sim_out->body_soil_pos_[5].ii, 12);
@@ -3732,31 +2812,11 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 6);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_[0][12][15] = 0.0;
-    sim_out->body_[1][12][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][12][15] = 0.0;
-    sim_out->body_soil_[1][12][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {0, 12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {0, 12, 15}});
 
     // -- Testing when there are two bucket layers and the soil on the second --
     // -- bucket layer is blocking the movement, then the soil is avalanching --
@@ -3804,8 +2864,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][12][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][12][15], 0.4, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[12][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[4].ind, 0);
     EXPECT_EQ(sim_out->body_soil_pos_[4].ii, 12);
@@ -3815,31 +2873,11 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[4].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[4].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 5);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_[0][12][15] = 0.0;
-    sim_out->body_[1][12][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][12][15] = 0.0;
-    sim_out->body_soil_[1][12][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {0, 12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {0, 12, 15}});
 
     // -- Testing when there are two bucket layers and the soil on the first  --
     // -- bucket layer is blocking the movement, then the soil is avalanching --
@@ -3891,8 +2929,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.9, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][12][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 0.6, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[12][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 2);
     EXPECT_EQ(sim_out->body_soil_pos_[5].ii, 12);
@@ -3902,31 +2938,11 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 6);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_[2][12][15] = 0.0;
-    sim_out->body_[3][12][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    sim_out->body_soil_[2][12][15] = 0.0;
-    sim_out->body_soil_[3][12][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {2, 12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {2, 12, 15}});
 
     // -- Testing when there are two bucket layers and the soil on the second --
     // -- bucket layer is blocking the movement, then the soil is avalanching --
@@ -3974,8 +2990,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][12][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 0.6, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[12][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[4].ind, 2);
     EXPECT_EQ(sim_out->body_soil_pos_[4].ii, 12);
@@ -3985,31 +2999,11 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[4].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[4].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 5);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_[2][12][15] = 0.0;
-    sim_out->body_[3][12][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    sim_out->body_soil_[2][12][15] = 0.0;
-    sim_out->body_soil_[3][12][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {2, 12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {2, 12, 15}});
 
     // -- Testing when there are two bucket layers and the soil is partially  --
     // -- avalanching on the first bucket layer, then the soil is avalanching --
@@ -4061,8 +3055,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.9, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][12][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][12][15], 0.6, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[12][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 0);
     EXPECT_EQ(sim_out->body_soil_pos_[5].ii, 11);
@@ -4079,31 +3071,11 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[6].z_b, posB[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[6].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 7);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_[0][12][15] = 0.0;
-    sim_out->body_[1][12][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][12][15] = 0.0;
-    sim_out->body_soil_[1][12][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {0, 12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {0, 12, 15}});
 
     // -- Testing when there are two bucket layers and the soil is partially --
     // -- avalanching on the second bucket layer, then the soil is           --
@@ -4151,8 +3123,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][12][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][12][15], 0.4, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[12][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[4].ind, 2);
     EXPECT_EQ(sim_out->body_soil_pos_[4].ii, 11);
@@ -4169,29 +3139,11 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posB[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 6);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[0][12][15] = 0.0;
-    sim_out->body_[1][12][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][12][15] = 0.0;
-    sim_out->body_soil_[1][12][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {0, 12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {0, 12, 15}});
 
     // -- Testing when there are two bucket layers and the soil is partially  --
     // -- avalanching on the first bucket layer, then the soil is avalanching --
@@ -4239,8 +3191,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.9, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][12][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 0.4, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[12][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[4].ind, 0);
     EXPECT_EQ(sim_out->body_soil_pos_[4].ii, 11);
@@ -4257,31 +3207,11 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posB[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 6);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_[2][12][15] = 0.0;
-    sim_out->body_[3][12][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    sim_out->body_soil_[2][12][15] = 0.0;
-    sim_out->body_soil_[3][12][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {2, 12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {2, 12, 15}});
 
     // -- Testing when there are two bucket layers and the soil is partially --
     // -- avalanching on the second bucket layer, then the soil is           --
@@ -4333,8 +3263,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][12][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 0.5, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[12][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 2);
     EXPECT_EQ(sim_out->body_soil_pos_[5].ii, 11);
@@ -4351,31 +3279,11 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[6].z_b, posB[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[6].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 7);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_[2][12][15] = 0.0;
-    sim_out->body_[3][12][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    sim_out->body_soil_[2][12][15] = 0.0;
-    sim_out->body_soil_[3][12][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {2, 12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {2, 12, 15}});
 
     // -- Testing when there are two bucket layers and the soil is partially  --
     // -- avalanching on the first bucket layer, then the first bucket layer  --
@@ -4517,63 +3425,17 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[11].z_b, posE[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[11].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 12);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_[0][12][15] = 0.0;
-    sim_out->body_[1][12][15] = 0.0;
-    sim_out->body_[0][10][16] = 0.0;
-    sim_out->body_[1][10][16] = 0.0;
-    sim_out->body_[2][10][16] = 0.0;
-    sim_out->body_[3][10][16] = 0.0;
-    sim_out->body_[2][10][17] = 0.0;
-    sim_out->body_[3][10][17] = 0.0;
-    sim_out->body_[0][11][14] = 0.0;
-    sim_out->body_[1][11][14] = 0.0;
-    sim_out->body_[2][11][14] = 0.0;
-    sim_out->body_[3][11][14] = 0.0;
-    sim_out->body_[2][12][13] = 0.0;
-    sim_out->body_[3][12][13] = 0.0;
-    sim_out->body_[0][9][14] = 0.0;
-    sim_out->body_[1][9][14] = 0.0;
-    sim_out->body_[2][9][14] = 0.0;
-    sim_out->body_[3][9][14] = 0.0;
-    sim_out->body_[2][8][13] = 0.0;
-    sim_out->body_[3][8][13] = 0.0;
-    sim_out->body_[0][11][16] = 0.0;
-    sim_out->body_[1][11][16] = 0.0;
-    sim_out->body_[2][11][16] = 0.0;
-    sim_out->body_[3][11][16] = 0.0;
-    sim_out->body_[0][12][17] = 0.0;
-    sim_out->body_[1][12][17] = 0.0;
-    sim_out->body_[2][12][17] = 0.0;
-    sim_out->body_[3][12][17] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    sim_out->body_soil_[2][10][16] = 0.0;
-    sim_out->body_soil_[3][10][16] = 0.0;
-    sim_out->body_soil_[0][11][14] = 0.0;
-    sim_out->body_soil_[1][11][14] = 0.0;
-    sim_out->body_soil_[2][9][14] = 0.0;
-    sim_out->body_soil_[3][9][14] = 0.0;
-    sim_out->body_soil_[0][11][16] = 0.0;
-    sim_out->body_soil_[1][11][16] = 0.0;
-    sim_out->body_soil_[2][12][17] = 0.0;
-    sim_out->body_soil_[3][12][17] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    std::vector<std::vector<int>> body_pos = {
+        {0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {0, 12, 15},
+        {0, 10, 16}, {2, 10, 16}, {2, 10, 17}, {0, 11, 14}, {2, 11, 14},
+        {2, 12, 13}, {0, 9, 14}, {2, 9, 14}, {2, 8, 13}, {0, 11, 16},
+        {2, 11, 16}, {0, 12, 17}, {2, 12, 17}};
+    std::vector<std::vector<int>> body_soil_pos = {
+        {0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 10, 16}, {0, 11, 14},
+        {2, 9, 14}, {0, 11, 16}, {2, 12, 17}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, body_pos, body_soil_pos);
 
     // -- Testing when there are two bucket layers and the soil on the first  --
     // -- bucket layer is blocking the movement, then the soil is fully       --
@@ -4618,8 +3480,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][12][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 1.5, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[12][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[4].ind, 2);
     EXPECT_EQ(sim_out->body_soil_pos_[4].ii, 12);
@@ -4629,29 +3489,11 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[4].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[4].h_soil, 1.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 5);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_[2][12][15] = 0.0;
-    sim_out->body_[3][12][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    sim_out->body_soil_[2][12][15] = 0.0;
-    sim_out->body_soil_[3][12][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {2, 12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {2, 12, 15}});
 
     // -- Testing when there are two bucket layers and the soil on the second --
     // -- bucket layer is blocking the movement, then the soil is fully       --
@@ -4696,8 +3538,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.4, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][12][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 1.8, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[12][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[4].ind, 2);
     EXPECT_EQ(sim_out->body_soil_pos_[4].ii, 12);
@@ -4707,29 +3547,11 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[4].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[4].h_soil, 1.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 5);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_[2][12][15] = 0.0;
-    sim_out->body_[3][12][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    sim_out->body_soil_[2][12][15] = 0.0;
-    sim_out->body_soil_[3][12][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {2, 12, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {2, 12, 15}});
 
     // -- Testing when there are two bucket layers and the soil on the first  --
     // -- bucket layer is blocking the movement, then the first bucket layer  --
@@ -4843,63 +3665,17 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[7].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[7].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 8);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_[0][12][15] = 0.0;
-    sim_out->body_[1][12][15] = 0.0;
-    sim_out->body_[0][10][16] = 0.0;
-    sim_out->body_[1][10][16] = 0.0;
-    sim_out->body_[2][10][16] = 0.0;
-    sim_out->body_[3][10][16] = 0.0;
-    sim_out->body_[2][10][17] = 0.0;
-    sim_out->body_[3][10][17] = 0.0;
-    sim_out->body_[0][11][14] = 0.0;
-    sim_out->body_[1][11][14] = 0.0;
-    sim_out->body_[2][11][14] = 0.0;
-    sim_out->body_[3][11][14] = 0.0;
-    sim_out->body_[2][12][13] = 0.0;
-    sim_out->body_[3][12][13] = 0.0;
-    sim_out->body_[0][9][14] = 0.0;
-    sim_out->body_[1][9][14] = 0.0;
-    sim_out->body_[2][9][14] = 0.0;
-    sim_out->body_[3][9][14] = 0.0;
-    sim_out->body_[2][8][13] = 0.0;
-    sim_out->body_[3][8][13] = 0.0;
-    sim_out->body_[0][11][16] = 0.0;
-    sim_out->body_[1][11][16] = 0.0;
-    sim_out->body_[2][11][16] = 0.0;
-    sim_out->body_[3][11][16] = 0.0;
-    sim_out->body_[0][12][17] = 0.0;
-    sim_out->body_[1][12][17] = 0.0;
-    sim_out->body_[2][12][17] = 0.0;
-    sim_out->body_[3][12][17] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    sim_out->body_soil_[2][10][16] = 0.0;
-    sim_out->body_soil_[3][10][16] = 0.0;
-    sim_out->body_soil_[0][11][14] = 0.0;
-    sim_out->body_soil_[1][11][14] = 0.0;
-    sim_out->body_soil_[2][9][14] = 0.0;
-    sim_out->body_soil_[3][9][14] = 0.0;
-    sim_out->body_soil_[0][11][16] = 0.0;
-    sim_out->body_soil_[1][11][16] = 0.0;
-    sim_out->body_soil_[0][12][17] = 0.0;
-    sim_out->body_soil_[1][12][17] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    body_pos = {
+        {0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {0, 12, 15},
+        {0, 10, 16}, {2, 10, 16}, {2, 10, 17}, {0, 11, 14}, {2, 11, 14},
+        {2, 12, 13}, {0, 9, 14}, {2, 9, 14}, {2, 8, 13}, {0, 11, 16},
+        {2, 11, 16}, {0, 12, 17}, {2, 12, 17}};
+    body_soil_pos = {
+        {0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 10, 16}, {0, 11, 14},
+        {2, 9, 14}, {0, 11, 16}, {0, 12, 17}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, body_pos, body_soil_pos);
 
     // -- Testing when there are two bucket layers and the soil on the second --
     // -- bucket layer is blocking the movement, then two bucket layers and   --
@@ -4942,8 +3718,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.9, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][12][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 0.4, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[12][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
     EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 12);
@@ -4953,31 +3727,13 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_[0][12][15] = 0.0;
-    sim_out->body_[1][12][15] = 0.0;
-    sim_out->body_[2][12][15] = 0.0;
-    sim_out->body_[3][12][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    sim_out->body_soil_[2][12][15] = 0.0;
-    sim_out->body_soil_[3][12][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    body_pos = {
+        {0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {0, 12, 15},
+        {2, 12, 15}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, body_pos, 
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {2, 12, 15}});
 
     // -- Testing when there are two bucket layers and the soil is partially  --
     // -- avalanching on the first bucket layer, then two bucket layers and   --
@@ -5172,79 +3928,19 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[15].z_b, posJ[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[15].h_soil, 0.4, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 16);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_[0][12][15] = 0.0;
-    sim_out->body_[1][12][15] = 0.0;
-    sim_out->body_[2][12][15] = 0.0;
-    sim_out->body_[3][12][15] = 0.0;
-    sim_out->body_[0][13][15] = 0.0;
-    sim_out->body_[1][13][15] = 0.0;
-    sim_out->body_[2][13][15] = 0.0;
-    sim_out->body_[3][13][15] = 0.0;
-    sim_out->body_[0][14][15] = 0.0;
-    sim_out->body_[1][14][15] = 0.0;
-    sim_out->body_[2][14][15] = 0.0;
-    sim_out->body_[3][14][15] = 0.0;
-    sim_out->body_[0][15][15] = 0.0;
-    sim_out->body_[1][15][15] = 0.0;
-    sim_out->body_[2][15][15] = 0.0;
-    sim_out->body_[3][15][15] = 0.0;
-    sim_out->body_[0][16][15] = 0.0;
-    sim_out->body_[1][16][15] = 0.0;
-    sim_out->body_[2][16][15] = 0.0;
-    sim_out->body_[3][16][15] = 0.0;
-    sim_out->body_[0][17][15] = 0.0;
-    sim_out->body_[1][17][15] = 0.0;
-    sim_out->body_[2][17][15] = 0.0;
-    sim_out->body_[3][17][15] = 0.0;
-    sim_out->body_[0][18][15] = 0.0;
-    sim_out->body_[1][18][15] = 0.0;
-    sim_out->body_[2][18][15] = 0.0;
-    sim_out->body_[3][18][15] = 0.0;
-    sim_out->body_[0][19][15] = 0.0;
-    sim_out->body_[1][19][15] = 0.0;
-    sim_out->body_[2][19][15] = 0.0;
-    sim_out->body_[3][19][15] = 0.0;
-    sim_out->body_[0][20][15] = 0.0;
-    sim_out->body_[1][20][15] = 0.0;
-    sim_out->body_[2][20][15] = 0.0;
-    sim_out->body_[3][20][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    sim_out->body_soil_[0][12][15] = 0.0;
-    sim_out->body_soil_[1][12][15] = 0.0;
-    sim_out->body_soil_[0][13][15] = 0.0;
-    sim_out->body_soil_[1][13][15] = 0.0;
-    sim_out->body_soil_[0][14][15] = 0.0;
-    sim_out->body_soil_[1][14][15] = 0.0;
-    sim_out->body_soil_[0][15][15] = 0.0;
-    sim_out->body_soil_[1][15][15] = 0.0;
-    sim_out->body_soil_[2][16][15] = 0.0;
-    sim_out->body_soil_[3][16][15] = 0.0;
-    sim_out->body_soil_[2][17][15] = 0.0;
-    sim_out->body_soil_[3][17][15] = 0.0;
-    sim_out->body_soil_[0][18][15] = 0.0;
-    sim_out->body_soil_[1][18][15] = 0.0;
-    sim_out->body_soil_[2][19][15] = 0.0;
-    sim_out->body_soil_[3][19][15] = 0.0;
-    sim_out->body_soil_[0][20][15] = 0.0;
-    sim_out->body_soil_[1][20][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    body_pos = {
+        {0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {0, 12, 15},
+        {2, 12, 15}, {0, 13, 15}, {2, 13, 15}, {0, 14, 15}, {2, 14, 15},
+        {0, 15, 15}, {2, 15, 15}, {0, 16, 15}, {2, 16, 15}, {0, 17, 15},
+        {2, 17, 15}, {0, 18, 15}, {2, 18, 15}, {0, 19, 15}, {2, 19, 15},
+        {0, 20, 15}, {2, 20, 15}};
+    body_soil_pos = {
+        {0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {0, 12, 15}, {0, 13, 15},
+        {0, 14, 15}, {0, 15, 15}, {2, 16, 15}, {2, 17, 15}, {0, 18, 15},
+        {2, 19, 15}, {0, 20, 15}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, body_pos, body_soil_pos);
 
     // -- Testing when there are two bucket layers and soil is partially      --
     // -- avalanching on the second bucket layer, then two bucket layers and  --
@@ -5466,85 +4162,19 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[19].z_b, posK[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[19].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 20);
-    sim_out->body_[0][9][15] = 0.0;
-    sim_out->body_[1][9][15] = 0.0;
-    sim_out->body_[2][9][15] = 0.0;
-    sim_out->body_[3][9][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_[0][12][15] = 0.0;
-    sim_out->body_[1][12][15] = 0.0;
-    sim_out->body_[2][12][15] = 0.0;
-    sim_out->body_[3][12][15] = 0.0;
-    sim_out->body_[0][13][15] = 0.0;
-    sim_out->body_[1][13][15] = 0.0;
-    sim_out->body_[2][13][15] = 0.0;
-    sim_out->body_[3][13][15] = 0.0;
-    sim_out->body_[0][14][15] = 0.0;
-    sim_out->body_[1][14][15] = 0.0;
-    sim_out->body_[2][14][15] = 0.0;
-    sim_out->body_[3][14][15] = 0.0;
-    sim_out->body_[0][15][15] = 0.0;
-    sim_out->body_[1][15][15] = 0.0;
-    sim_out->body_[2][15][15] = 0.0;
-    sim_out->body_[3][15][15] = 0.0;
-    sim_out->body_[0][16][15] = 0.0;
-    sim_out->body_[1][16][15] = 0.0;
-    sim_out->body_[2][16][15] = 0.0;
-    sim_out->body_[3][16][15] = 0.0;
-    sim_out->body_[0][17][15] = 0.0;
-    sim_out->body_[1][17][15] = 0.0;
-    sim_out->body_[2][17][15] = 0.0;
-    sim_out->body_[3][17][15] = 0.0;
-    sim_out->body_[0][18][15] = 0.0;
-    sim_out->body_[1][18][15] = 0.0;
-    sim_out->body_[2][18][15] = 0.0;
-    sim_out->body_[3][18][15] = 0.0;
-    sim_out->body_[0][19][15] = 0.0;
-    sim_out->body_[1][19][15] = 0.0;
-    sim_out->body_[2][19][15] = 0.0;
-    sim_out->body_[3][19][15] = 0.0;
-    sim_out->body_[0][20][15] = 0.0;
-    sim_out->body_[1][20][15] = 0.0;
-    sim_out->body_[2][20][15] = 0.0;
-    sim_out->body_[3][20][15] = 0.0;
-    sim_out->body_soil_[0][9][15] = 0.0;
-    sim_out->body_soil_[1][9][15] = 0.0;
-    sim_out->body_soil_[2][9][15] = 0.0;
-    sim_out->body_soil_[3][9][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    sim_out->body_soil_[2][12][15] = 0.0;
-    sim_out->body_soil_[3][12][15] = 0.0;
-    sim_out->body_soil_[2][13][15] = 0.0;
-    sim_out->body_soil_[3][13][15] = 0.0;
-    sim_out->body_soil_[2][14][15] = 0.0;
-    sim_out->body_soil_[3][14][15] = 0.0;
-    sim_out->body_soil_[0][15][15] = 0.0;
-    sim_out->body_soil_[1][15][15] = 0.0;
-    sim_out->body_soil_[0][16][15] = 0.0;
-    sim_out->body_soil_[1][16][15] = 0.0;
-    sim_out->body_soil_[2][17][15] = 0.0;
-    sim_out->body_soil_[3][17][15] = 0.0;
-    sim_out->body_soil_[0][18][15] = 0.0;
-    sim_out->body_soil_[1][18][15] = 0.0;
-    sim_out->body_soil_[2][19][15] = 0.0;
-    sim_out->body_soil_[3][19][15] = 0.0;
-    sim_out->body_soil_[0][20][15] = 0.0;
-    sim_out->body_soil_[1][20][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    body_pos = {
+        {0, 9, 15}, {2, 9, 15}, {0, 10, 15}, {2, 10, 15}, {0, 11, 15},
+        {2, 11, 15}, {0, 12, 15}, {2, 12, 15}, {0, 13, 15}, {2, 13, 15},
+        {0, 14, 15}, {2, 14, 15}, {0, 15, 15}, {2, 15, 15}, {0, 16, 15},
+        {2, 16, 15}, {0, 17, 15}, {2, 17, 15}, {0, 18, 15}, {2, 18, 15},
+        {0, 19, 15}, {2, 19, 15}, {0, 20, 15}, {2, 20, 15}};
+    body_soil_pos = {
+        {0, 9, 15}, {2, 9, 15}, {2, 10, 15}, {0, 11, 15}, {2, 12, 15}, {2, 13, 15},
+        {2, 14, 15}, {0, 15, 15}, {0, 16, 15}, {2, 17, 15}, {0, 18, 15},
+        {2, 19, 15}, {0, 20, 15}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, body_pos, body_soil_pos);
 
     // -- Testing when there are two bucket layers and the soil on the first --
     // -- bucket layer is blocking the movement, then two bucket layers and  --
@@ -5650,52 +4280,16 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[8].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[8].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 9);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_[0][12][15] = 0.0;
-    sim_out->body_[1][12][15] = 0.0;
-    sim_out->body_[2][12][15] = 0.0;
-    sim_out->body_[3][12][15] = 0.0;
-    sim_out->body_[0][13][15] = 0.0;
-    sim_out->body_[1][13][15] = 0.0;
-    sim_out->body_[2][13][15] = 0.0;
-    sim_out->body_[3][13][15] = 0.0;
-    sim_out->body_[0][14][15] = 0.0;
-    sim_out->body_[1][14][15] = 0.0;
-    sim_out->body_[2][14][15] = 0.0;
-    sim_out->body_[3][14][15] = 0.0;
-    sim_out->body_[0][15][15] = 0.0;
-    sim_out->body_[1][15][15] = 0.0;
-    sim_out->body_[2][15][15] = 0.0;
-    sim_out->body_[3][15][15] = 0.0;
-    sim_out->body_[0][16][15] = 0.0;
-    sim_out->body_[1][16][15] = 0.0;
-    sim_out->body_[2][16][15] = 0.0;
-    sim_out->body_[3][16][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    sim_out->body_soil_[0][12][15] = 0.0;
-    sim_out->body_soil_[1][12][15] = 0.0;
-    sim_out->body_soil_[2][13][15] = 0.0;
-    sim_out->body_soil_[3][13][15] = 0.0;
-    sim_out->body_soil_[2][14][15] = 0.0;
-    sim_out->body_soil_[3][14][15] = 0.0;
-    sim_out->body_soil_[0][15][15] = 0.0;
-    sim_out->body_soil_[1][15][15] = 0.0;
-    sim_out->body_soil_[0][16][15] = 0.0;
-    sim_out->body_soil_[1][16][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    body_pos = {
+        {0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {0, 12, 15},
+        {2, 12, 15}, {0, 13, 15}, {2, 13, 15}, {0, 14, 15}, {2, 14, 15},
+        {0, 15, 15}, {2, 15, 15}, {0, 16, 15}, {2, 16, 15}};
+    body_soil_pos = {
+        {0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {0, 12, 15}, {2, 13, 15},
+        {2, 14, 15}, {0, 15, 15}, {0, 16, 15}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, body_pos, body_soil_pos);
 
     // -- Testing when there are two bucket layers and the soil is partially --
     // -- avalanching on the first bucket layer, then two bucket layers and  --
@@ -5828,52 +4422,16 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[11].z_b, posF[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[11].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 12);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_[0][12][15] = 0.0;
-    sim_out->body_[1][12][15] = 0.0;
-    sim_out->body_[2][12][15] = 0.0;
-    sim_out->body_[3][12][15] = 0.0;
-    sim_out->body_[0][13][15] = 0.0;
-    sim_out->body_[1][13][15] = 0.0;
-    sim_out->body_[2][13][15] = 0.0;
-    sim_out->body_[3][13][15] = 0.0;
-    sim_out->body_[0][14][15] = 0.0;
-    sim_out->body_[1][14][15] = 0.0;
-    sim_out->body_[2][14][15] = 0.0;
-    sim_out->body_[3][14][15] = 0.0;
-    sim_out->body_[0][15][15] = 0.0;
-    sim_out->body_[1][15][15] = 0.0;
-    sim_out->body_[2][15][15] = 0.0;
-    sim_out->body_[3][15][15] = 0.0;
-    sim_out->body_[0][16][15] = 0.0;
-    sim_out->body_[1][16][15] = 0.0;
-    sim_out->body_[2][16][15] = 0.0;
-    sim_out->body_[3][16][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    sim_out->body_soil_[0][12][15] = 0.0;
-    sim_out->body_soil_[1][12][15] = 0.0;
-    sim_out->body_soil_[2][13][15] = 0.0;
-    sim_out->body_soil_[3][13][15] = 0.0;
-    sim_out->body_soil_[2][14][15] = 0.0;
-    sim_out->body_soil_[3][14][15] = 0.0;
-    sim_out->body_soil_[0][15][15] = 0.0;
-    sim_out->body_soil_[1][15][15] = 0.0;
-    sim_out->body_soil_[2][16][15] = 0.0;
-    sim_out->body_soil_[3][16][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    body_pos = {
+        {0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {0, 12, 15},
+        {2, 12, 15}, {0, 13, 15}, {2, 13, 15}, {0, 14, 15}, {2, 14, 15},
+        {0, 15, 15}, {2, 15, 15}, {0, 16, 15}, {2, 16, 15}};
+    body_soil_pos = {
+        {0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {0, 12, 15}, {2, 13, 15},
+        {2, 14, 15}, {0, 15, 15}, {2, 16, 15}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, body_pos, body_soil_pos);
 
     // -- Testing when there are two bucket layers and the soil is partially  --
     // -- avalanching on the first bucket layer, then two bucket layers and   --
@@ -6063,79 +4621,19 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[17].z_b, posF[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[17].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 18);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_[0][12][15] = 0.0;
-    sim_out->body_[1][12][15] = 0.0;
-    sim_out->body_[2][12][15] = 0.0;
-    sim_out->body_[3][12][15] = 0.0;
-    sim_out->body_[0][13][15] = 0.0;
-    sim_out->body_[1][13][15] = 0.0;
-    sim_out->body_[2][13][15] = 0.0;
-    sim_out->body_[3][13][15] = 0.0;
-    sim_out->body_[0][14][15] = 0.0;
-    sim_out->body_[1][14][15] = 0.0;
-    sim_out->body_[2][14][15] = 0.0;
-    sim_out->body_[3][14][15] = 0.0;
-    sim_out->body_[0][15][15] = 0.0;
-    sim_out->body_[1][15][15] = 0.0;
-    sim_out->body_[2][15][15] = 0.0;
-    sim_out->body_[3][15][15] = 0.0;
-    sim_out->body_[0][16][15] = 0.0;
-    sim_out->body_[1][16][15] = 0.0;
-    sim_out->body_[2][16][15] = 0.0;
-    sim_out->body_[3][16][15] = 0.0;
-    sim_out->body_[0][17][15] = 0.0;
-    sim_out->body_[1][17][15] = 0.0;
-    sim_out->body_[2][17][15] = 0.0;
-    sim_out->body_[3][17][15] = 0.0;
-    sim_out->body_[0][18][15] = 0.0;
-    sim_out->body_[1][18][15] = 0.0;
-    sim_out->body_[2][18][15] = 0.0;
-    sim_out->body_[3][18][15] = 0.0;
-    sim_out->body_[0][19][15] = 0.0;
-    sim_out->body_[1][19][15] = 0.0;
-    sim_out->body_[2][19][15] = 0.0;
-    sim_out->body_[3][19][15] = 0.0;
-    sim_out->body_[0][20][15] = 0.0;
-    sim_out->body_[1][20][15] = 0.0;
-    sim_out->body_[2][20][15] = 0.0;
-    sim_out->body_[3][20][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    sim_out->body_soil_[0][12][15] = 0.0;
-    sim_out->body_soil_[1][12][15] = 0.0;
-    sim_out->body_soil_[0][13][15] = 0.0;
-    sim_out->body_soil_[1][13][15] = 0.0;
-    sim_out->body_soil_[2][14][15] = 0.0;
-    sim_out->body_soil_[3][14][15] = 0.0;
-    sim_out->body_soil_[2][15][15] = 0.0;
-    sim_out->body_soil_[3][15][15] = 0.0;
-    sim_out->body_soil_[0][16][15] = 0.0;
-    sim_out->body_soil_[1][16][15] = 0.0;
-    sim_out->body_soil_[2][17][15] = 0.0;
-    sim_out->body_soil_[3][17][15] = 0.0;
-    sim_out->body_soil_[2][18][15] = 0.0;
-    sim_out->body_soil_[3][18][15] = 0.0;
-    sim_out->body_soil_[0][19][15] = 0.0;
-    sim_out->body_soil_[1][19][15] = 0.0;
-    sim_out->body_soil_[0][20][15] = 0.0;
-    sim_out->body_soil_[1][20][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    body_pos = {
+        {0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {0, 12, 15},
+        {2, 12, 15}, {0, 13, 15}, {2, 13, 15}, {0, 14, 15}, {2, 14, 15},
+        {0, 15, 15}, {2, 15, 15}, {0, 16, 15}, {2, 16, 15}, {0, 17, 15},
+        {2, 17, 15}, {0, 18, 15}, {2, 18, 15}, {0, 19, 15}, {2, 19, 15},
+        {0, 20, 15}, {2, 20, 15}};
+    body_soil_pos = {
+        {0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {0, 12, 15}, {0, 13, 15},
+        {2, 14, 15}, {2, 15, 15}, {0, 16, 15}, {2, 17, 15}, {2, 18, 15},
+        {0, 19, 15}, {0, 20, 15}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, body_pos, body_soil_pos);
 
     // -- Testing when there are two bucket layers and the soil is partially --
     // -- avalanching on the second bucket layer, then two bucket layers and --
@@ -6178,8 +4676,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 1.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][12][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 0.8, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[12][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
     EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
@@ -6196,31 +4692,13 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[4].z_b, posB[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[4].h_soil, 0.7, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 5);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_[0][12][15] = 0.0;
-    sim_out->body_[1][12][15] = 0.0;
-    sim_out->body_[2][12][15] = 0.0;
-    sim_out->body_[3][12][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    sim_out->body_soil_[2][12][15] = 0.0;
-    sim_out->body_soil_[3][12][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    body_pos = {
+        {0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {0, 12, 15},
+        {2, 12, 15}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, body_pos,
+        {{0, 10, 15}, {2, 10, 15}, {2, 11, 15}, {2, 12, 15}});
 
     // -- Testing when several layers of soil is present at a given location --
     soil_simulator::rng.seed(1234);
@@ -6268,8 +4746,6 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][11][16], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][11][14], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][14], 0.2, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][15], 0.0, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[12][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
@@ -6295,31 +4771,11 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[8].z_b, posC[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[8].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 9);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[0][11][14] = 0.0;
-    sim_out->body_[1][11][14] = 0.0;
-    sim_out->body_[0][11][15] = 0.0;
-    sim_out->body_[1][11][15] = 0.0;
-    sim_out->body_[0][11][16] = 0.0;
-    sim_out->body_[1][11][16] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][11][14] = 0.0;
-    sim_out->body_soil_[1][11][14] = 0.0;
-    sim_out->body_soil_[0][11][15] = 0.0;
-    sim_out->body_soil_[1][11][15] = 0.0;
-    sim_out->body_soil_[0][11][16] = 0.0;
-    sim_out->body_soil_[1][11][16] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 14}, {0, 11, 15}, {0, 11, 16}},
+        {{0, 10, 15}, {2, 10, 15}, {0, 11, 14}, {0, 11, 15}, {0, 11, 16}});
 
     // -- Testing when there is nothing to move --
     soil_simulator::rng.seed(1234);
@@ -6352,23 +4808,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.9, 1e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_[2][11][15] = 0.0;
-    sim_out->body_[3][11][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][11][15] = 0.0;
-    sim_out->body_soil_[3][11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, {{0, 10, 15}, {2, 10, 15}, {2, 11, 15}},
+        {{0, 10, 15}, {2, 10, 15}, {2, 11, 15}});
 
     // -- Testing randomness of movement --
     soil_simulator::rng.seed(1234);
@@ -6407,33 +4850,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->terrain_[9][16], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[9][16] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{9, 16}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing that warning is properly sent when soil cannot be moved --
     // TBD: It is not straightforward to have proper warning system
     // This should be improved in the implementation in order to be able to
     // test it
-
-    // -- Testing that everything has been reset properly --
-    for (auto ii = 0; ii < sim_out->body_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->body_[0].size(); jj++)
-            for (auto kk = 0; kk < sim_out->body_[0][0].size(); kk++) {
-                EXPECT_NEAR(sim_out->body_[ii][jj][kk], 0.0, 1e-5);
-                EXPECT_NEAR(sim_out->body_soil_[ii][jj][kk], 0.0, 1e-5);
-            }
 
     delete bucket;
     delete sim_out;
@@ -6522,17 +4947,13 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
     sim_out->body_[1][10][18] = 0.5;
     sim_out->terrain_[11][17] = 0.1;
     soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][17], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[10][17], 0.1, 1e-5);
-    sim_out->terrain_[10][17] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    for (auto ii = 10; ii < 13; ii++)
-        for (auto jj = 16; jj < 19; jj++) {
-            sim_out->body_[0][ii][jj] = 0.0;
-            sim_out->body_[1][ii][jj] = 0.0;
-        }
+    // Resetting values
+    std::vector<std::vector<int>> body_pos = {
+        {0, 10, 16}, {0, 10, 18}, {0, 11, 16}, {0, 11, 17}, {0, 11, 18},
+        {0, 12, 16}, {0, 12, 17}, {0, 12, 18}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 17}}, body_pos, {});
 
     // -- Testing for a single intersecting cells in the +X direction --
     for (auto ii = 10; ii < 12; ii++)
@@ -6546,17 +4967,13 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
     sim_out->body_[1][12][18] = 0.5;
     sim_out->terrain_[11][17] = 0.2;
     soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][17], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][17], 0.2, 1e-5);
-    sim_out->terrain_[12][17] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    for (auto ii = 10; ii < 13; ii++)
-        for (auto jj = 16; jj < 19; jj++) {
-            sim_out->body_[0][ii][jj] = 0.0;
-            sim_out->body_[1][ii][jj] = 0.0;
-        }
+    // Resetting values
+    body_pos = { 
+        {0, 10, 16}, {0, 10, 17}, {0, 10, 18}, {0, 11, 16}, {0, 11, 17},
+        {0, 11, 18}, {0, 12, 16}, {0, 12, 18}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{12, 17}}, body_pos, {});
 
     // -- Testing for a single intersecting cells in the -Y direction --
     for (auto ii = 10; ii < 13; ii++)
@@ -6570,17 +4987,13 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
     sim_out->body_[1][12][16] = 0.5;
     sim_out->terrain_[11][17] = 0.05;
     soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][17], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][16], 0.05, 1e-5);
-    sim_out->terrain_[11][16] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    for (auto ii = 10; ii < 13; ii++)
-        for (auto jj = 16; jj < 19; jj++) {
-            sim_out->body_[0][ii][jj] = 0.0;
-            sim_out->body_[1][ii][jj] = 0.0;
-        }
+    // Resetting values
+    body_pos = {
+        {0, 10, 16}, {0, 10, 17}, {0, 10, 18}, {0, 11, 17}, {0, 11, 18},
+        {0, 12, 16}, {0, 12, 17}, {0, 12, 18}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{11, 16}}, body_pos, {});
 
     // -- Testing for a single intersecting cells in the +Y direction --
     for (auto ii = 10; ii < 13; ii++)
@@ -6594,17 +5007,13 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
     sim_out->body_[1][12][18] = 0.5;
     sim_out->terrain_[11][17] = 0.25;
     soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][17], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][18], 0.25, 1e-5);
-    sim_out->terrain_[11][18] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    for (auto ii = 10; ii < 13; ii++)
-        for (auto jj = 16; jj < 19; jj++) {
-            sim_out->body_[0][ii][jj] = 0.0;
-            sim_out->body_[1][ii][jj] = 0.0;
-        }
+    // Resetting values
+    body_pos = {
+        {0, 10, 16}, {0, 10, 17}, {0, 10, 18}, {0, 11, 16}, {0, 11, 17},
+        {0, 12, 16}, {0, 12, 17}, {0, 12, 18}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{11, 18}}, body_pos, {});
 
     // -- Testing for a single intersecting cells in the -X-Y direction --
     for (auto ii = 10; ii < 13; ii++)
@@ -6618,17 +5027,13 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
     sim_out->body_[1][12][16] = 0.5;
     sim_out->terrain_[11][17] = 0.4;
     soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][17], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[10][16], 0.4, 1e-5);
-    sim_out->terrain_[10][16] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    for (auto ii = 10; ii < 13; ii++)
-        for (auto jj = 16; jj < 19; jj++) {
-            sim_out->body_[0][ii][jj] = 0.0;
-            sim_out->body_[1][ii][jj] = 0.0;
-        }
+    // Resetting values
+    body_pos = {
+        {0, 10, 17}, {0, 10, 18}, {0, 11, 16}, {0, 11, 17}, {0, 11, 18},
+        {0, 12, 16}, {0, 12, 17}, {0, 12, 18}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 16}}, body_pos, {});
 
     // -- Testing for a single intersecting cells in the +X-Y direction --
     for (auto ii = 10; ii < 13; ii++)
@@ -6642,17 +5047,13 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
     sim_out->body_[1][11][16] = 0.5;
     sim_out->terrain_[11][17] = 0.1;
     soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][17], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][16], 0.1, 1e-5);
-    sim_out->terrain_[12][16] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    for (auto ii = 10; ii < 13; ii++)
-        for (auto jj = 16; jj < 19; jj++) {
-            sim_out->body_[0][ii][jj] = 0.0;
-            sim_out->body_[1][ii][jj] = 0.0;
-        }
+    // Resetting values
+    body_pos = {
+        {0, 10, 16}, {0, 10, 17}, {0, 10, 18}, {0, 11, 16}, {0, 11, 17},
+        {0, 11, 18}, {0, 12, 17}, {0, 12, 18}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{12, 16}}, body_pos, {});
 
     // -- Testing for a single intersecting cells in the -X+Y direction --
     for (auto ii = 10; ii < 13; ii++)
@@ -6666,17 +5067,13 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
     sim_out->body_[1][12][18] = 0.5;
     sim_out->terrain_[11][17] = 0.5;
     soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][17], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[10][18], 0.5, 1e-5);
-    sim_out->terrain_[10][18] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    for (auto ii = 10; ii < 13; ii++)
-        for (auto jj = 16; jj < 19; jj++) {
-            sim_out->body_[0][ii][jj] = 0.0;
-            sim_out->body_[1][ii][jj] = 0.0;
-        }
+    // Resetting values
+    body_pos = {
+        {0, 10, 16}, {0, 10, 17}, {0, 11, 16}, {0, 11, 17}, {0, 11, 18},
+        {0, 12, 16}, {0, 12, 17}, {0, 12, 18}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 18}}, body_pos, {});
 
     // -- Testing for a single intersecting cells in the +X+Y direction --
     for (auto ii = 10; ii < 13; ii++)
@@ -6690,17 +5087,13 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
     sim_out->body_[1][11][18] = 0.5;
     sim_out->terrain_[11][17] = 0.8;
     soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][17], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][18], 0.8, 1e-5);
-    sim_out->terrain_[12][18] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    for (auto ii = 10; ii < 13; ii++)
-        for (auto jj = 16; jj < 19; jj++) {
-            sim_out->body_[0][ii][jj] = 0.0;
-            sim_out->body_[1][ii][jj] = 0.0;
-        }
+    // Resetting values
+    body_pos = {
+        {0, 10, 16}, {0, 10, 17}, {0, 10, 18}, {0, 11, 16}, {0, 11, 17},
+        {0, 11, 18}, {0, 12, 16}, {0, 12, 17}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{12, 18}}, body_pos, {});
 
     // -- Testing for a single intersecting cells in the second bucket layer --
     for (auto ii = 10; ii < 13; ii++)
@@ -6714,17 +5107,13 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
     sim_out->body_[3][12][18] = 0.5;
     sim_out->terrain_[11][17] = 0.5;
     soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][17], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[10][18], 0.5, 1e-5);
-    sim_out->terrain_[10][18] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    for (auto ii = 10; ii < 13; ii++)
-        for (auto jj = 16; jj < 19; jj++) {
-            sim_out->body_[2][ii][jj] = 0.0;
-            sim_out->body_[3][ii][jj] = 0.0;
-        }
+    // Resetting values
+    body_pos = {
+        {2, 10, 16}, {2, 10, 17}, {2, 11, 16}, {2, 11, 17}, {2, 11, 18},
+        {2, 12, 16}, {2, 12, 17}, {2, 12, 18}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 18}}, body_pos, {});
 
     // -- Testing for a single intersecting cells with various bucket layer --
     sim_out->body_[2][10][16] = 0.0;
@@ -6749,19 +5138,13 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
     sim_out->body_[3][12][18] = 0.5;
     sim_out->terrain_[11][17] = 0.5;
     soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
-    EXPECT_NEAR(sim_out->terrain_[11][17], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[10][18], 0.5, 1e-5);
-    sim_out->terrain_[10][18] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    for (auto ii = 10; ii < 13; ii++)
-        for (auto jj = 16; jj < 19; jj++) {
-            sim_out->body_[0][ii][jj] = 0.0;
-            sim_out->body_[1][ii][jj] = 0.0;
-            sim_out->body_[2][ii][jj] = 0.0;
-            sim_out->body_[3][ii][jj] = 0.0;
-        }
+    // Resetting values
+    body_pos = {
+        {2, 10, 16}, {2, 10, 17}, {0, 11, 16}, {0, 11, 17}, {0, 12, 16},
+        {2, 12, 16}, {0, 12, 17}, {2, 12, 17}, {0, 11, 18}, {2, 12, 18}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 18}}, body_pos, {});
 
     // -- Testing for single intersecting cells with all bucket under terrain --
     for (auto ii = 10; ii < 13; ii++)
@@ -6781,18 +5164,12 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
     soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][17], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][18], 1.0, 1e-5);
-    sim_out->terrain_[12][18] = 0.0;
-    sim_out->terrain_[11][17] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    for (auto ii = 10; ii < 13; ii++)
-        for (auto jj = 16; jj < 19; jj++) {
-            sim_out->body_[0][ii][jj] = 0.0;
-            sim_out->body_[1][ii][jj] = 0.0;
-        }
-    sim_out->body_[2][11][17] = 0.0;
-    sim_out->body_[3][11][17] = 0.0;
+    // Resetting values
+    body_pos = {
+        {0, 10, 16}, {0, 10, 17}, {0, 10, 18}, {0, 11, 16}, {0, 11, 17},
+        {2, 11, 17}, {0, 11, 18}, {0, 12, 16}, {0, 12, 17}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{12, 18}, {11, 17}}, body_pos, {});
 
     // -- Testing for a single intersecting cells under a large bucket --
     for (auto ii = 8; ii < 15; ii++)
@@ -6808,16 +5185,14 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
     soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][17], -0.4, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[8][17], 0.9, 1e-5);
-    sim_out->terrain_[8][17] = 0.0;
-    sim_out->terrain_[11][17] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
+    // Resetting values
+    body_pos = {};
     for (auto ii = 8; ii < 15; ii++)
         for (auto jj = 14; jj < 21; jj++) {
-            sim_out->body_[0][ii][jj] = 0.0;
-            sim_out->body_[1][ii][jj] = 0.0;
+            body_pos.push_back(std::vector<int> {0, ii, jj});
         }
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{8, 17}, {11, 17}}, body_pos, {});
 
     // -- Testing when soil is moved by small amount (1) --
     // Soil is fitting under the bucket
@@ -6854,25 +5229,22 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
     EXPECT_NEAR(sim_out->terrain_[13][17], 0.05, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[13][19], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[14][20], 0.2, 1e-5);
-    sim_out->terrain_[11][17] = 0.0;
-    sim_out->terrain_[10][17] = 0.0;
-    sim_out->terrain_[8][17] = 0.0;
-    sim_out->terrain_[12][17] = 0.0;
-    sim_out->terrain_[13][17] = 0.0;
-    sim_out->terrain_[13][19] = 0.0;
-    sim_out->terrain_[14][20] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    for (auto ii = 8; ii < 15; ii++)
-        for (auto jj = 14; jj < 21; jj++) {
-            sim_out->body_[0][ii][jj] = 0.0;
-            sim_out->body_[1][ii][jj] = 0.0;
-        }
-    sim_out->body_[2][13][17] = 0.0;
-    sim_out->body_[3][13][17] = 0.0;
-    sim_out->body_[2][14][20] = 0.0;
-    sim_out->body_[3][14][20] = 0.0;
+    // Resetting values
+    body_pos = {
+        {0, 8, 14}, {0, 8, 15}, {0, 8, 16}, {0, 8, 17}, {0, 8, 18}, {0, 8, 19},
+        {0, 8, 20}, {0, 9, 14}, {0, 9, 15}, {0, 9, 16}, {0, 9, 17}, {0, 9, 18},
+        {0, 9, 19}, {0, 9, 20}, {0, 10, 14}, {0, 10, 15}, {0, 10, 16},
+        {0, 10, 17}, {0, 10, 18}, {0, 10, 19}, {0, 10, 20}, {0, 11, 14},
+        {0, 11, 15}, {0, 11, 16}, {0, 11, 17}, {0, 11, 18}, {0, 11, 19},
+        {0, 11, 20}, {0, 12, 14}, {0, 12, 15}, {0, 12, 16}, {0, 12, 17},
+        {0, 12, 18}, {0, 12, 19}, {0, 12, 20}, {0, 13, 14}, {0, 13, 15},
+        {0, 13, 16}, {0, 13, 17}, {0, 13, 18}, {0, 13, 19}, {0, 13, 20},
+        {0, 14, 14}, {0, 14, 15}, {0, 14, 16}, {0, 14, 17}, {0, 14, 18},
+        {0, 14, 19}, {2, 13, 17}, {2, 14, 20}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out,
+        {{11, 17}, {10, 17}, {8, 17}, {12, 17}, {13, 17}, {13, 19}, {14, 20}},
+        body_pos, {});
 
     // -- Testing when soil is moved by small amount (2) --
     // Soil is going out of the bucket
@@ -6910,26 +5282,23 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
     EXPECT_NEAR(sim_out->terrain_[13][19], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[14][20], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[15][17], 0.2, 1e-5);
-    sim_out->terrain_[11][17] = 0.0;
-    sim_out->terrain_[10][17] = 0.0;
-    sim_out->terrain_[8][17] = 0.0;
-    sim_out->terrain_[12][17] = 0.0;
-    sim_out->terrain_[13][17] = 0.0;
-    sim_out->terrain_[13][19] = 0.0;
-    sim_out->terrain_[14][20] = 0.0;
-    sim_out->terrain_[15][17] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    for (auto ii = 8; ii < 15; ii++)
-        for (auto jj = 14; jj < 21; jj++) {
-            sim_out->body_[0][ii][jj] = 0.0;
-            sim_out->body_[1][ii][jj] = 0.0;
-        }
-    sim_out->body_[2][13][17] = 0.0;
-    sim_out->body_[3][13][17] = 0.0;
-    sim_out->body_[2][14][20] = 0.0;
-    sim_out->body_[3][14][20] = 0.0;
+    // Resetting values
+    std::vector<std::vector<int>> terrain_pos = {
+        {11, 17}, {10, 17}, {8, 17}, {12, 17}, {13, 17}, {13, 19}, {14, 20},
+        {15, 17}};
+    body_pos = {
+        {0, 8, 14}, {0, 8, 15}, {0, 8, 16}, {0, 8, 17}, {0, 8, 18}, {0, 8, 19},
+        {0, 8, 20}, {0, 9, 14}, {0, 9, 15}, {0, 9, 16}, {0, 9, 17}, {0, 9, 18},
+        {0, 9, 19}, {0, 9, 20}, {0, 10, 14}, {0, 10, 15}, {0, 10, 16},
+        {0, 10, 17}, {0, 10, 18}, {0, 10, 19}, {0, 10, 20}, {0, 11, 14},
+        {0, 11, 15}, {0, 11, 16}, {0, 11, 17}, {0, 11, 18}, {0, 11, 19},
+        {0, 11, 20}, {0, 12, 14}, {0, 12, 15}, {0, 12, 16}, {0, 12, 17},
+        {0, 12, 18}, {0, 12, 19}, {0, 12, 20}, {0, 13, 14}, {0, 13, 15},
+        {0, 13, 16}, {0, 13, 17}, {0, 13, 18}, {0, 13, 19}, {0, 13, 20},
+        {0, 14, 14}, {0, 14, 15}, {0, 14, 16}, {0, 14, 17}, {0, 14, 18},
+        {0, 14, 19}, {2, 13, 17}, {2, 14, 20}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, terrain_pos, body_pos, {});
 
     // -- Testing when soil is moved by small amount (3) --
     // Soil is just fitting under the bucket
@@ -6966,25 +5335,22 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
     EXPECT_NEAR(sim_out->terrain_[13][17], 0.05, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[13][19], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[14][20], 0.2, 1e-5);
-    sim_out->terrain_[11][17] = 0.0;
-    sim_out->terrain_[10][17] = 0.0;
-    sim_out->terrain_[8][17] = 0.0;
-    sim_out->terrain_[12][17] = 0.0;
-    sim_out->terrain_[13][17] = 0.0;
-    sim_out->terrain_[13][19] = 0.0;
-    sim_out->terrain_[14][20] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    for (auto ii = 8; ii < 15; ii++)
-        for (auto jj = 14; jj < 21; jj++) {
-            sim_out->body_[0][ii][jj] = 0.0;
-            sim_out->body_[1][ii][jj] = 0.0;
-        }
-    sim_out->body_[2][13][17] = 0.0;
-    sim_out->body_[3][13][17] = 0.0;
-    sim_out->body_[2][14][20] = 0.0;
-    sim_out->body_[3][14][20] = 0.0;
+    // Resetting values
+    body_pos = {
+        {0, 8, 14}, {0, 8, 15}, {0, 8, 16}, {0, 8, 17}, {0, 8, 18}, {0, 8, 19},
+        {0, 8, 20}, {0, 9, 14}, {0, 9, 15}, {0, 9, 16}, {0, 9, 17}, {0, 9, 18},
+        {0, 9, 19}, {0, 9, 20}, {0, 10, 14}, {0, 10, 15}, {0, 10, 16},
+        {0, 10, 17}, {0, 10, 18}, {0, 10, 19}, {0, 10, 20}, {0, 11, 14},
+        {0, 11, 15}, {0, 11, 16}, {0, 11, 17}, {0, 11, 18}, {0, 11, 19},
+        {0, 11, 20}, {0, 12, 14}, {0, 12, 15}, {0, 12, 16}, {0, 12, 17},
+        {0, 12, 18}, {0, 12, 19}, {0, 12, 20}, {0, 13, 14}, {0, 13, 15},
+        {0, 13, 16}, {0, 13, 17}, {0, 13, 18}, {0, 13, 19}, {0, 13, 20},
+        {0, 14, 14}, {0, 14, 15}, {0, 14, 16}, {0, 14, 17}, {0, 14, 18},
+        {0, 14, 19}, {2, 13, 17}, {2, 14, 20}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out,
+        {{11, 17}, {10, 17}, {8, 17}, {12, 17}, {13, 17}, {13, 19}, {14, 20}},
+        body_pos, {});
 
     // -- Testing when there is nothing to move --
     for (auto ii = 8; ii < 15; ii++)
@@ -6993,14 +5359,20 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
             sim_out->body_[1][ii][jj] = 0.2;
         }
     soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    for (auto ii = 8; ii < 15; ii++)
-        for (auto jj = 14; jj < 21; jj++) {
-            sim_out->body_[0][ii][jj] = 0.0;
-            sim_out->body_[1][ii][jj] = 0.0;
-        }
+    // Resetting values
+    body_pos = {
+        {0, 8, 14}, {0, 8, 15}, {0, 8, 16}, {0, 8, 17}, {0, 8, 18}, {0, 8, 19},
+        {0, 8, 20}, {0, 9, 14}, {0, 9, 15}, {0, 9, 16}, {0, 9, 17}, {0, 9, 18},
+        {0, 9, 19}, {0, 9, 20}, {0, 10, 14}, {0, 10, 15}, {0, 10, 16},
+        {0, 10, 17}, {0, 10, 18}, {0, 10, 19}, {0, 10, 20}, {0, 11, 14},
+        {0, 11, 15}, {0, 11, 16}, {0, 11, 17}, {0, 11, 18}, {0, 11, 19},
+        {0, 11, 20}, {0, 12, 14}, {0, 12, 15}, {0, 12, 16}, {0, 12, 17},
+        {0, 12, 18}, {0, 12, 19}, {0, 12, 20}, {0, 13, 14}, {0, 13, 15},
+        {0, 13, 16}, {0, 13, 17}, {0, 13, 18}, {0, 13, 19}, {0, 13, 20},
+        {0, 14, 14}, {0, 14, 15}, {0, 14, 16}, {0, 14, 17}, {0, 14, 18},
+        {0, 14, 19}, {0, 14, 20}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {}, body_pos, {});
 
     // -- Testing randomness of movement --
     soil_simulator::rng.seed(1234);
@@ -7017,21 +5389,9 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
     soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][17], -0.4, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[10][18], 0.9, 1e-5);
-    sim_out->terrain_[11][17] = 0.0;
-    sim_out->terrain_[10][18] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_[0][11][17] = 0.0;
-    sim_out->body_[1][11][17] = 0.0;
-
-    // -- Testing that everything has been reset properly --
-    for (auto ii = 0; ii < sim_out->body_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->body_[0].size(); jj++)
-            for (auto kk = 0; kk < sim_out->body_[0][0].size(); kk++) {
-                EXPECT_NEAR(sim_out->body_[ii][jj][kk], 0.0, 1e-5);
-                EXPECT_NEAR(sim_out->body_soil_[ii][jj][kk], 0.0, 1e-5);
-            }
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{11, 17}, {10, 18}}, {{0, 11, 17}}, {});
 
     delete sim_out;
 }

--- a/test/unit_tests/test_intersecting_cells.cpp
+++ b/test/unit_tests/test_intersecting_cells.cpp
@@ -24,9 +24,8 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     auto pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.7, grid, bucket);
     auto pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.0, grid, bucket);
 
-    // Setting lambda function to set initial state
-    auto SetInitState = [&]() 
-    {
+    // Creating a lambda function to set the initial state
+    auto SetInitState = [&]() {
         sim_out->body_[0][10][15] = 0.3;
         sim_out->body_[1][10][15] = 0.7;
         sim_out->body_[2][10][15] = -0.2;
@@ -3732,7 +3731,7 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
         {0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {0, 12, 15},
         {2, 12, 15}};
     test_soil_simulator::ResetValueAndTest(
-        sim_out, {}, body_pos, 
+        sim_out, {}, body_pos,
         {{0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {2, 12, 15}});
 
     // -- Testing when there are two bucket layers and the soil is partially  --
@@ -4170,9 +4169,9 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
         {2, 16, 15}, {0, 17, 15}, {2, 17, 15}, {0, 18, 15}, {2, 18, 15},
         {0, 19, 15}, {2, 19, 15}, {0, 20, 15}, {2, 20, 15}};
     body_soil_pos = {
-        {0, 9, 15}, {2, 9, 15}, {2, 10, 15}, {0, 11, 15}, {2, 12, 15}, {2, 13, 15},
-        {2, 14, 15}, {0, 15, 15}, {0, 16, 15}, {2, 17, 15}, {0, 18, 15},
-        {2, 19, 15}, {0, 20, 15}};
+        {0, 9, 15}, {2, 9, 15}, {2, 10, 15}, {0, 11, 15}, {2, 12, 15},
+        {2, 13, 15}, {2, 14, 15}, {0, 15, 15}, {0, 16, 15}, {2, 17, 15},
+        {0, 18, 15}, {2, 19, 15}, {0, 20, 15}};
     test_soil_simulator::ResetValueAndTest(
         sim_out, {}, body_pos, body_soil_pos);
 
@@ -4969,7 +4968,7 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
     soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][17], 0.2, 1e-5);
     // Resetting values
-    body_pos = { 
+    body_pos = {
         {0, 10, 16}, {0, 10, 17}, {0, 10, 18}, {0, 11, 16}, {0, 11, 17},
         {0, 11, 18}, {0, 12, 16}, {0, 12, 18}};
     test_soil_simulator::ResetValueAndTest(

--- a/test/unit_tests/test_relax.cpp
+++ b/test/unit_tests/test_relax.cpp
@@ -7,6 +7,7 @@ Copyright, 2023, Vilella Kenny.
 #include "gtest/gtest.h"
 #include "soil_simulator/relax.hpp"
 #include "soil_simulator/utils.hpp"
+#include "test/unit_tests/utility.hpp"
 
 TEST(UnitTestRelax, LocateUnstableTerrainCell) {
     // Setting up the environment
@@ -63,7 +64,8 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 40);
-    sim_out->terrain_[10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(sim_out, {{10, 15}}, {}, {});
 
     // -- Testing case where there is first bucket layer with space under it --
     sim_out->terrain_[10][15] = -0.2;
@@ -72,9 +74,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 10);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}}, {});
 
     // -- Testing case with first bucket layer and soil avalanche on it --
     sim_out->terrain_[10][15] = -0.4;
@@ -83,9 +85,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 14);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}}, {});
 
     // -- Testing case with first bucket layer and it is high enough to --
     // -- prevent the soil from avalanching                             --
@@ -95,9 +97,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 0);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}}, {});
 
     // -- Testing case where there is first bucket layer with bucket soil --
     // -- and it has space under it                                       --
@@ -109,11 +111,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 10);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}}, {{0, 10, 15}});
 
     // -- Testing case where there is first bucket layer with bucket soil --
     // -- and soil should avalanche on it                                 --
@@ -125,11 +125,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 13);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}}, {{0, 10, 15}});
 
     // -- Testing case where there is first bucket layer with bucket soil --
     // -- and it is high enough to prevent the soil from avalanching      --
@@ -141,11 +139,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 0);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}}, {{0, 10, 15}});
 
     // -- Testing case with second bucket layer and it has space under it --
     sim_out->terrain_[10][15] = -0.2;
@@ -154,9 +150,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 20);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{2, 10, 15}}, {});
 
     // -- Testing case with second bucket layer and soil avalanche on it --
     sim_out->terrain_[10][15] = -0.4;
@@ -165,9 +161,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 22);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{2, 10, 15}}, {});
 
     // -- Testing case with second bucket layer and it is high enough to --
     // -- prevent the soil from avalanching                              --
@@ -177,9 +173,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 0);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{2, 10, 15}}, {});
 
     // -- Testing case where there is second bucket layer with bucket soil --
     // -- and it has space under it                                        --
@@ -191,11 +187,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 20);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{2, 10, 15}}, {{2, 10, 15}});
 
     // -- Testing case where there is second bucket layer with bucket soil --
     // -- and soil should avalanche on it                                  --
@@ -207,11 +201,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 21);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{2, 10, 15}}, {{2, 10, 15}});
 
     // -- Testing case where there is second bucket layer with bucket soil --
     // -- and it is high enough to prevent the soil from avalanching       --
@@ -223,11 +215,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 0);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{2, 10, 15}}, {{2, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer being lower --
     // -- and it has space under it                                    --
@@ -239,11 +229,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 30);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}}, {});
 
     // -- Testing case with two bucket layers, first layer being lower --
     // -- and soil should avalanche on the first bucket layer          --
@@ -255,11 +243,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 34);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}}, {});
 
     // -- Testing case with two bucket layers, first layer being lower and    --
     // -- second bucket layer is high enough to prevent soil from avalanching --
@@ -272,11 +258,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 34);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}}, {});
 
     // -- Testing case with two bucket layers, first layer being lower and --
     // -- it has space under it, while second layer is with bucket soil    --
@@ -290,13 +274,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 30);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}}, {{2, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer being lower,      --
     // -- second bucket layer with bucket soil, soil avalanche on the first  --
@@ -311,13 +291,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 34);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}}, {{2, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer being lower and --
     // -- second bucket layer with bucket soil is high enough to prevent   --
@@ -332,13 +308,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 34);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}}, {{2, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer with bucket soil --
     // -- being lower and has space under it                                --
@@ -352,13 +324,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 30);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}}, {{0, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer with bucket soil --
     // -- being lower, soil should avalanche on the first bucket soil layer --
@@ -372,13 +340,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 33);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}}, {{0, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer with bucket soil --
     // -- being lower, second bucket layer is high enough to prevent soil   --
@@ -393,13 +357,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 33);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}}, {{0, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer with bucket soil --
     // -- being lower, soil fill the space between the two bucket layers,   --
@@ -414,13 +374,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 30);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}}, {{0, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer with bucket soil --
     // -- being lower, soil fill the space between the two bucket layers,   --
@@ -435,13 +391,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 32);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}}, {{0, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer with bucket soil   --
     // -- being lower, soil fill the space between the two bucket layers,     --
@@ -457,13 +409,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 0);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}}, {{0, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil, --
     // -- first layer being lower and it has space under it                --
@@ -479,15 +427,10 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 30);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil, --
     // -- first layer being lower, soil should avalanche on first          --
@@ -504,15 +447,10 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 33);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil, --
     // -- first layer being lower, second bucket layer is high enough to   --
@@ -530,15 +468,10 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 33);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil,    --
     // -- first layer being lower, soil fill the space between the two bucket --
@@ -555,15 +488,10 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 30);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil,    --
     // -- first layer being lower, soil fill the space between the two bucket --
@@ -580,15 +508,10 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 31);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil,    --
     // -- first layer being lower, soil fill the space between the two bucket --
@@ -606,15 +529,10 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 0);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer being lower and --
     // -- it has space under it                                             --
@@ -626,11 +544,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 30);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}}, {});
 
     // -- Testing case with two bucket layers, second layer being lower and --
     // -- soil should avalanche on the second bucket layer                  --
@@ -642,11 +558,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 32);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}}, {});
 
     // -- Testing case with two bucket layers, second layer being lower and   --
     // -- first bucket layer is high enough to prevent soil from avalanching, --
@@ -659,11 +573,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 32);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}}, {});
 
     // -- Testing case with two bucket layers, second layer being lower and --
     // -- has space under it, while the first layer is with bucket soil     --
@@ -677,13 +589,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 30);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}}, {{0, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer being lower,    --
     // -- first bucket layer with bucket soil, soil should avalanche on the --
@@ -698,13 +606,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 32);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}}, {{0, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer being lower and --
     // -- first bucket layer with bucket soil is high enough to prevent     --
@@ -719,13 +623,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 32);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}}, {{0, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer with bucket soil --
     // -- being lower and it has space under it                              --
@@ -739,13 +639,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 30);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}}, {{2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer with bucket soil --
     // -- being lower, soil should avalanche on the second bucket layer      --
@@ -759,13 +655,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 31);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}}, {{2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer with bucket soil --
     // -- being lower, first bucket layer is high enough to prevent soil     --
@@ -780,13 +672,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 31);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}}, {{2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer with bucket soil --
     // -- being lower, soil fill the space between the two bucket layers,    --
@@ -801,13 +689,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 30);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}}, {{2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer with bucket soil --
     // -- being lower, soil fill the space between the two bucket layers,    --
@@ -822,13 +706,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 34);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}}, {{2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer with bucket soil --
     // -- being lower, soil fill the space between the two bucket layers,    --
@@ -844,13 +724,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 0);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}}, {{2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil, --
     // -- second layer being lower and has space under it                  --
@@ -866,15 +742,10 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 30);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil, --
     // -- second layer being lower, soil avalanche on second bucket layer  --
@@ -890,15 +761,10 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 31);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil, --
     // -- second layer being lower, first bucket layer is high enough to   --
@@ -916,15 +782,10 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 31);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil, --
     // -- second layer being lower, soil fill the space between the two    --
@@ -941,15 +802,10 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 30);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil, --
     // -- second layer being lower, soil fill the space between the two    --
@@ -966,15 +822,10 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 33);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil, --
     // -- second layer being lower, soil fill the space between the two    --
@@ -992,15 +843,10 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 0);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing edge case where a lot of space under the bucket is present --
     sim_out->terrain_[10][15] = -1.0;
@@ -1009,9 +855,9 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.6, 1e-5);
     EXPECT_EQ(status, 10);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}}, {});
 
     // -- Testing edge case for soil avalanching on the bucket --
     sim_out->terrain_[10][15] = -0.4;
@@ -1020,16 +866,17 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 0);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}}, {});
 
     // -- Testing edge case for soil avalanching on terrain --
     sim_out->terrain_[10][15] = -0.4;
     status = soil_simulator::CheckUnstableTerrainCell(
         sim_out, 10, 15, -0.4, 1e-5);
     EXPECT_EQ(status, 0);
-    sim_out->terrain_[10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(sim_out, {{10, 15}}, {}, {});
 
     delete sim_out;
 }
@@ -1055,8 +902,9 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->terrain_[10][14], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[10][15], 0.2, 1e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 0);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {}, {});
 
     // -- Testing case where there is first bucket layer with space under it, --
     // -- soil fully avalanche                                                --
@@ -1068,10 +916,9 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->terrain_[10][14], -0.3, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[10][15], -0.5, 1e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 0);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 15}}, {});
 
     // -- Testing case where there is first bucket layer with space under it, --
     // -- soil partially avalanche                                            --
@@ -1083,10 +930,9 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->terrain_[10][14], -0.4, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[10][15], -0.4, 1e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 0);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 15}}, {});
 
     // -- Testing case with first bucket layer and soil fully avalanche on it --
     sim_out->terrain_[10][15] = -0.4;
@@ -1107,14 +953,9 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 15}}, {{0, 10, 15}});
 
     // -- Testing case where there is first bucket layer with bucket soil --
     // -- and it has space under it, soil fully avalanche                 --
@@ -1133,14 +974,9 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], -0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.3, 1e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 15}}, {{0, 10, 15}});
 
     // -- Testing case where there is first bucket layer with bucket soil --
     // -- and it has space under it, soil partially avalanche             --
@@ -1159,14 +995,9 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], -0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.3, 1e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 15}}, {{0, 10, 15}});
 
     // -- Testing case where there is first bucket layer with bucket soil --
     // -- and soil fully avalanche on it                                  --
@@ -1192,14 +1023,9 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 15}}, {{0, 10, 15}});
 
     // -- Testing case where there is second bucket layer with space under it --
     // -- soil fully avalanche                                                --
@@ -1211,10 +1037,9 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->terrain_[10][14], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[10][15], -0.4, 1e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 0);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{2, 10, 15}}, {});
 
     // -- Testing case where there is second bucket layer with space under it --
     // -- soil partially avalanche                                            --
@@ -1226,10 +1051,9 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->terrain_[10][14], -0.3, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[10][15], -0.3, 1e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 0);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{2, 10, 15}}, {});
 
     // -- Testing case with second bucket layer and soil fully avalanche --
     // -- on it                                                          --
@@ -1251,14 +1075,9 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{2, 10, 15}}, {{2, 10, 15}});
 
     // -- Testing case where there is second bucket layer with bucket soil --
     // -- and it has space under it, soil fully avalanche                  --
@@ -1277,14 +1096,9 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.3, 1e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{2, 10, 15}}, {{2, 10, 15}});
 
     // -- Testing case where there is second bucket layer with bucket soil --
     // -- and it has space under it, soil partially avalanche              --
@@ -1303,14 +1117,9 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.5, 1e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{2, 10, 15}}, {{2, 10, 15}});
 
     // -- Testing case where there is second bucket layer with bucket soil --
     // -- and soil should fully avalanche on it                            --
@@ -1336,14 +1145,9 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{2, 10, 15}}, {{2, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer being lower --
     // -- and it has space under it, soil fully avalanche              --
@@ -1357,12 +1161,9 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->terrain_[10][14], -0.1, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[10][15], -0.7, 1e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 0);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 15}, {2, 10, 15}}, {});
 
     // -- Testing case with two bucket layers, first layer being lower --
     // -- and it has space under it, soil partially avalanche          --
@@ -1376,12 +1177,9 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->terrain_[10][14], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[10][15], -0.3, 1e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 0);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 15}, {2, 10, 15}}, {});
 
     // -- Testing case with two bucket layers, first layer being lower --
     // -- and soil should fully avalanche on the first bucket layer    --
@@ -1405,16 +1203,10 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer being lower  --
     // -- and soil should partially avalanche on the first bucket layer --
@@ -1438,16 +1230,10 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer with bucket soil --
     // -- being lower, soil fill the space between the two bucket layers,   --
@@ -1479,18 +1265,10 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil, --
     // -- first layer being lower, soil should fully avalanche on first    --
@@ -1526,18 +1304,10 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil,  --
     // -- first layer being lower, soil should partially avalanche on first --
@@ -1573,18 +1343,10 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil,    --
     // -- first layer being lower, soil fill the space between the two bucket --
@@ -1620,18 +1382,10 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer being lower --
     // -- and it has space under it, soil fully avalanche               --
@@ -1645,12 +1399,9 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->terrain_[10][14], -0.1, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[10][15], -0.7, 1e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 0);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 15}, {2, 10, 15}}, {});
 
     // -- Testing case with two bucket layers, second layer being lower --
     // -- and it has space under it, soil partially avalanche           --
@@ -1664,12 +1415,9 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->terrain_[10][14], -0.4, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[10][15], -0.4, 1e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 0);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 15}, {2, 10, 15}}, {});
 
     // -- Testing case with two bucket layers, second layer being lower --
     // -- and soil should fully avalanche on the second bucket layer    --
@@ -1693,16 +1441,10 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 15}, {2, 10, 15}},
+        {{2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer being lower  --
     // -- and soil should partially avalanche on the second bucket layer --
@@ -1726,16 +1468,10 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 15}, {2, 10, 15}},
+        {{2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer with bucket soil --
     // -- being lower, soil fill the space between the two bucket layers,    --
@@ -1767,18 +1503,10 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil, --
     // -- second layer being lower, soil should fully avalanche on second  --
@@ -1814,18 +1542,10 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil,    --
     // -- second layer being lower, soil should partially avalanche on second --
@@ -1861,18 +1581,10 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil,  --
     // -- second layer being lower, soil fill the space between the two     --
@@ -1909,18 +1621,10 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     delete bucket;
     delete sim_out;
@@ -1959,11 +1663,9 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 15);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 0);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}, {10, 16}}, {}, {});
 
     // -- Testing case with no bucket and soil is unstable --
     soil_simulator::rng.seed(200);
@@ -1980,11 +1682,9 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 0);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}, {10, 16}}, {}, {});
 
     // -- Testing case where there is first bucket layer with space under it --
     soil_simulator::rng.seed(200);
@@ -2003,13 +1703,9 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 0);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}, {10, 16}}, {{0, 10, 15}}, {});
 
     // -- Testing case with first bucket layer and soil avalanche on it --
     soil_simulator::rng.seed(200);
@@ -2038,17 +1734,9 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}, {10, 16}}, {{0, 10, 15}}, {{0, 10, 15}});
 
     // -- Testing case with first bucket layer and it is high enough to --
     // -- prevent the soil from avalanching                             --
@@ -2067,13 +1755,9 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 0);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}, {10, 16}}, {{0, 10, 15}}, {});
 
     // -- Testing case where there is first bucket layer with bucket soil --
     // -- and it has space under it                                       --
@@ -2100,17 +1784,9 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}, {10, 16}}, {{0, 10, 15}}, {{0, 10, 15}});
 
     // -- Testing case where there is first bucket layer with bucket soil --
     // -- and soil should avalanche on it                                 --
@@ -2152,18 +1828,9 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->terrain_[9][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{9, 15}, {10, 15}, {10, 16}}, {{0, 10, 15}}, {{0, 10, 15}});
 
     // -- Testing case where there is first bucket layer with bucket soil --
     // -- and it is high enough to prevent the soil from avalanching      --
@@ -2189,16 +1856,9 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{0, 10, 15}}, {{0, 10, 15}});
 
     // -- Testing case with second bucket layer and it has space under it --
     soil_simulator::rng.seed(200);
@@ -2217,13 +1877,9 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 0);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}, {10, 16}}, {{2, 10, 15}}, {});
 
     // -- Testing case with second bucket layer and soil avalanche on it --
     soil_simulator::rng.seed(200);
@@ -2252,17 +1908,9 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}, {10, 16}}, {{2, 10, 15}}, {{2, 10, 15}});
 
     // -- Testing case with second bucket layer and it is high enough to --
     // -- prevent the soil from avalanching                              --
@@ -2281,12 +1929,9 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 0);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{2, 10, 15}}, {});
 
     // -- Testing case where there is second bucket layer with bucket soil --
     // -- and it has space under it                                        --
@@ -2313,17 +1958,9 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}, {10, 16}}, {{2, 10, 15}}, {{2, 10, 15}});
 
     // -- Testing case where there is second bucket layer with bucket soil --
     // -- and soil should avalanche on it                                  --
@@ -2357,17 +1994,9 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}, {10, 16}}, {{2, 10, 15}}, {{2, 10, 15}});
 
     // -- Testing case where there is second bucket layer with bucket soil --
     // -- and it is high enough to prevent the soil from avalanching       --
@@ -2393,16 +2022,9 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}}, {{2, 10, 15}}, {{2, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer being lower --
     // -- and it has space under it, soil avalanche under the bucket   --
@@ -2424,15 +2046,9 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 0);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}, {10, 16}}, {{0, 10, 15}, {2, 10, 15}}, {});
 
     // -- Testing case with two bucket layers, first layer being lower and    --
     // -- second bucket layer is high enough to prevent soil from avalanching --
@@ -2465,19 +2081,10 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}, {10, 16}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer being lower --
     // -- soil avalanche on the first bucket layer then on the second  --
@@ -2521,22 +2128,10 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posB[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->terrain_[9][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{9, 15}, {10, 15}, {10, 16}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer being lower and --
     // -- it has space under it, while second layer is with bucket soil,   --
@@ -2566,19 +2161,10 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}, {10, 16}}, {{0, 10, 15}, {2, 10, 15}},
+        {{2, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer being lower and --
     // -- second bucket layer with bucket soil is high enough to prevent   --
@@ -2618,21 +2204,10 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}, {10, 16}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer being lower,      --
     // -- second bucket layer with bucket soil, soil avalanche on the first  --
@@ -2680,22 +2255,10 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posB[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->terrain_[9][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{9, 15}, {10, 15}, {10, 16}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer with bucket soil   --
     // -- being lower and has space under it, soil avalanche under the bucket --
@@ -2725,20 +2288,10 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->terrain_[9][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{9, 15}, {10, 15}, {10, 16}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer with bucket soil --
     // -- being lower, second bucket layer is high enough to prevent soil   --
@@ -2775,19 +2328,10 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}, {10, 16}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer with bucket soil  --
     // -- being lower, soil avalanche on the first bucket soil layer then on --
@@ -2835,22 +2379,10 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posB[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->terrain_[9][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{9, 15}, {10, 15}, {10, 16}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil,  --
     // -- first layer being lower and it has space under it, soil avalanche --
@@ -2887,21 +2419,10 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}, {10, 16}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil, --
     // -- first layer being lower, second bucket layer is high enough to   --
@@ -2946,21 +2467,10 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}, {10, 16}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil,   --
     // -- first layer being lower, soil avalanche on first bucket soil layer --
@@ -3012,22 +2522,10 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posB[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->terrain_[9][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{9, 15}, {10, 15}, {10, 16}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer being lower --
     // -- and it has space under it, soil avalanche under the bucket    --
@@ -3049,15 +2547,9 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 0);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}, {10, 16}}, {{0, 10, 15}, {2, 10, 15}}, {});
 
     // -- Testing case with two bucket layers, second layer being lower and  --
     // -- first bucket layer is high enough to prevent soil from avalanching --
@@ -3090,19 +2582,10 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}, {10, 16}}, {{0, 10, 15}, {2, 10, 15}},
+        {{2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer being lower --
     // -- soil avalanche on the second bucket layer then on the first   --
@@ -3146,22 +2629,10 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posB[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->terrain_[9][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{9, 15}, {10, 15}, {10, 16}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer being lower and --
     // -- it has space under it, while first layer is with bucket soil,     --
@@ -3191,19 +2662,10 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}, {10, 16}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer being lower and --
     // -- first bucket layer with bucket soil is high enough to prevent     --
@@ -3243,21 +2705,10 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}, {10, 16}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer being lower,    --
     // -- first bucket layer with bucket soil, soil avalanche on the second --
@@ -3305,22 +2756,10 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posB[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->terrain_[9][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{9, 15}, {10, 15}, {10, 16}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer with bucket soil  --
     // -- being lower and has space under it, soil avalanche under the bucket --
@@ -3349,19 +2788,10 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}, {10, 16}}, {{0, 10, 15}, {2, 10, 15}},
+        {{2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer with bucket soil --
     // -- being lower, first bucket layer is high enough to prevent soil     --
@@ -3414,21 +2844,10 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->terrain_[9][15] = 0.0;
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{9, 15}, {10, 14}, {10, 15}, {10, 16}},
+        {{0, 10, 15}, {2, 10, 15}}, {{2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer with bucket soil  --
     // -- being lower, soil avalanche on the second bucket soil layer then on --
@@ -3476,22 +2895,10 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posB[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->terrain_[9][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{9, 15}, {10, 15}, {10, 16}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil,   --
     // -- second layer being lower and it has space under it, soil avalanche --
@@ -3528,21 +2935,10 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}, {10, 16}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil, --
     // -- second layer being lower, first bucket layer is high enough to   --
@@ -3587,21 +2983,10 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}, {10, 16}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil, --
     // -- second layer being lower, soil avalanche on second bucket soil   --
@@ -3653,22 +3038,10 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posB[2], 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->terrain_[9][15] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{9, 15}, {10, 15}, {10, 16}}, {{0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 15}, {2, 10, 15}});
 
     // -- Testing edge case where a lot of space under the bucket is present --
     soil_simulator::rng.seed(200);
@@ -3689,15 +3062,9 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 0);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->terrain_[9][15] = 0.0;
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{9, 15}, {10, 14}, {10, 15}, {10, 16}}, {{0, 10, 15}}, {});
 
     // -- Testing edge case for soil avalanching on terrain --
     soil_simulator::rng.seed(200);
@@ -3715,12 +3082,9 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 0);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[10][16] = 0.0;
-    sim_out->terrain_[9][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{9, 15}, {10, 15}, {10, 16}}, {}, {});
 
     // -- Testing randomization --
     soil_simulator::rng.seed(200);
@@ -3740,11 +3104,9 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_NEAR(sim_out->terrain_[10][15], -0.1, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[11][15], -0.1, 1e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 0);
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->terrain_[11][15] = 0.0;
-    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
-        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1e-5);
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 15}, {11, 15}}, {}, {});
 
     delete bucket;
     delete sim_out;
@@ -3766,12 +3128,9 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 40);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}}, {{0, 10, 14}});
 
     // -- Testing case with first bucket layer and soil should avalanche --
     // -- on terrain                                                     --
@@ -3786,14 +3145,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 10);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}},
+        {{0, 10, 14}});
 
     // -- Testing case where there is the first bucket layer with bucket soil --
     // -- and soil should avalanche on the terrain                            --
@@ -3810,16 +3165,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 10);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
 
     // -- Testing case with first bucket layer and soil avalanche on it --
     sim_out->terrain_[10][15] = -0.2;
@@ -3833,14 +3182,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 14);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}},
+        {{0, 10, 14}});
 
     // -- Testing case where there is the first bucket layer with bucket soil --
     // -- and soil should avalanche on it                                     --
@@ -3857,16 +3202,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 13);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
 
     // -- Testing case with second bucket layer and soil should avalanche --
     // -- on terrain                                                      --
@@ -3881,14 +3220,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 20);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
+        {{0, 10, 14}});
 
     // -- Testing case where there is the second bucket layer with bucket --
     // -- soil and soil should avalanche on the terrain                   --
@@ -3905,16 +3240,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 20);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case with second bucket layer and soil avalanche on it --
     sim_out->terrain_[10][15] = -0.2;
@@ -3928,14 +3257,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 22);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
+        {{0, 10, 14}});
 
     // -- Testing case where there is the second bucket layer with bucket --
     // -- soil and soil should avalanche on it                            --
@@ -3952,16 +3277,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 21);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers, the first layer --
     // -- being lower and soil should avalanche on it                     --
@@ -3978,16 +3297,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 34);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}});
 
     // -- Testing case with two bucket layers, the first layer with bucket --
     // -- soil being lower and soil should avalanche on it                 --
@@ -4006,18 +3319,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 33);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
 
     // -- Testing case with two bucket layers, the first layer being lower --
     // -- and soil avalanche on it, while second layer is with bucket soil --
@@ -4036,18 +3341,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 34);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil, --
     // -- the first layer being lower and soil should avalanche on it      --
@@ -4068,20 +3365,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 33);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, the first layer being lower --
     // -- and soil should avalanche on the second bucket layer             --
@@ -4098,16 +3385,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 32);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}});
 
     // -- Testing case with two bucket layers, the first layer with bucket  --
     // -- soil being lower and soil should avalanche on second bucket layer --
@@ -4126,18 +3407,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 32);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
 
     // -- Testing case with two bucket layers, the first layer being lower --
     // -- and soil should avalanche on the second bucket layer with soil   --
@@ -4156,18 +3429,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 31);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil, --
     // -- the first layer being lower and soil should avalanche on the     --
@@ -4189,20 +3454,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 31);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, the second layer being lower --
     // -- and soil should avalanche on it                                   --
@@ -4219,16 +3474,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 32);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}});
 
     // -- Testing case with two bucket layers, the second layer with bucket --
     // -- soil being lower and soil should avalanche on it                  --
@@ -4247,18 +3496,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 31);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, the second layer being lower --
     // -- and soil avalanche on it, while first layer is with bucket soil   --
@@ -4277,18 +3518,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 32);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil, --
     // -- the second layer being lower and soil should avalanche on it     --
@@ -4309,20 +3542,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 31);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, the second layer being lower --
     // -- and soil should avalanche on the first bucket layer               --
@@ -4339,16 +3562,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 34);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}});
 
     // -- Testing case with two bucket layers, the second layer with bucket --
     // -- soil being lower and soil should avalanche on first bucket layer  --
@@ -4367,18 +3584,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 34);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, the second layer being lower --
     // -- and soil should avalanche on the first bucket layer with soil     --
@@ -4397,18 +3606,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 33);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil,  --
     // -- second layer being lower and soil avalanche on first bucket layer --
@@ -4429,20 +3630,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 33);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer being lower and --
     // -- soil fully cover the space between the two layers, first bucket   --
@@ -4462,18 +3653,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 0);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with soil, second  --
     // -- layer being lower and soil fully cover the space between the two  --
@@ -4495,20 +3678,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 0);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer being lower and --
     // -- soil fully cover the space between the two layers, second bucket --
@@ -4528,18 +3701,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 0);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
 
     // -- Testing case where there are two bucket layers with soil, first    --
     // -- layer being lower and soil fully cover the space between the two   --
@@ -4561,20 +3726,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 0);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer being lower and --
     // -- soil fully cover the space between the two layers, but soil can   --
@@ -4594,18 +3749,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 34);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with soil, second  --
     // -- layer being lower and soil fully cover the space between the two  --
@@ -4627,20 +3774,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 33);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer being lower and --
     // -- soil fully cover the space between the two layers, but the soil  --
@@ -4660,18 +3797,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 32);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
 
     // -- Testing case where there are two bucket layers with soil, first    --
     // -- layer being lower and soil fully cover the space between the two   --
@@ -4693,20 +3822,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 31);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case where there is no bucket and soil is not unstable --
     sim_out->terrain_[10][15] = 0.1;
@@ -4718,12 +3837,9 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 0);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}}, {{0, 10, 14}});
 
     // -- Testing case with first bucket layer and soil is not unstable --
     sim_out->terrain_[10][15] = -0.2;
@@ -4737,14 +3853,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 0);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}},
+        {{0, 10, 14}});
 
     // -- Testing case where there is the first bucket layer with bucket --
     // -- soil and soil is not unstable                                  --
@@ -4761,16 +3873,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 0);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
 
     // -- Testing case with second bucket layer and soil is not unstable --
     sim_out->terrain_[10][15] = -0.2;
@@ -4784,14 +3890,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 0);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
+        {{0, 10, 14}});
 
     // -- Testing case where there is the second bucket layer with bucket --
     // -- soil and soil is not unstable                                   --
@@ -4808,16 +3910,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 0);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers and soil is not unstable (1) --
     sim_out->terrain_[10][15] = -0.4;
@@ -4835,18 +3931,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 0);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers and soil is not unstable (2) --
     sim_out->terrain_[10][15] = -0.4;
@@ -4864,18 +3952,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 0);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers and soil is not unstable (3) --
     sim_out->terrain_[10][15] = -0.4;
@@ -4893,18 +3973,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, 0.1, 1e-5);
     EXPECT_EQ(status, 0);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers and soil is not unstable (4) --
     sim_out->terrain_[10][15] = -0.4;
@@ -4920,16 +3992,10 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     status = soil_simulator::CheckUnstableBodyCell(
         sim_out, 10, 14, 0, 10, 15, -0.1, 1e-5);
     EXPECT_EQ(status, 0);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}});
 
     delete sim_out;
 }
@@ -4969,14 +4035,9 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_EQ(body_soil_pos->size(), 0);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}}, {{0, 10, 14}});
 
     // -- Testing case with no bucket and soil should fully avalanche --
     sim_out->terrain_[10][14] = -0.2;
@@ -4998,14 +4059,9 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_EQ(body_soil_pos->size(), 0);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}}, {{0, 10, 14}});
 
     // -- Testing case with no bucket, soil should fully avalanche but not --
     // -- enough soil in body_soil_pos_                                    --
@@ -5031,14 +4087,9 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}}, {{0, 10, 14}});
 
     // -- Testing case with first bucket layer and soil should partially --
     // -- avalanche on the terrain                                       --
@@ -5063,16 +4114,10 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_EQ(body_soil_pos->size(), 0);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}},
+        {{0, 10, 14}});
 
     // -- Testing case with first bucket layer and soil should fully --
     // -- avalanche on the terrain                                   --
@@ -5104,18 +4149,10 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_EQ(body_soil_pos->size(), 0);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
 
     // -- Testing case with first bucket layer and soil should partially      --
     // -- avalanche on the terrain but there is not enough space for all soil --
@@ -5139,16 +4176,10 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.3, 1e-5);
     EXPECT_EQ(body_soil_pos->size(), 0);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.3, 1.e-5);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}},
+        {{0, 10, 14}});
 
     // -- Testing case with first bucket layer and soil should partially --
     // -- avalanche on it                                                --
@@ -5182,19 +4213,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case with first bucket layer and soil should fully --
     // -- avalanche on it                                            --
@@ -5228,19 +4251,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case with first bucket layer and soil should fully --
     // -- avalanche on it, but not enough soil in body_soil_pos_     --
@@ -5277,19 +4292,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case where there is the first bucket layer with bucket --
     // -- soil and soil should partially avalanche on it                 --
@@ -5328,19 +4335,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case where there is the first bucket layer with bucket --
     // -- soil and soil should fully avalanche on it                     --
@@ -5379,19 +4378,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case where there is the first bucket layer with bucket  --
     // -- soil and soil should fully avalanche on it, but not enough soil --
@@ -5434,19 +4425,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case with second bucket layer and soil should partially --
     // -- avalanche on the terrain                                        --
@@ -5478,18 +4461,10 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 0);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case with second bucket layer and soil should fully --
     // -- avalanche on the terrain                                    --
@@ -5513,16 +4488,10 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 0);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
+        {{0, 10, 14}});
 
     // -- Testing case with second bucket layer and soil should partially     --
     // -- avalanche on the terrain but there is not enough space for all soil --
@@ -5554,18 +4523,10 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.3, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.4, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 0);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case with second bucket layer and soil should --
     // -- partially avalanche on it                             --
@@ -5599,19 +4560,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case with second bucket layer and soil should fully --
     // -- avalanche on it                                             --
@@ -5645,19 +4598,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case with second bucket layer and soil should fully --
     // -- avalanche on it, but not enough soil in body_soil_pos_      --
@@ -5694,19 +4639,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case where there is the second bucket layer with bucket --
     // -- soil and soil should partially avalanche on it                  --
@@ -5745,19 +4682,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case where there is the second bucket layer with bucket --
     // -- soil and soil should fully avalanche on it                      --
@@ -5796,19 +4725,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case where there is the second bucket layer with bucket --
     // -- soil and soil should fully avalanche on it, but not enough soil --
@@ -5851,19 +4772,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case with two bucket layers, first layer being lower --
     // -- and soil should partially avalanche on it                    --
@@ -5899,21 +4812,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case with two bucket layers, first layer being lower --
     // -- and soil should fully avalanche on it                        --
@@ -5949,21 +4852,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case with two bucket layers, first layer being lower  --
     // -- and soil should fully avalanche on it, but not enough soil in --
@@ -6003,21 +4896,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case whith two bucket layers, first layer being lower     --
     // -- and soil should partially avalanche on it but there is not enough --
@@ -6054,21 +4937,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case with two bucket layers, first layer being lower   --
     // -- and soil should partially avalanche on the second bucket layer --
@@ -6104,21 +4977,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.4, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case with two bucket layers, first layer being lower --
     // -- and soil should fully avalanche on the second bucket layer   --
@@ -6154,21 +5017,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.3, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case where there are two bucket layers with bucket soil   --
     // -- first layer being lower and soil should partially avalanche on it --
@@ -6215,23 +5068,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case where there are two bucket layers with bucket soil --
     // -- first layer being lower and soil should fully avalanche on it   --
@@ -6278,23 +5119,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case where there are two bucket layers with bucket soil    --
     // -- first layer being lower and soil should fully avalanche on it, but --
@@ -6345,23 +5174,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case where there are two bucket layers with bucket soil   --
     // -- first layer being lower and soil should partially avalanche on it --
@@ -6409,23 +5226,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.3, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.5, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case where there are two bucket layers with bucket soil    --
     // -- first layer being lower and soil should partially avalanche on the --
@@ -6473,23 +5278,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.6, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case where there are two bucket layers with bucket soil --
     // -- first layer being lower and soil should fully avalanche on the  --
@@ -6537,23 +5330,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case with two bucket layers, second layer being lower --
     // -- and soil should partially avalanche on it                     --
@@ -6589,21 +5370,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case with two bucket layers, second layer being lower --
     // -- and soil should fully avalanche on it                         --
@@ -6639,21 +5410,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case with two bucket layers, second layer being lower --
     // -- and soil should fully avalanche on it, but not enough soil in --
@@ -6693,21 +5454,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case with two bucket layers, second layer being lower     --
     // -- and soil should partially avalanche on it but there is not enough --
@@ -6744,21 +5495,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.5, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case with two bucket layers, second layer being lower --
     // -- and soil should partially avalanche on the first bucket layer --
@@ -6794,21 +5535,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.5, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case with two bucket layers, second layer being lower --
     // -- and soil should fully avalanche on the first bucket layer     --
@@ -6844,21 +5575,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case where there are two bucket layers with bucket soil    --
     // -- second layer being lower and soil should partially avalanche on it --
@@ -6905,23 +5626,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case where there are two bucket layers with bucket soil    --
     // -- the second layer being lower and soil should fully avalanche on it --
@@ -6968,23 +5677,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case where there are two bucket layers with bucket soil     --
     // -- the second layer being lower and soil should fully avalanche on it, --
@@ -7035,23 +5732,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case where there are two bucket layers with bucket soil    --
     // -- second layer being lower and soil should partially avalanche on it --
@@ -7099,23 +5784,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.6, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case where there are two bucket layers with bucket soil     --
     // -- second layer being lower and soil should partially avalanche on the --
@@ -7163,23 +5836,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.6, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case where there are two bucket layers with bucket soil     --
     // -- the second layer being lower and soil should fully avalanche on the --
@@ -7227,23 +5888,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case where there are two bucket layers with bucket soil   --
     // -- first layer being lower and soil should partially avalanche on it --
@@ -7283,23 +5932,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.8, 1e-5);
     EXPECT_EQ(body_soil_pos->size(), 0);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case where there are two bucket layers with bucket soil    --
     // -- second layer being lower and soil should partially avalanche on it --
@@ -7339,23 +5976,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.1, 1e-5);
     EXPECT_EQ(body_soil_pos->size(), 0);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case with two bucket layers, first layer being lower    --
     // -- and soil fully cover the space between the two layers, the soil --
@@ -7399,23 +6024,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.3, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.5, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case with two bucket layers, first layer being lower    --
     // -- and soil fully cover the space between the two layers, the soil --
@@ -7463,23 +6076,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.6, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case with two bucket layers, second layer being lower   --
     // -- and soil fully cover the space between the two layers, the soil --
@@ -7523,23 +6124,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.7, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     // -- Testing case with two bucket layers, second layer being lower   --
     // -- and soil fully cover the space between the two layers, the soil --
@@ -7587,23 +6176,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.7, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 
     delete bucket;
     delete sim_out;
@@ -7646,14 +6223,9 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], -0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}}, {{0, 10, 14}});
 
     // -- Testing case with no bucket and soil should fully avalanche --
     soil_simulator::rng.seed(1234);
@@ -7673,14 +6245,9 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}}, {{0, 10, 14}});
 
     // -- Testing case with no bucket and soil should fully avalanche, --
     // -- soil should avalanche in several steps                       --
@@ -7704,14 +6271,9 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}}, {{0, 10, 14}});
 
     // -- Testing case with first bucket layer and soil should partially --
     // -- avalanche on the terrain                                       --
@@ -7734,16 +6296,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}},
+        {{0, 10, 14}});
 
     // -- Testing case with first bucket layer and soil should fully --
     // -- avalanche on the terrain                                   --
@@ -7775,20 +6331,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[2][10][14] = 0.0;
-    sim_out->body_[3][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 14}, {0, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
 
     // -- Testing case with first bucket layer and soil should partially      --
     // -- avalanche on the terrain but there is not enough space for all soil --
@@ -7811,16 +6357,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}},
+        {{0, 10, 14}});
 
     // -- Testing case with first bucket layer and soil should partially --
     // -- avalanche on it                                                --
@@ -7853,18 +6393,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
 
     // -- Testing case with first bucket layer and soil should fully --
     // -- avalanche on it                                            --
@@ -7897,18 +6429,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
 
     // -- Testing case with first bucket layer and soil should fully --
     // -- avalanche on it in several steps                           --
@@ -7951,18 +6475,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
 
     // -- Testing case where there is the first bucket layer with bucket soil --
     // -- and soil should partially avalanche on it                           --
@@ -7999,18 +6515,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
 
     // -- Testing case where there is the first bucket layer with bucket soil --
     // -- and soil should fully avalanche on it                               --
@@ -8047,18 +6555,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
 
     // -- Testing case where there is the first bucket layer with bucket soil --
     // -- and soil should fully avalanche on it in several steps              --
@@ -8105,18 +6605,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 5);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
 
     // -- Testing case with second bucket layer and soil should partially --
     // -- avalanche on the terrain                                        --
@@ -8139,16 +6631,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
+        {{0, 10, 14}});
 
     // -- Testing case with second bucket layer and soil should fully --
     // -- avalanche on the terrain                                    --
@@ -8171,16 +6657,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
+        {{0, 10, 14}});
 
     // -- Testing case with second bucket layer and soil should partially     --
     // -- avalanche on the terrain but there is not enough space for all soil --
@@ -8203,16 +6683,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
+        {{0, 10, 14}});
 
     // -- Testing case with second bucket layer and soil should partially --
     // -- avalanche on it                                                 --
@@ -8245,18 +6719,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case with second bucket layer and soil should fully --
     // -- avalanche on it                                             --
@@ -8289,18 +6755,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case with second bucket layer and soil should fully --
     // -- avalanche on it in several steps                            --
@@ -8343,18 +6801,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case where there is the second bucket layer with bucket --
     // -- soil and soil should partially avalanche on it                  --
@@ -8391,18 +6841,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case where there is the second bucket layer with bucket --
     // -- soil and soil should fully avalanche on it                      --
@@ -8439,18 +6881,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case where there is the second bucket layer with bucket --
     // -- soil and soil should fully avalanche on it in several steps     --
@@ -8497,18 +6931,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 5);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer being lower and --
     // -- soil should partially avalanche on it                            --
@@ -8543,20 +6969,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer being lower and --
     // -- soil should fully avalanche on it                                --
@@ -8591,20 +7007,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer being lower and --
     // -- soil should fully avalanche on it in several steps               --
@@ -8649,20 +7055,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer being lower and --
     // -- soil should partially avalanche on the second bucket layer       --
@@ -8697,20 +7093,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer being lower and --
     // -- soil should fully avalanche on the second bucket layer           --
@@ -8745,20 +7131,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer with soil being --
     // -- lower and soil should partially avalanche on it                  --
@@ -8797,20 +7173,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer with soil being --
     // -- lower and soil should fully avalanche on it                      --
@@ -8849,20 +7215,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer with soil being --
     // -- lower and soil should fully avalanche on it in several steps     --
@@ -8911,20 +7267,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 5);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer with soil being --
     // -- lower and soil should partially avalanche on second bucket layer --
@@ -8966,22 +7312,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer with soil being --
     // -- lower and soil should fully avalanche on the second bucket layer --
@@ -9023,22 +7357,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer being lower and --
     // -- soil should partially avalanche on it, while the second layer is --
@@ -9081,22 +7403,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer being lower and --
     // -- soil should fully avalanche on it, while the second layer is     --
@@ -9139,22 +7449,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer being lower and --
     // -- soil should partially avalanche on second bucket layer with soil --
@@ -9193,20 +7491,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer being lower and --
     // -- soil should fully avalanche on the second bucket layer with soil --
@@ -9245,20 +7533,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil   --
     // -- first layer being lower and soil should partially avalanche on it --
@@ -9304,22 +7582,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil --
     // -- first layer being lower and soil should fully avalanche on it   --
@@ -9365,22 +7631,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil --
     // -- first layer being lower and soil should partially avalanche on  --
@@ -9427,22 +7681,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil --
     // -- first layer being lower and soil should fully avalanche on      --
@@ -9489,22 +7731,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer being lower and --
     // -- soil should partially avalanche on it but there is not enough    --
@@ -9540,20 +7770,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.4, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil --
     // -- first layer being lower and soil should partially avalanche on  --
@@ -9600,22 +7820,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.4, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil   --
     // -- first layer being lower and soil should partially avalanche on it --
@@ -9655,22 +7863,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.4, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer being lower and --
     // -- soil should partially avalanche on it                             --
@@ -9705,20 +7901,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer being lower and --
     // -- soil should fully avalanche on it                                 --
@@ -9753,20 +7939,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer being lower and --
     // -- soil should fully avalanche on it in several steps                --
@@ -9811,20 +7987,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer being lower and --
     // -- soil should partially avalanche on the first bucket layer         --
@@ -9859,20 +8025,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer being lower and --
     // -- soil should fully avalanche on the first bucket layer             --
@@ -9907,20 +8063,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer with soil being --
     // -- lower and soil should partially avalanche on it                   --
@@ -9959,20 +8105,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer with soil being --
     // -- lower and soil should fully avalanche on it                       --
@@ -10011,20 +8147,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer with soil being --
     // -- lower and soil should fully avalanche on it in several steps      --
@@ -10073,20 +8199,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 5);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer with soil being   --
     // -- lower and soil should partially avalanche on the first bucket layer --
@@ -10128,22 +8244,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer with soil being --
     // -- lower and soil should fully avalanche on the first bucket layer   --
@@ -10185,22 +8289,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer being lower and --
     // -- soil should partially avalanche on it, while the first layer is   --
@@ -10243,22 +8335,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer being lower and --
     // -- soil should fully avalanche on it, while the first layer is with  --
@@ -10301,22 +8381,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer being lower and   --
     // -- soil should partially avalanche on the first bucket layer with soil --
@@ -10355,20 +8423,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer being lower and --
     // -- soil should fully avalanche on the first bucket layer with soil   --
@@ -10407,20 +8465,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil    --
     // -- second layer being lower and soil should partially avalanche on it --
@@ -10466,22 +8514,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil --
     // -- second layer being lower and soil should fully avalanche on it  --
@@ -10527,22 +8563,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil  --
     // -- the second layer being lower and soil should partially avalanche --
@@ -10589,22 +8613,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil --
     // -- second layer being lower and soil should fully avalanche on the --
@@ -10651,22 +8663,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer being lower and   --
     // -- soil should partially avalanche on it but there is not enough space --
@@ -10702,20 +8702,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.5, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil --
     // -- second layer being lower and soil should partially avalanche on --
@@ -10762,22 +8752,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.5, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil --
     // -- second layer being lower and soil should partially avalanche on --
@@ -10817,22 +8795,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.4, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.7, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer being lower and --
     // -- soil fully cover the space between the two layers, the soil can  --
@@ -10875,22 +8841,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.5, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer being lower and --
     // -- soil fully cover the space between the two layers, the soil can  --
@@ -10937,22 +8891,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.6, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer being lower and --
     // -- soil fully cover the space between the two layers, the soil can   --
@@ -10995,22 +8937,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.6, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer being lower and --
     // -- soil fully cover the space between the two layers, the soil can   --
@@ -11057,22 +8987,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.6, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with no bucket and soil is not unstable --
     soil_simulator::rng.seed(1234);
@@ -11090,13 +9008,9 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.7, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}}, {{0, 10, 14}});
 
     // -- Testing case with first bucket layer and soil is not unstable --
     soil_simulator::rng.seed(1234);
@@ -11118,16 +9032,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.7, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}},
+        {{0, 10, 14}});
 
     // -- Testing case with first bucket layer with bucket soil and soil --
     // -- is not unstable                                                --
@@ -11157,18 +9065,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.7, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
 
     // -- Testing case with second bucket layer and soil is not unstable --
     soil_simulator::rng.seed(1234);
@@ -11190,16 +9090,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.7, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
+        {{0, 10, 14}});
 
     // -- Testing case where there is the second bucket layer with bucket --
     // -- soil and soil is not unstable                                   --
@@ -11229,18 +9123,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.7, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, first layer being lower and --
     // -- soil is not unstable                                             --
@@ -11265,18 +9151,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.7, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}});
 
     // -- Testing case with two bucket layers, first layer with bucket soil --
     // -- being lower and soil is not unstable                              --
@@ -11308,20 +9186,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.7, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil --
     // -- first layer being lower and soil is not unstable                --
@@ -11363,23 +9231,13 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.7, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    for (auto ii = 9; ii < 12;  ii++)
-        for (auto jj = 13; jj < 16;  jj++)
-            sim_out->terrain_[ii][jj] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    std::vector<std::vector<int>> terrain_pos = {
+        {9, 13}, {9, 14}, {9, 15}, {10, 13}, {10, 14}, {10, 15}, {11, 13},
+        {11, 14}, {11, 15}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, terrain_pos, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing case with two bucket layers, second layer being lower and --
     // -- soil is not unstable                                              --
@@ -11404,18 +9262,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.7, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}});
 
     // -- Testing case with two bucket layers, second layer with bucket soil --
     // -- being lower and soil is not unstable                               --
@@ -11447,20 +9297,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.7, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
 
     // -- Testing case where there are two bucket layers with bucket soil --
     // -- second layer being lower and soil is not unstable               --
@@ -11502,23 +9342,13 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.7, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
-    for (auto ii = 9; ii < 12;  ii++)
-        for (auto jj = 13; jj < 16;  jj++)
-            sim_out->terrain_[ii][jj] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_[0][10][15] = 0.0;
-    sim_out->body_[1][10][15] = 0.0;
-    sim_out->body_[2][10][15] = 0.0;
-    sim_out->body_[3][10][15] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][15] = 0.0;
-    sim_out->body_soil_[1][10][15] = 0.0;
-    sim_out->body_soil_[2][10][15] = 0.0;
-    sim_out->body_soil_[3][10][15] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    terrain_pos = {
+        {9, 13}, {9, 14}, {9, 15}, {10, 13}, {10, 14}, {10, 15}, {11, 13},
+        {11, 14}, {11, 15}};
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, terrain_pos, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
 
     // -- Testing randomization --
     soil_simulator::rng.seed(1234);
@@ -11553,15 +9383,9 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], -0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
-    sim_out->terrain_[10][13] = 0.0;
-    sim_out->terrain_[10][14] = 0.0;
-    sim_out->terrain_[10][15] = 0.0;
-    sim_out->body_[0][10][14] = 0.0;
-    sim_out->body_[1][10][14] = 0.0;
-    sim_out->body_soil_[0][10][14] = 0.0;
-    sim_out->body_soil_[1][10][14] = 0.0;
-    sim_out->body_soil_pos_.erase(
-        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+    // Resetting values
+    test_soil_simulator::ResetValueAndTest(
+        sim_out, {{10, 13}, {10, 14}, {10, 15}}, {{0, 10, 14}}, {{0, 10, 14}});
 
     delete bucket;
     delete sim_out;

--- a/test/unit_tests/utility.cpp
+++ b/test/unit_tests/utility.cpp
@@ -38,7 +38,7 @@ void test_soil_simulator::ResetValueAndTest(
         sim_out->body_soil_[ind+1][ii][jj] = 0.0;
     }
 
-    // Checking that everything is resetted
+    // Checking that everything is properly reset
     for (auto ii = 0; ii < sim_out->body_.size(); ii++)
         for (auto jj = 0; jj < sim_out->body_[0].size(); jj++)
             for (auto kk = 0; kk < sim_out->body_[0][0].size(); kk++) {

--- a/test/unit_tests/utility.cpp
+++ b/test/unit_tests/utility.cpp
@@ -1,0 +1,55 @@
+/*
+This file implements utility functions for unit testing.
+
+Copyright, 2023, Vilella Kenny.
+*/
+#include <iostream>
+#include <vector>
+#include "gtest/gtest.h"
+#include "test/unit_tests/utility.hpp"
+
+void test_soil_simulator::ResetValueAndTest(
+    soil_simulator::SimOut* sim_out, std::vector<std::vector<int>> terrain_pos,
+    std::vector<std::vector<int>> body_pos,
+    std::vector<std::vector<int>> body_soil_pos
+) {
+    // Resetting requested terrain
+    for (auto nn = 0; nn < terrain_pos.size(); nn++) {
+        int ii = terrain_pos[nn][0];
+        int jj = terrain_pos[nn][1];
+        sim_out->terrain_[ii][jj] = 0.0;
+    }
+
+    // Resetting requested body
+    for (auto nn = 0; nn < body_pos.size(); nn++) {
+        int ind = body_pos[nn][0];
+        int ii = body_pos[nn][1];
+        int jj = body_pos[nn][2];
+        sim_out->body_[ind][ii][jj] = 0.0;
+        sim_out->body_[ind+1][ii][jj] = 0.0;
+    }
+
+    // Resetting requested body_soil
+    for (auto nn = 0; nn < body_soil_pos.size(); nn++) {
+        int ind = body_soil_pos[nn][0];
+        int ii = body_soil_pos[nn][1];
+        int jj = body_soil_pos[nn][2];
+        sim_out->body_soil_[ind][ii][jj] = 0.0;
+        sim_out->body_soil_[ind+1][ii][jj] = 0.0;
+    }
+
+    // Checking that everything is resetted
+    for (auto ii = 0; ii < sim_out->body_.size(); ii++)
+        for (auto jj = 0; jj < sim_out->body_[0].size(); jj++)
+            for (auto kk = 0; kk < sim_out->body_[0][0].size(); kk++) {
+                EXPECT_NEAR(sim_out->body_[ii][jj][kk], 0.0, 1.e-5);
+                EXPECT_NEAR(sim_out->body_soil_[ii][jj][kk], 0.0, 1.e-5);
+            }
+    for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
+        for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
+            EXPECT_NEAR(sim_out->terrain_[ii][jj], 0.0, 1.e-5);
+
+    // Resetting body_soil_pos
+    sim_out->body_soil_pos_.erase(
+        sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
+}

--- a/test/unit_tests/utility.hpp
+++ b/test/unit_tests/utility.hpp
@@ -24,4 +24,3 @@ void ResetValueAndTest(
     std::vector<std::vector<int>> body_soil_pos);
 
 }  // namespace test_soil_simulator
-

--- a/test/unit_tests/utility.hpp
+++ b/test/unit_tests/utility.hpp
@@ -1,0 +1,27 @@
+/*
+This file declares the utility functions for unit testing.
+
+Copyright, 2023, Vilella Kenny.
+*/
+#pragma once
+
+#include <vector>
+#include "soil_simulator/types.hpp"
+
+namespace test_soil_simulator {
+
+/// \brief This function resets the requested outputs and checks that all
+///        terrain, body and body_soil is properly reset. This can be used to
+///        catch potential unexpected modifications of the outputs.
+///
+/// \param sim_out: Class that stores simulation outputs.
+/// \param terrain_pos: Collection of terrain cells that should be reset.
+/// \param body_pos: Collection of body cells that should be reset.
+/// \param body_soil_pos: Collection of body soil cells that should be reset.
+void ResetValueAndTest(
+    soil_simulator::SimOut* sim_out, std::vector<std::vector<int>> terrain_pos,
+    std::vector<std::vector<int>> body_pos,
+    std::vector<std::vector<int>> body_soil_pos);
+
+}  // namespace test_soil_simulator
+


### PR DESCRIPTION
# Description
- Added a utility function to reset specified outputs and test that everything else have not been modified.
- Used the new utility function wherever possible