### PR TITLE
Refactor unit tests: Add utility function to check body_soil struct (2)

### DIFF
--- a/test/unit_tests/test_body_soil.cpp
+++ b/test/unit_tests/test_body_soil.cpp
@@ -33,13 +33,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][11][10], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][10], 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 10);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 11, 10, {0.0, 0.0, 0.0}, 0.1);
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -59,13 +54,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][11][10], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][10], 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 10);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 11, 10, {0.0, 0.0, 0.0}, 0.1);
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -85,13 +75,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][11][10], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][10], 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 10);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 2, 11, 10, {0.0, 0.0, 0.0}, 0.1);
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -111,13 +96,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][11][10], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][10], 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 10);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 2, 11, 10, {0.0, 0.0, 0.0}, 0.1);
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -137,13 +117,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][11], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][11], 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 11);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, 0.1, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, 0., 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 10, 11, {0.1, 0.0, 0.0}, 0.1);
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -163,13 +138,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][11][11], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][11], 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 11);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, 0.1, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 11, 11, {0.1, 0.0, 0.0}, 0.1);
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -189,13 +159,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][12][11], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][12][11], 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 12);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 11);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, 0.1, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 12, 11, {0.1, 0.0, 0.0}, 0.1);
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -230,25 +195,15 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 11, 10, 0.1, 0.0, 0.0, 0.1});
     sim_out->body_soil_pos_.push_back(
-        soil_simulator::body_soil {0, 12, 10, 0.2, 0.0, 0.0, 0.2});
+        soil_simulator::body_soil {1, 12, 10, 0.2, 0.0, 0.0, 0.2});
     soil_simulator::UpdateBodySoil(
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][10], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][10], 0.4, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 10);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, 0.1, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 10);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, 0.2, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 10, 10, {0.1, 0.0, 0.0}, 0.1);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 0, 10, 10, {0.2, 0.0, 0.0}, 0.2);
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -272,20 +227,10 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][10], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][10], 0.4, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 10);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, 0.1, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 10);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, 0.2, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 10, 10, {0.1, 0.0, 0.0}, 0.1);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 0, 10, 10, {0.2, 0.0, 0.0}, 0.2);
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -309,20 +254,10 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][10], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][10], 0.4, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 10);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, 0.1, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 10);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, 0.2, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 2, 10, 10, {0.1, 0.0, 0.0}, 0.1);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 2, 10, 10, {0.2, 0.0, 0.0}, 0.2);
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -361,13 +296,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][10], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][10], 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 10);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 10, 10, {0.0, 0.0, 0.0}, 0.1);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
         sim_out, {}, {{0, 10, 10}}, {{0, 10, 10}});
@@ -388,9 +318,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][11][10], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][10], 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 10);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 11, 10, {0.0, 0.0, 0.0}, 0.1);
     // Testing for second direction
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -405,9 +334,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][12][10], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][12][10], 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 12);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 10);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 12, 10, {0.0, 0.0, 0.0}, 0.1);
     // Testing for third direction
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -422,9 +350,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][12][11], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][12][11], 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 12);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 11);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 12, 11, {0.0, 0.0, 0.0}, 0.1);
     // Testing for fouth direction
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -439,9 +366,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][11][11], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][11], 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 11);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 11, 11, {0.0, 0.0, 0.0}, 0.1);
     // Testing for fifth direction
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -456,9 +382,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][12][9], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][12][9], 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 12);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 9);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 12, 9, {0.0, 0.0, 0.0}, 0.1);
     // Testing for sixth direction
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -473,9 +398,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][11][9], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][9], 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 9);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 11, 9, {0.0, 0.0, 0.0}, 0.1);
     // Testing for seventh direction
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -490,9 +414,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][11], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][11], 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 11);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 10, 11, {0.0, 0.0, 0.0}, 0.1);
     // Testing for eighth direction
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -507,9 +430,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][10], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][10], 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 10);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 10, 10, {0.0, 0.0, 0.0}, 0.1);
     // Testing for ninth direction
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -524,9 +446,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][9], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][9], 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 9);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 10, 9, {0.0, 0.0, 0.0}, 0.1);
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -552,9 +473,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][9], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][9], 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 9);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 10, 9, {0.0, 0.0, 0.0}, 0.1);
     // Testing for second direction
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -569,9 +489,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][8], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][8], 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 8);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 10, 8, {0.0, 0.0, 0.0}, 0.1);
     // Testing for third direction
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -586,9 +505,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][9][8], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][9][8], 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 9);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 8);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 9, 8, {0.0, 0.0, 0.0}, 0.1);
     // Testing for fouth direction
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -603,9 +521,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][9][9], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][9][9], 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 9);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 9);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 9, 9, {0.0, 0.0, 0.0}, 0.1);
     // Testing for fifth direction
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -620,9 +537,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][11][8], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][8], 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 8);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 11, 8, {0.0, 0.0, 0.0}, 0.1);
     // Testing for sixth direction
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -637,9 +553,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][11][9], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][9], 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 9);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 11, 9, {0.0, 0.0, 0.0}, 0.1);
     // Testing for seventh direction
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -654,9 +569,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][9][10], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][9][10], 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 9);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 10);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 9, 10, {0.0, 0.0, 0.0}, 0.1);
     // Testing for eighth direction
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -671,9 +585,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][10], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][10], 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 10);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 10, 10, {0.0, 0.0, 0.0}, 0.1);
     // Testing for ninth direction
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -688,9 +601,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][11][10], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][10], 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 10);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 11, 10, {0.0, 0.0, 0.0}, 0.1);
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -718,9 +630,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][9], 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][9], 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 9);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 10, 9, {0.0, 0.0, 0.0}, 0.1);
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
@@ -748,9 +659,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][11][9], -0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][9], 0.0, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 9);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 11, 9, {0.0, 0.0, 0.0}, 0.1);
     // Resetting values
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};

--- a/test/unit_tests/test_intersecting_cells.cpp
+++ b/test/unit_tests/test_intersecting_cells.cpp
@@ -98,13 +98,8 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(h_soil, 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][5][7], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][5][7], 1.0, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 7);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.6, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 0, 5, 7, posA, 0.6);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -122,13 +117,8 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(h_soil, 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][5][7], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][5][7], 0.8, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 7);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.6, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 0, 5, 7, posA, 0.6);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -150,13 +140,8 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(h_soil, 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][5][7], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][5][7], 0.8, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 7);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.6, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 0, 5, 7, posA, 0.6);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -215,13 +200,8 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(h_soil, 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][5][7], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][5][7], 0.9, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 7);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.6, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 2, 5, 7, posA, 0.6);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -239,13 +219,8 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(h_soil, 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][5][7], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][5][7], 0.6, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 7);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.6, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 2, 5, 7, posA, 0.6);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -267,13 +242,8 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(h_soil, 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][5][7], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][5][7], 0.8, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 7);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.6, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 2, 5, 7, posA, 0.6);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -346,13 +316,8 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(h_soil, 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][5][7], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][5][7], 0.8, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 7);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.6, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 0, 5, 7, posA, 0.6);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -373,13 +338,8 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(h_soil, 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][5][7], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][5][7], 0.6, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 7);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.6, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 2, 5, 7, posA, 0.6);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -404,13 +364,8 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(h_soil, 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][5][7], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][5][7], 0.8, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 7);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.6, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 0, 5, 7, posA, 0.6);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -435,13 +390,8 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(h_soil, 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][5][7], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][5][7], 0.8, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 7);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.6, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 2, 5, 7, posA, 0.6);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -466,13 +416,8 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(h_soil, 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][5][7], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][5][7], 0.9, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 7);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.6, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 0, 5, 7, posA, 0.6);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -497,13 +442,8 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_NEAR(h_soil, 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][5][7], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][5][7], 0.7, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 7);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 2, 5, 7, posA, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -527,13 +467,8 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_EQ(jj, 7);
     EXPECT_NEAR(sim_out->body_soil_[0][5][7], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][5][7], 0.4, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 7);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 0, 5, 7, posA, 0.3);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -557,13 +492,8 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_EQ(jj, 7);
     EXPECT_NEAR(sim_out->body_soil_[2][5][7], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][5][7], 0.3, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 7);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 2, 5, 7, posA, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -591,13 +521,8 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_EQ(jj, 7);
     EXPECT_NEAR(sim_out->body_soil_[0][5][7], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][5][7], 0.4, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 7);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 0, 5, 7, posA, 0.2);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -625,13 +550,8 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_EQ(jj, 7);
     EXPECT_NEAR(sim_out->body_soil_[2][5][7], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][5][7], 0.6, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 7);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.4, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 2, 5, 7, posA, 0.4);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -659,13 +579,8 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_EQ(jj, 7);
     EXPECT_NEAR(sim_out->body_soil_[0][5][7], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][5][7], 0.4, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 7);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 0, 5, 7, posA, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -693,13 +608,8 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     EXPECT_EQ(jj, 7);
     EXPECT_NEAR(sim_out->body_soil_[2][5][7], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][5][7], 0.7, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 7);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 2, 5, 7, posA, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1099,13 +1009,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 0, 11, 15, posA, 0.3);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1139,13 +1044,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 0, 11, 15, posA, 0.3);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1179,13 +1079,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 2, 11, 15, posA, 0.3);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1219,13 +1114,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 2, 11, 15, posA, 0.3);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1264,13 +1154,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 0, 11, 15, posA, 0.3);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1309,13 +1194,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 0, 11, 15, posA, 0.3);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1354,13 +1234,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 2, 11, 15, posA, 0.3);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1399,13 +1274,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 2, 11, 15, posA, 0.3);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1442,13 +1312,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 0, 11, 15, posA, 0.3);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1485,13 +1350,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 0, 11, 15, posA, 0.3);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1528,13 +1388,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 2, 11, 15, posA, 0.3);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1571,13 +1426,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 2, 11, 15, posA, 0.3);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1618,13 +1468,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 0, 11, 15, posA, 0.3);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1665,13 +1510,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 0, 11, 15, posA, 0.3);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1712,13 +1552,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 2, 11, 15, posA, 0.3);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1759,13 +1594,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 2, 11, 15, posA, 0.3);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1803,13 +1633,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.4, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 0, 11, 15, posA, 0.2);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1848,13 +1673,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.4, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 0, 11, 15, posA, 0.2);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1893,13 +1713,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.4, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 2, 11, 15, posA, 0.2);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1938,13 +1753,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.4, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 2, 11, 15, posA, 0.2);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1987,13 +1797,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.4, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 0, 11, 15, posA, 0.2);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -2036,13 +1841,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 0.9, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 0, 11, 15, posA, 0.2);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -2085,13 +1885,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.4, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 2, 11, 15, posA, 0.2);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -2134,13 +1929,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.9, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 2, 11, 15, posA, 0.2);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -2200,13 +1990,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][12][15], 0.8, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[5], 0, 11, 15, posA, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 6);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -2266,13 +2051,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][12][15], 0.8, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[5], 2, 11, 15, posA, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 6);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -2450,13 +2230,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][12][15], 0.8, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[5], 0, 11, 15, posA, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 6);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -2516,13 +2291,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][12][15], 0.8, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[5], 2, 11, 15, posA, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 6);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -2582,13 +2352,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 0.8, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[5], 0, 11, 15, posA, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 6);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -2648,13 +2413,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 0.8, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[12][15], 0.4, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[5], 2, 11, 15, posA, 0.2);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 6);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -2694,13 +2454,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[0][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][11][15], 1.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 0, 11, 15, posA, 0.3);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -2739,13 +2494,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][11][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][11][15], 0.8, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 2, 11, 15, posA, 0.3);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -2803,13 +2553,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[0][12][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][12][15], 0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].ii, 12);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[5], 0, 12, 15, posA, 0.3);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 6);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -2864,13 +2609,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[0][12][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][12][15], 0.4, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].ii, 12);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[4], 0, 12, 15, posA, 0.3);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 5);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -2929,13 +2669,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][12][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].ii, 12);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[5], 2, 12, 15, posA, 0.3);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 6);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -2990,13 +2725,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][12][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].ii, 12);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[4], 2, 12, 15, posA, 0.3);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 5);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -3055,20 +2785,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[0][12][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][12][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[6].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[6].ii, 12);
-    EXPECT_EQ(sim_out->body_soil_pos_[6].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[6].x_b, posB[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[6].y_b, posB[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[6].z_b, posB[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[6].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[5], 0, 11, 15, posA, 0.1);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[6], 0, 12, 15, posB, 0.2);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 7);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -3123,20 +2843,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[0][12][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][12][15], 0.4, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].ii, 12);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].x_b, posB[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].y_b, posB[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posB[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[4], 2, 11, 15, posA, 0.1);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[5], 0, 12, 15, posB, 0.2);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 6);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -3191,20 +2901,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][12][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 0.4, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].ii, 12);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].x_b, posB[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].y_b, posB[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posB[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[4], 0, 11, 15, posA, 0.2);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[5], 2, 12, 15, posB, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 6);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -3263,20 +2963,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][12][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[5].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[5].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[6].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[6].ii, 12);
-    EXPECT_EQ(sim_out->body_soil_pos_[6].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[6].x_b, posB[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[6].y_b, posB[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[6].z_b, posB[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[6].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[5], 2, 11, 15, posA, 0.1);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[6], 2, 12, 15, posB, 0.2);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 7);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -3388,41 +3078,16 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][12][17], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][12][17], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[7].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[7].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[7].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[7].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[7].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[7].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[7].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[8].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[8].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[8].jj, 16);
-    EXPECT_NEAR(sim_out->body_soil_pos_[8].x_b, posB[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[8].y_b, posB[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[8].z_b, posB[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[8].h_soil, 0.3, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[9].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[9].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[9].jj, 14);
-    EXPECT_NEAR(sim_out->body_soil_pos_[9].x_b, posC[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[9].y_b, posC[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[9].z_b, posC[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[9].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[10].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[10].ii, 9);
-    EXPECT_EQ(sim_out->body_soil_pos_[10].jj, 14);
-    EXPECT_NEAR(sim_out->body_soil_pos_[10].x_b, posD[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[10].y_b, posD[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[10].z_b, posD[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[10].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[11].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[11].ii, 12);
-    EXPECT_EQ(sim_out->body_soil_pos_[11].jj, 17);
-    EXPECT_NEAR(sim_out->body_soil_pos_[11].x_b, posE[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[11].y_b, posE[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[11].z_b, posE[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[11].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[7], 0, 11, 15, posA, 0.2);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[8], 2, 10, 16, posB, 0.3);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[9], 0, 11, 14, posC, 0.2);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[10], 2, 9, 14, posD, 0.1);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[11], 2, 12, 17, posE, 0.2);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 12);
     // Resetting values
     std::vector<std::vector<int>> body_pos = {
@@ -3480,13 +3145,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][12][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 1.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].ii, 12);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].h_soil, 1.0, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[4], 2, 12, 15, posA, 1.0);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 5);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -3538,13 +3198,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][12][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 1.8, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].ii, 12);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].h_soil, 1.0, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[4], 2, 12, 15, posA, 1.0);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 5);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -3656,13 +3311,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[0][12][17], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][12][17], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[7].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[7].ii, 12);
-    EXPECT_EQ(sim_out->body_soil_pos_[7].jj, 17);
-    EXPECT_NEAR(sim_out->body_soil_pos_[7].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[7].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[7].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[7].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[7], 0, 12, 17, posA, 0.3);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 8);
     // Resetting values
     body_pos = {
@@ -3718,13 +3368,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][12][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 0.4, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 12);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 2, 12, 15, posA, 0.3);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
     body_pos = {
@@ -3856,76 +3501,26 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[0][20][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][20][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[6].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[6].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[6].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[6].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[6].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[6].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[6].h_soil, 0.3, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[7].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[7].ii, 12);
-    EXPECT_EQ(sim_out->body_soil_pos_[7].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[7].x_b, posB[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[7].y_b, posB[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[7].z_b, posB[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[7].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[8].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[8].ii, 13);
-    EXPECT_EQ(sim_out->body_soil_pos_[8].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[8].x_b, posC[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[8].y_b, posC[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[8].z_b, posC[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[8].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[9].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[9].ii, 14);
-    EXPECT_EQ(sim_out->body_soil_pos_[9].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[9].x_b, posD[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[9].y_b, posD[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[9].z_b, posD[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[9].h_soil, 0.4, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[10].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[10].ii, 15);
-    EXPECT_EQ(sim_out->body_soil_pos_[10].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[10].x_b, posE[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[10].y_b, posE[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[10].z_b, posE[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[10].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[11].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[11].ii, 16);
-    EXPECT_EQ(sim_out->body_soil_pos_[11].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[11].x_b, posF[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[11].y_b, posF[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[11].z_b, posF[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[11].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[12].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[12].ii, 17);
-    EXPECT_EQ(sim_out->body_soil_pos_[12].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[12].x_b, posG[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[12].y_b, posG[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[12].z_b, posG[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[12].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[13].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[13].ii, 18);
-    EXPECT_EQ(sim_out->body_soil_pos_[13].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[13].x_b, posH[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[13].y_b, posH[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[13].z_b, posH[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[13].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[14].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[14].ii, 19);
-    EXPECT_EQ(sim_out->body_soil_pos_[14].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[14].x_b, posI[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[14].y_b, posI[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[14].z_b, posI[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[14].h_soil, 0.5, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[15].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[15].ii, 20);
-    EXPECT_EQ(sim_out->body_soil_pos_[15].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[15].x_b, posJ[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[15].y_b, posJ[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[15].z_b, posJ[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[15].h_soil, 0.4, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[6], 0, 11, 15, posA, 0.3);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[7], 0, 12, 15, posB, 0.1);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[8], 0, 13, 15, posC, 0.2);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[9], 0, 14, 15, posD, 0.4);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[10], 0, 15, 15, posE, 0.2);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[11], 2, 16, 15, posF, 0.2);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[12], 2, 17, 15, posG, 0.1);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[13], 0, 18, 15, posH, 0.1);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[14], 2, 19, 15, posI, 0.5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[15], 0, 20, 15, posJ, 0.4);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 16);
     // Resetting values
     body_pos = {
@@ -4083,83 +3678,28 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[0][20][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][20][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[9].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[9].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[9].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[9].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[9].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[9].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[9].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[10].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[10].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[10].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[10].x_b, posB[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[10].y_b, posB[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[10].z_b, posB[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[10].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[11].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[11].ii, 12);
-    EXPECT_EQ(sim_out->body_soil_pos_[11].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[11].x_b, posC[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[11].y_b, posC[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[11].z_b, posC[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[11].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[12].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[12].ii, 13);
-    EXPECT_EQ(sim_out->body_soil_pos_[12].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[12].x_b, posD[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[12].y_b, posD[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[12].z_b, posD[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[12].h_soil, 0.3, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[13].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[13].ii, 14);
-    EXPECT_EQ(sim_out->body_soil_pos_[13].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[13].x_b, posE[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[13].y_b, posE[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[13].z_b, posE[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[13].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[14].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[14].ii, 15);
-    EXPECT_EQ(sim_out->body_soil_pos_[14].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[14].x_b, posF[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[14].y_b, posF[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[14].z_b, posF[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[14].h_soil, 0.4, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[15].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[15].ii, 16);
-    EXPECT_EQ(sim_out->body_soil_pos_[15].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[15].x_b, posG[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[15].y_b, posG[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[15].z_b, posG[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[15].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[16].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[16].ii, 17);
-    EXPECT_EQ(sim_out->body_soil_pos_[16].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[16].x_b, posH[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[16].y_b, posH[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[16].z_b, posH[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[16].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[17].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[17].ii, 18);
-    EXPECT_EQ(sim_out->body_soil_pos_[17].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[17].x_b, posI[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[17].y_b, posI[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[17].z_b, posI[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[17].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[18].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[18].ii, 19);
-    EXPECT_EQ(sim_out->body_soil_pos_[18].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[18].x_b, posJ[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[18].y_b, posJ[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[18].z_b, posJ[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[18].h_soil, 0.3, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[19].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[19].ii, 20);
-    EXPECT_EQ(sim_out->body_soil_pos_[19].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[19].x_b, posK[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[19].y_b, posK[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[19].z_b, posK[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[19].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[9], 2, 10, 15, posA, 0.1);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[10], 0, 11, 15, posB, 0.2);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[11], 2, 12, 15, posC, 0.2);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[12], 2, 13, 15, posD, 0.3);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[13], 2, 14, 15, posE, 0.2);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[14], 0, 15, 15, posF, 0.4);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[15], 0, 16, 15, posG, 0.1);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[16], 2, 17, 15, posH, 0.2);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[17], 0, 18, 15, posI, 0.2);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[18], 2, 19, 15, posJ, 0.3);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[19], 0, 20, 15, posK, 0.3);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 20);
     // Resetting values
     body_pos = {
@@ -4271,13 +3811,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[0][16][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][16][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[8].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[8].ii, 16);
-    EXPECT_EQ(sim_out->body_soil_pos_[8].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[8].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[8].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[8].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[8].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[8], 0, 16, 15, posA, 0.3);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 9);
     // Resetting values
     body_pos = {
@@ -4378,48 +3913,18 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][16][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][16][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[6].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[6].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[6].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[6].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[6].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[6].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[6].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[7].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[7].ii, 12);
-    EXPECT_EQ(sim_out->body_soil_pos_[7].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[7].x_b, posB[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[7].y_b, posB[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[7].z_b, posB[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[7].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[8].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[8].ii, 13);
-    EXPECT_EQ(sim_out->body_soil_pos_[8].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[8].x_b, posC[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[8].y_b, posC[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[8].z_b, posC[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[8].h_soil, 0.5, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[9].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[9].ii, 14);
-    EXPECT_EQ(sim_out->body_soil_pos_[9].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[9].x_b, posD[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[9].y_b, posD[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[9].z_b, posD[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[9].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[10].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[10].ii, 15);
-    EXPECT_EQ(sim_out->body_soil_pos_[10].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[10].x_b, posE[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[10].y_b, posE[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[10].z_b, posE[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[10].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[11].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[11].ii, 16);
-    EXPECT_EQ(sim_out->body_soil_pos_[11].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[11].x_b, posF[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[11].y_b, posF[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[11].z_b, posF[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[11].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[6], 0, 11, 15, posA, 0.2);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[7], 0, 12, 15, posB, 0.2);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[8], 2, 13, 15, posC, 0.5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[9], 2, 14, 15, posD, 0.1);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[10], 0, 15, 15, posE, 0.2);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[11], 2, 16, 15, posF, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 12);
     // Resetting values
     body_pos = {
@@ -4577,48 +4082,18 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[0][20][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][20][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[12].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[12].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[12].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[12].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[12].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[12].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[12].h_soil, 0.3, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[13].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[13].ii, 13);
-    EXPECT_EQ(sim_out->body_soil_pos_[13].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[13].x_b, posB[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[13].y_b, posB[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[13].z_b, posB[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[13].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[14].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[14].ii, 15);
-    EXPECT_EQ(sim_out->body_soil_pos_[14].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[14].x_b, posC[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[14].y_b, posC[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[14].z_b, posC[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[14].h_soil, 0.3, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[15].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[15].ii, 17);
-    EXPECT_EQ(sim_out->body_soil_pos_[15].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[15].x_b, posD[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[15].y_b, posD[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[15].z_b, posD[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[15].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[16].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[16].ii, 19);
-    EXPECT_EQ(sim_out->body_soil_pos_[16].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[16].x_b, posE[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[16].y_b, posE[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[16].z_b, posE[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[16].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[17].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[17].ii, 20);
-    EXPECT_EQ(sim_out->body_soil_pos_[17].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[17].x_b, posF[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[17].y_b, posF[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[17].z_b, posF[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[17].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[12], 0, 11, 15, posA, 0.3);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[13], 0, 13, 15, posB, 0.1);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[14], 2, 15, 15, posC, 0.3);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[15], 2, 17, 15, posD, 0.2);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[16], 0, 19, 15, posE, 0.2);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[17], 0, 20, 15, posF, 0.2);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 18);
     // Resetting values
     body_pos = {
@@ -4676,20 +4151,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[2][12][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][12][15], 0.8, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.6, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].ii, 12);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].x_b, posB[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].y_b, posB[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].z_b, posB[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].h_soil, 0.7, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 2, 11, 15, posA, 0.6);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[4], 2, 12, 15, posB, 0.7);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 5);
     // Resetting values
     body_pos = {
@@ -4748,27 +4213,12 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[6].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[6].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[6].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[6].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[6].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[6].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[6].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[7].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[7].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[7].jj, 16);
-    EXPECT_NEAR(sim_out->body_soil_pos_[7].x_b, posB[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[7].y_b, posB[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[7].z_b, posB[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[7].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[8].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[8].ii, 11);
-    EXPECT_EQ(sim_out->body_soil_pos_[8].jj, 14);
-    EXPECT_NEAR(sim_out->body_soil_pos_[8].x_b, posC[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[8].y_b, posC[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[8].z_b, posC[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[8].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[6], 0, 11, 15, posA, 0.2);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[7], 0, 11, 16, posB, 0.1);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[8], 0, 11, 14, posC, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 9);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(

--- a/test/unit_tests/test_relax.cpp
+++ b/test/unit_tests/test_relax.cpp
@@ -945,13 +945,8 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->terrain_[10][15], -0.4, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.1, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 10, 15, posA, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1015,13 +1010,8 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->terrain_[10][15], -0.8, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], -0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.2, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 0, 10, 15, posA, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1067,13 +1057,8 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->terrain_[10][15], -0.4, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.2, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 2, 10, 15, posA, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1137,13 +1122,8 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->terrain_[10][15], -0.8, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.2, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 2, 10, 15, posA, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1195,13 +1175,8 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->terrain_[10][15], -0.8, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], -0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.3, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 10, 15, posA, 0.3);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1222,13 +1197,8 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->terrain_[10][15], -0.8, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], -0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.4, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 10, 15, posA, 0.2);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1257,13 +1227,8 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.4, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.2, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 2, 10, 15, posA, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1296,13 +1261,8 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.9, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 0, 10, 15, posA, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1335,13 +1295,8 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.4, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.2, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 0, 10, 15, posA, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1374,13 +1329,8 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.4, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.1, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 2, 10, 15, posA, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1433,13 +1383,8 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->terrain_[10][15], -0.8, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.3, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 2, 10, 15, posA, 0.3);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1460,13 +1405,8 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->terrain_[10][15], -0.8, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.4, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.3, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 2, 10, 15, posA, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1495,13 +1435,8 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.6, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 0, 10, 15, posA, 0.2);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1534,13 +1469,8 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.3, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 2, 10, 15, posA, 0.3);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1573,13 +1503,8 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.5, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 2, 10, 15, posA, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1613,13 +1538,8 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.5, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 0, 10, 15, posA, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1726,13 +1646,8 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[0][1], 15);
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 10, 15, posA, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1813,20 +1728,10 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[0][1], 15);
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 0, 10, 15, posA, 0.1);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 0, 10, 15, posA, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1900,13 +1805,8 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[0][1], 15);
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 2, 10, 15, posA, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -1986,13 +1886,8 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[0][1], 15);
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 2, 10, 15, posA, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -2073,13 +1968,8 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[0][1], 15);
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 10, 15, posA, 0.2);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -2113,20 +2003,10 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[0][1], 15);
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, posB[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, posB[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posB[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 0, 10, 15, posA, 0.2);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 2, 10, 15, posB, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -2196,13 +2076,8 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[0][1], 15);
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 0, 10, 15, posA, 0.2);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -2240,20 +2115,10 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[0][1], 15);
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posB[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posB[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posB[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 0, 10, 15, posA, 0.2);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 2, 10, 15, posB, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -2320,13 +2185,8 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[0][1], 15);
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 0, 10, 15, posA, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -2364,20 +2224,10 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[0][1], 15);
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posB[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posB[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posB[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 0, 10, 15, posA, 0.1);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 2, 10, 15, posB, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -2459,13 +2309,8 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[0][1], 15);
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 0, 10, 15, posA, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -2507,20 +2352,10 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[0][1], 15);
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posB[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posB[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posB[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 0, 10, 15, posA, 0.1);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 2, 10, 15, posB, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -2574,13 +2409,8 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[0][1], 15);
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 2, 10, 15, posA, 0.2);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -2614,20 +2444,10 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[0][1], 15);
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[0].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, posB[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, posB[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posB[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[0], 2, 10, 15, posA, 0.2);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 0, 10, 15, posB, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -2697,13 +2517,8 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[0][1], 15);
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 2, 10, 15, posA, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -2741,20 +2556,10 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[0][1], 15);
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posB[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posB[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posB[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 2, 10, 15, posA, 0.2);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 0, 10, 15, posB, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -2822,27 +2627,12 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[0][1], 15);
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 2, 10, 15, posA, 0.2);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 2, 10, 15, posA, 0.1);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 2, 10, 15, posA, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -2880,20 +2670,10 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[0][1], 15);
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posB[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posB[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posB[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 2, 10, 15, posA, 0.1);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 0, 10, 15, posB, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -2975,13 +2755,8 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[0][1], 15);
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 2, 10, 15, posA, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -3023,20 +2798,10 @@ TEST(UnitTestRelax, RelaxTerrain) {
     EXPECT_EQ(sim_out->relax_area_[0][1], 15);
     EXPECT_EQ(sim_out->relax_area_[1][0], 10);
     EXPECT_EQ(sim_out->relax_area_[1][1], 20);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posB[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posB[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posB[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 2, 10, 15, posA, 0.1);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 0, 10, 15, posB, 0.1);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
     test_soil_simulator::ResetValueAndTest(
@@ -4551,13 +4316,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.1, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 2);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 2, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
     // Resetting values
@@ -4589,13 +4349,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.0, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 2);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 2, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
     // Resetting values
@@ -4629,13 +4384,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.1, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 2);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 2, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
@@ -4672,13 +4422,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.1, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 2);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 2, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
@@ -4715,13 +4460,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.1, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 2);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 2, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
@@ -4761,13 +4501,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.0, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 2);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 2, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
@@ -4803,13 +4538,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], -0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.1, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 0);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 0, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
     // Resetting values
@@ -4843,13 +4573,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], -0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.0, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 0);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 0, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
     // Resetting values
@@ -4886,13 +4611,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.1, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 0);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 0, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
@@ -4928,13 +4648,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], -0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.1, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 0);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 0, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
     // Resetting values
@@ -4968,13 +4683,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.4, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.4, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 2);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 2, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.4, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
     // Resetting values
@@ -5008,13 +4718,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.5, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 2);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 2, 10, 15, posA, 0.3);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
     // Resetting values
@@ -5059,13 +4764,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.5, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 0);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 0, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
     // Resetting values
@@ -5110,13 +4810,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.5, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 0);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 0, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
     // Resetting values
@@ -5164,13 +4859,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.5, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 0);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 0, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
@@ -5217,13 +4907,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.5, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 0);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 0, 10, 15, posA, 0.3);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.5, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
     // Resetting values
@@ -5269,13 +4954,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.7, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 2);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 2, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.6, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
     // Resetting values
@@ -5321,13 +5001,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.7, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 2);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 2, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
     // Resetting values
@@ -5361,13 +5036,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.1, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 2);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 2, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
     // Resetting values
@@ -5401,13 +5071,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.2, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 2);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 2, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
     // Resetting values
@@ -5444,13 +5109,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.1, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 2);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 2, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
@@ -5486,13 +5146,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.2, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 2);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 2, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.5, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
     // Resetting values
@@ -5526,13 +5181,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.4, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.6, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 0);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 0, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.5, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
     // Resetting values
@@ -5566,13 +5216,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.4, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 0);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 0, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
     // Resetting values
@@ -5617,13 +5262,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.8, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.1, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 2);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 2, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
     // Resetting values
@@ -5668,13 +5308,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.8, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.0, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 2);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 2, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
     // Resetting values
@@ -5722,13 +5357,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.8, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.1, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 2);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 2, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
@@ -5775,13 +5405,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.8, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.1, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 2);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 2, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.6, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
     // Resetting values
@@ -5827,13 +5452,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.1, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 0);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 0, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.6, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
     // Resetting values
@@ -5879,13 +5499,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.1, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 0);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 0, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
     // Resetting values
@@ -6015,13 +5630,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.5, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 2);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.3, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 2, 10, 15, posA, 0.3);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.5, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
     // Resetting values
@@ -6067,13 +5677,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.6, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 2);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 2, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.6, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
     // Resetting values
@@ -6115,13 +5720,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.4, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 0);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 0, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.7, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
     // Resetting values
@@ -6167,13 +5767,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.4, 1e-5);
-    EXPECT_EQ((*body_soil_pos)[0].ind, 0);
-    EXPECT_EQ((*body_soil_pos)[0].ii, 10);
-    EXPECT_EQ((*body_soil_pos)[0].jj, 15);
-    EXPECT_NEAR((*body_soil_pos)[0].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR((*body_soil_pos)[0].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        (*body_soil_pos)[0], 0, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.7, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
     // Resetting values
@@ -6384,13 +5979,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], -0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.2, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 0, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     // Resetting values
@@ -6420,13 +6010,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], -0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.3, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 0, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     // Resetting values
@@ -6458,20 +6043,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], -0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.3, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 0, 10, 15, posA, 0.1);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 0, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
@@ -6506,13 +6081,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], -0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], -0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.1, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 0, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
@@ -6546,13 +6116,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], -0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.3, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 0, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
@@ -6588,20 +6153,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], -0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.3, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 0, 10, 15, posA, 0.1);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[4], 0, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 5);
@@ -6710,13 +6265,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.2, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 2, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     // Resetting values
@@ -6746,13 +6296,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.3, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 2, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     // Resetting values
@@ -6784,20 +6329,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.3, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 2, 10, 15, posA, 0.1);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 2, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
@@ -6832,13 +6367,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], -0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.1, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 2, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
@@ -6872,13 +6402,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.3, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 2, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
@@ -6914,20 +6439,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.3, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 2, 10, 15, posA, 0.1);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[4], 2, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 5);
@@ -6960,13 +6475,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], -0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.2, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 0, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     // Resetting values
@@ -6998,13 +6508,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], -0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.3, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 0, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     // Resetting values
@@ -7038,20 +6543,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], -0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.3, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 0, 10, 15, posA, 0.1);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 0, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
@@ -7084,13 +6579,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], -0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.1, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 2, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     // Resetting values
@@ -7122,13 +6612,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.3, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 2, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     // Resetting values
@@ -7164,13 +6649,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], -0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.2, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 0, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
@@ -7206,13 +6686,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], -0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.3, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 0, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
@@ -7250,20 +6725,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], -0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.2, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 0, 10, 15, posA, 0.1);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[4], 0, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 5);
@@ -7303,13 +6768,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.1, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 2, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
@@ -7348,13 +6808,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.4, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.2, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 2, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
@@ -7394,13 +6849,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.1, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 0, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
@@ -7440,13 +6890,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.1, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 0, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
@@ -7482,13 +6927,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], -0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.1, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 2, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
@@ -7524,13 +6964,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.1, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 2, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
@@ -7573,13 +7008,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.0, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 0, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
@@ -7622,13 +7052,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.0, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 0, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
@@ -7672,13 +7097,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.4, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.0, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 2, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
@@ -7722,13 +7142,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.2, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 2, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
@@ -7761,13 +7176,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], -0.4, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.2, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 0, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.4, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     // Resetting values
@@ -7811,13 +7221,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], 0.1, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 0, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.4, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
@@ -7892,13 +7297,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], -0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.2, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 2, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     // Resetting values
@@ -7930,13 +7330,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.3, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 2, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     // Resetting values
@@ -7970,20 +7365,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.3, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 2, 10, 15, posA, 0.1);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 2, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
@@ -8016,13 +7401,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], -0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.1, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 0, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     // Resetting values
@@ -8054,13 +7434,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], -0.4, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.3, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 0, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     // Resetting values
@@ -8096,13 +7471,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.2, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 2, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
@@ -8138,13 +7508,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.3, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 2, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
@@ -8182,20 +7547,10 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.3, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[4].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[4].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 2, 10, 15, posA, 0.1);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[4], 2, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 5);
@@ -8235,13 +7590,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.4, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 0, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
@@ -8280,13 +7630,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.6, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.5, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 0, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
@@ -8326,13 +7671,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.2, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 2, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
@@ -8372,13 +7712,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.3, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 2, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
@@ -8414,13 +7749,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], -0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], -0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.1, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 0, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
@@ -8456,13 +7786,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], -0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.2, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 0, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
@@ -8505,13 +7830,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.2, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 2, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
@@ -8554,13 +7874,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.4, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 2, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
@@ -8604,13 +7919,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.0, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.4, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 0, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.3, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
@@ -8654,13 +7964,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.6, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 0, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
@@ -8693,13 +7998,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][14], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.5, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[1].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[1], 2, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.5, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     // Resetting values
@@ -8743,13 +8043,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.4, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 2, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.5, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
@@ -8832,13 +8127,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.4, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.2, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.2, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 2, 10, 15, posA, 0.2);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.5, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
@@ -8882,13 +8172,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.5, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.4, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.1, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 2);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 2, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.6, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values
@@ -8928,13 +8213,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.2, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.4, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[2].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[2].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[2], 0, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.6, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
@@ -8978,13 +8258,8 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], -0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[2][10][15], -0.7, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[3][10][15], -0.4, 1e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ind, 0);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].ii, 10);
-    EXPECT_EQ(sim_out->body_soil_pos_[3].jj, 15);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].x_b, posA[0], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].y_b, posA[1], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].z_b, posA[2], 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[3].h_soil, 0.1, 1.e-5);
+    test_soil_simulator::CheckBodySoilPos(
+        sim_out->body_soil_pos_[3], 0, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.6, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 4);
     // Resetting values

--- a/test/unit_tests/utility.cpp
+++ b/test/unit_tests/utility.cpp
@@ -55,7 +55,7 @@ void test_soil_simulator::ResetValueAndTest(
 }
 
 void test_soil_simulator::CheckBodySoilPos(
-    soil_simulator::body_soil body_soil_pos, int ind, int, ii, int jj,
+    soil_simulator::body_soil body_soil_pos, int ind, int ii, int jj,
     std::vector<float> pos, float h_soil
 ) {
     // Checking the body soil position

--- a/test/unit_tests/utility.cpp
+++ b/test/unit_tests/utility.cpp
@@ -53,3 +53,17 @@ void test_soil_simulator::ResetValueAndTest(
     sim_out->body_soil_pos_.erase(
         sim_out->body_soil_pos_.begin(), sim_out->body_soil_pos_.end());
 }
+
+void test_soil_simulator::CheckBodySoilPos(
+    soil_simulator::body_soil body_soil_pos, int ind, int, ii, int jj,
+    std::vector<float> pos, float h_soil
+) {
+    // Checking the body soil position
+    EXPECT_EQ(body_soil_pos.ind, ind);
+    EXPECT_EQ(body_soil_pos.ii, ii);
+    EXPECT_EQ(body_soil_pos.jj, jj);
+    EXPECT_NEAR(body_soil_pos.x_b, pos[0], 1.e-5);
+    EXPECT_NEAR(body_soil_pos.y_b, pos[1], 1.e-5);
+    EXPECT_NEAR(body_soil_pos.z_b, pos[2], 1.e-5);
+    EXPECT_NEAR(body_soil_pos.h_soil, h_soil, 1.e-5);
+}

--- a/test/unit_tests/utility.hpp
+++ b/test/unit_tests/utility.hpp
@@ -34,7 +34,7 @@ void ResetValueAndTest(
 ///             reference bucket frame. [m]
 /// \param h_soil: Expected height of the soil column. [m]
 void CheckBodySoilPos(
-    soil_simulator::body_soil body_soil_pos, int ind, int, ii, int jj,
+    soil_simulator::body_soil body_soil_pos, int ind, int ii, int jj,
     std::vector<float> pos, float h_soil);
 
 }  // namespace test_soil_simulator

--- a/test/unit_tests/utility.hpp
+++ b/test/unit_tests/utility.hpp
@@ -23,4 +23,18 @@ void ResetValueAndTest(
     std::vector<std::vector<int>> body_pos,
     std::vector<std::vector<int>> body_soil_pos);
 
+/// \brief This function checks the values of an inputted `body_soil` struct
+///        against provided values.
+///
+/// \param body_soil_pos: `body_soil` struct to be checked.
+/// \param ind: Expected index of the soil layer.
+/// \param ii: Expected index of the body soil in the X direction.
+/// \param jj: Expected index of the body soil in the Y direction.
+/// \param pos: Expected Cartesian coordinates of the body soil in the
+///             reference bucket frame. [m]
+/// \param h_soil: Expected height of the soil column. [m]
+void CheckBodySoilPos(
+    soil_simulator::body_soil body_soil_pos, int ind, int, ii, int jj,
+    std::vector<float> pos, float h_soil);
+
 }  // namespace test_soil_simulator


### PR DESCRIPTION
# Description
- Added a utility function to check the value of a `body_soil` struct against provided values.
- Used the new utility function wherever possible