### PR TITLE
Refactor unit tests: Improve type declaration (4)

### DIFF
--- a/test/unit_tests/test_body_soil.cpp
+++ b/test/unit_tests/test_body_soil.cpp
@@ -17,12 +17,17 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     soil_simulator::Bucket *bucket = new soil_simulator::Bucket(
         o_pos, j_pos, b_pos, t_pos, 0.5);
     soil_simulator::SimOut *sim_out = new soil_simulator::SimOut(grid);
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+
+    // Declaring variables
+    std::vector<float> pos;
+    std::vector<float> ori;
+    std::vector<std::vector<int>> body_pos;
 
     // Test: BS-UBS-1
-    auto pos = std::vector<float> {grid.cell_size_xy_, 0.0, 0.0};
-    auto ori = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    pos = {grid.cell_size_xy_, 0.0, 0.0};
+    ori = {1.0, 0.0, 0.0, 0.0};
     sim_out->body_[0][11][10] = 0.0;
     sim_out->body_[1][11][10] = 0.1;
     sim_out->body_soil_[0][10][10] = 0.1;
@@ -36,14 +41,14 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 11, 10, {0.0, 0.0, 0.0}, 0.1);
     // Resetting values
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     test_soil_simulator::ResetValueAndTest(
         sim_out, {}, {{0, 11, 10}}, {{0, 11, 10}});
 
     // Test: BS-UBS-2
-    pos = std::vector<float> {grid.cell_size_xy_, 0.0, 0.0};
-    ori = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    pos = {grid.cell_size_xy_, 0.0, 0.0};
+    ori = {1.0, 0.0, 0.0, 0.0};
     sim_out->body_[0][11][10] = 0.0;
     sim_out->body_[1][11][10] = 0.1;
     sim_out->body_soil_[2][10][10] = 0.1;
@@ -57,14 +62,14 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 11, 10, {0.0, 0.0, 0.0}, 0.1);
     // Resetting values
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     test_soil_simulator::ResetValueAndTest(
         sim_out, {}, {{0, 11, 10}}, {{0, 11, 10}});
 
     // Test: BS-UBS-3
-    pos = std::vector<float> {grid.cell_size_xy_, 0.0, 0.0};
-    ori = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    pos = {grid.cell_size_xy_, 0.0, 0.0};
+    ori = {1.0, 0.0, 0.0, 0.0};
     sim_out->body_[2][11][10] = 0.0;
     sim_out->body_[3][11][10] = 0.1;
     sim_out->body_soil_[0][10][10] = 0.1;
@@ -78,14 +83,14 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 2, 11, 10, {0.0, 0.0, 0.0}, 0.1);
     // Resetting values
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     test_soil_simulator::ResetValueAndTest(
         sim_out, {}, {{2, 11, 10}}, {{2, 11, 10}});
 
     // Test: BS-UBS-4
-    pos = std::vector<float> {grid.cell_size_xy_, 0.0, 0.0};
-    ori = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    pos = {grid.cell_size_xy_, 0.0, 0.0};
+    ori = {1.0, 0.0, 0.0, 0.0};
     sim_out->body_[2][11][10] = 0.0;
     sim_out->body_[3][11][10] = 0.1;
     sim_out->body_soil_[2][10][10] = 0.1;
@@ -99,14 +104,14 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 2, 11, 10, {0.0, 0.0, 0.0}, 0.1);
     // Resetting values
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     test_soil_simulator::ResetValueAndTest(
         sim_out, {}, {{2, 11, 10}}, {{2, 11, 10}});
 
     // Test: BS-UBS-5
-    pos = std::vector<float> {0.0, 0.0, 0.0};
-    ori = std::vector<float> {0.707107, 0.0, 0.0, -0.707107};
+    pos = {0.0, 0.0, 0.0};
+    ori = {0.707107, 0.0, 0.0, -0.707107};
     sim_out->body_[0][10][11] = 0.0;
     sim_out->body_[1][10][11] = 0.1;
     sim_out->body_soil_[0][11][10] = 0.1;
@@ -120,14 +125,14 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 10, 11, {0.1, 0.0, 0.0}, 0.1);
     // Resetting values
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     test_soil_simulator::ResetValueAndTest(
         sim_out, {}, {{0, 10, 11}}, {{0, 10, 11}});
 
     // Test: BS-UBS-6
-    pos = std::vector<float> {0.0, 0.0, 0.0};
-    ori = std::vector<float> {0.92388, 0.0, 0.0, -0.382683};
+    pos = {0.0, 0.0, 0.0};
+    ori = {0.92388, 0.0, 0.0, -0.382683};
     sim_out->body_[0][11][11] = 0.0;
     sim_out->body_[1][11][11] = 0.1;
     sim_out->body_soil_[0][11][10] = 0.1;
@@ -141,14 +146,14 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 11, 11, {0.1, 0.0, 0.0}, 0.1);
     // Resetting values
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     test_soil_simulator::ResetValueAndTest(
         sim_out, {}, {{0, 11, 11}}, {{0, 11, 11}});
 
     // Test: BS-UBS-7
-    pos = std::vector<float> {grid.cell_size_xy_, 0.0, 0.0};
-    ori = std::vector<float> {0.92388, 0.0, 0.0, -0.382683};
+    pos = {grid.cell_size_xy_, 0.0, 0.0};
+    ori = {0.92388, 0.0, 0.0, -0.382683};
     sim_out->body_[0][12][11] = 0.0;
     sim_out->body_[1][12][11] = 0.1;
     sim_out->body_soil_[0][11][10] = 0.1;
@@ -162,14 +167,14 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 12, 11, {0.1, 0.0, 0.0}, 0.1);
     // Resetting values
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     test_soil_simulator::ResetValueAndTest(
         sim_out, {}, {{0, 12, 11}}, {{0, 12, 11}});
 
     // Test: BS-UBS-8
-    pos = std::vector<float> {0.0, 0.0, 0.0};
-    ori = std::vector<float> {0.0, 0.0, 1.0, 0.0};
+    pos = {0.0, 0.0, 0.0};
+    ori = {0.0, 0.0, 1.0, 0.0};
     sim_out->body_soil_[0][11][10] = 0.1;
     sim_out->body_soil_[1][11][10] = 0.2;
     sim_out->body_soil_pos_.push_back(
@@ -178,14 +183,14 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->terrain_[9][10], 0.1, 1.e-5);
     // Resetting values
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     test_soil_simulator::ResetValueAndTest(
         sim_out, {{9, 10}}, {}, {});
 
     // Test: BS-UBS-9
-    pos = std::vector<float> {0.0, 0.0, 0.0};
-    ori = std::vector<float> {0.707107, 0.0, 0.707107, 0.0};
+    pos = {0.0, 0.0, 0.0};
+    ori = {0.707107, 0.0, 0.707107, 0.0};
     sim_out->body_[0][10][10] = 0.0;
     sim_out->body_[1][10][10] = 0.1;
     sim_out->body_soil_[0][11][10] = 0.1;
@@ -205,14 +210,14 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[1], 0, 10, 10, {0.2, 0.0, 0.0}, 0.2);
     // Resetting values
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     test_soil_simulator::ResetValueAndTest(
         sim_out, {}, {{0, 10, 10}}, {{0, 10, 10}});
 
     // Test: BS-UBS-10
-    pos = std::vector<float> {0.0, 0.0, 0.0};
-    ori = std::vector<float> {0.707107, 0.0, 0.707107, 0.0};
+    pos = {0.0, 0.0, 0.0};
+    ori = {0.707107, 0.0, 0.707107, 0.0};
     sim_out->body_[0][10][10] = 0.0;
     sim_out->body_[1][10][10] = 0.1;
     sim_out->body_soil_[0][11][10] = 0.1;
@@ -232,14 +237,14 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[1], 0, 10, 10, {0.2, 0.0, 0.0}, 0.2);
     // Resetting values
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     test_soil_simulator::ResetValueAndTest(
         sim_out, {}, {{0, 10, 10}}, {{0, 10, 10}});
 
     // Test: BS-UBS-11
-    pos = std::vector<float> {0.0, 0.0, 0.0};
-    ori = std::vector<float> {0.707107, 0.0, 0.707107, 0.0};
+    pos = {0.0, 0.0, 0.0};
+    ori = {0.707107, 0.0, 0.707107, 0.0};
     sim_out->body_[2][10][10] = 0.0;
     sim_out->body_[3][10][10] = 0.1;
     sim_out->body_soil_[0][11][10] = 0.1;
@@ -259,8 +264,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[1], 2, 10, 10, {0.2, 0.0, 0.0}, 0.2);
     // Resetting values
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     test_soil_simulator::ResetValueAndTest(
         sim_out, {}, {{2, 10, 10}}, {{2, 10, 10}});
 
@@ -303,8 +308,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, {}, {{0, 10, 10}}, {{0, 10, 10}});
 
     // Test: BS-UBS-14
-    pos = std::vector<float> {grid.cell_size_xy_, 0.01, 0.0};
-    ori = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    pos = {grid.cell_size_xy_, 0.01, 0.0};
+    ori = {1.0, 0.0, 0.0, 0.0};
     for (auto ii = 10; ii < 13; ii++)
         for (auto jj = 9; jj < 12; jj++) {
             sim_out->body_[0][ii][jj] = 0.0;
@@ -321,8 +326,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 11, 10, {0.0, 0.0, 0.0}, 0.1);
     // Testing for second direction
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     sim_out->body_soil_[0][11][10] = 0.0;
     sim_out->body_soil_[1][11][10] = 0.0;
     sim_out->body_soil_[0][10][10] = 0.1;
@@ -337,8 +342,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 12, 10, {0.0, 0.0, 0.0}, 0.1);
     // Testing for third direction
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     sim_out->body_soil_[0][12][10] = 0.0;
     sim_out->body_soil_[1][12][10] = 0.0;
     sim_out->body_soil_[0][10][10] = 0.1;
@@ -353,8 +358,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 12, 11, {0.0, 0.0, 0.0}, 0.1);
     // Testing for fouth direction
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     sim_out->body_soil_[0][12][11] = 0.0;
     sim_out->body_soil_[1][12][11] = 0.0;
     sim_out->body_soil_[0][10][10] = 0.1;
@@ -369,8 +374,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 11, 11, {0.0, 0.0, 0.0}, 0.1);
     // Testing for fifth direction
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     sim_out->body_soil_[0][11][11] = 0.0;
     sim_out->body_soil_[1][11][11] = 0.0;
     sim_out->body_soil_[0][10][10] = 0.1;
@@ -385,8 +390,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 12, 9, {0.0, 0.0, 0.0}, 0.1);
     // Testing for sixth direction
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     sim_out->body_soil_[0][12][9] = 0.0;
     sim_out->body_soil_[1][12][9] = 0.0;
     sim_out->body_soil_[0][10][10] = 0.1;
@@ -401,8 +406,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 11, 9, {0.0, 0.0, 0.0}, 0.1);
     // Testing for seventh direction
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     sim_out->body_soil_[0][11][9] = 0.0;
     sim_out->body_soil_[1][11][9] = 0.0;
     sim_out->body_soil_[0][10][10] = 0.1;
@@ -417,8 +422,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 10, 11, {0.0, 0.0, 0.0}, 0.1);
     // Testing for eighth direction
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     sim_out->body_soil_[0][10][11] = 0.0;
     sim_out->body_soil_[1][10][11] = 0.0;
     sim_out->body_soil_[0][10][10] = 0.1;
@@ -433,8 +438,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 10, 10, {0.0, 0.0, 0.0}, 0.1);
     // Testing for ninth direction
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     sim_out->body_soil_[0][10][10] = 0.0;
     sim_out->body_soil_[1][10][10] = 0.0;
     sim_out->body_soil_[0][10][10] = 0.1;
@@ -449,17 +454,17 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 10, 9, {0.0, 0.0, 0.0}, 0.1);
     // Resetting values
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
-    std::vector<std::vector<int>> body_pos = {
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    body_pos = {
         {0, 10, 9}, {0, 10, 10}, {0, 10, 11}, {0, 11, 9}, {0, 11, 10},
         {0, 11, 11}, {0, 12, 9}, {0, 12, 10}, {0, 12, 11}};
     test_soil_simulator::ResetValueAndTest(
         sim_out, {}, body_pos, {{0, 10, 9}});
 
     // Test: BS-UBS-15
-    pos = std::vector<float> {-0.01, -grid.cell_size_xy_, 0.0};
-    ori = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    pos = {-0.01, -grid.cell_size_xy_, 0.0};
+    ori = {1.0, 0.0, 0.0, 0.0};
     for (auto ii = 9; ii < 12; ii++)
         for (auto jj = 8; jj < 11; jj++) {
             sim_out->body_[0][ii][jj] = 0.0;
@@ -476,8 +481,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 10, 9, {0.0, 0.0, 0.0}, 0.1);
     // Testing for second direction
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     sim_out->body_soil_[0][10][9] = 0.0;
     sim_out->body_soil_[1][10][9] = 0.0;
     sim_out->body_soil_[0][10][10] = 0.1;
@@ -492,8 +497,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 10, 8, {0.0, 0.0, 0.0}, 0.1);
     // Testing for third direction
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     sim_out->body_soil_[0][10][8] = 0.0;
     sim_out->body_soil_[1][10][8] = 0.0;
     sim_out->body_soil_[0][10][10] = 0.1;
@@ -508,8 +513,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 9, 8, {0.0, 0.0, 0.0}, 0.1);
     // Testing for fouth direction
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     sim_out->body_soil_[0][9][8] = 0.0;
     sim_out->body_soil_[1][9][8] = 0.0;
     sim_out->body_soil_[0][10][10] = 0.1;
@@ -524,8 +529,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 9, 9, {0.0, 0.0, 0.0}, 0.1);
     // Testing for fifth direction
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     sim_out->body_soil_[0][9][9] = 0.0;
     sim_out->body_soil_[1][9][9] = 0.0;
     sim_out->body_soil_[0][10][10] = 0.1;
@@ -540,8 +545,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 11, 8, {0.0, 0.0, 0.0}, 0.1);
     // Testing for sixth direction
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     sim_out->body_soil_[0][11][8] = 0.0;
     sim_out->body_soil_[1][11][8] = 0.0;
     sim_out->body_soil_[0][10][10] = 0.1;
@@ -556,8 +561,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 11, 9, {0.0, 0.0, 0.0}, 0.1);
     // Testing for seventh direction
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     sim_out->body_soil_[0][11][9] = 0.0;
     sim_out->body_soil_[1][11][9] = 0.0;
     sim_out->body_soil_[0][10][10] = 0.1;
@@ -572,8 +577,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 9, 10, {0.0, 0.0, 0.0}, 0.1);
     // Testing for eighth direction
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     sim_out->body_soil_[0][9][10] = 0.0;
     sim_out->body_soil_[1][9][10] = 0.0;
     sim_out->body_soil_[0][10][10] = 0.1;
@@ -588,8 +593,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 10, 10, {0.0, 0.0, 0.0}, 0.1);
     // Testing for ninth direction
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     sim_out->body_soil_[0][10][10] = 0.0;
     sim_out->body_soil_[1][10][10] = 0.0;
     sim_out->body_soil_[0][10][10] = 0.1;
@@ -604,8 +609,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 11, 10, {0.0, 0.0, 0.0}, 0.1);
     // Resetting values
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     body_pos = {
         {0, 9, 8}, {0, 9, 9}, {0, 9, 10}, {0, 10, 8}, {0, 10, 9},
         {0, 10, 10}, {0, 11, 8}, {0, 11, 9}, {0, 11, 10}};
@@ -613,8 +618,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, {}, body_pos, {{0, 11, 10}});
 
     // Test: BS-UBS-16
-    pos = std::vector<float> {grid.cell_size_xy_, 0.01, 0.0};
-    ori = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    pos = {grid.cell_size_xy_, 0.01, 0.0};
+    ori = {1.0, 0.0, 0.0, 0.0};
     for (auto ii = 10; ii < 13; ii++)
         for (auto jj = 9; jj < 12; jj++) {
             sim_out->body_[0][ii][jj] = 0.2;
@@ -633,8 +638,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 10, 9, {0.0, 0.0, 0.0}, 0.1);
     // Resetting values
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     body_pos = {
         {0, 10, 9}, {0, 10, 10}, {0, 10, 11}, {0, 11, 9}, {0, 11, 10},
         {0, 11, 11}, {0, 12, 9}, {0, 12, 10}, {0, 12, 11}};
@@ -642,8 +647,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out, {}, body_pos, {{0, 10, 9}});
 
     // Test: BS-UBS-17
-    pos = std::vector<float> {grid.cell_size_xy_, 0.01, 0.0};
-    ori = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    pos = {grid.cell_size_xy_, 0.01, 0.0};
+    ori = {1.0, 0.0, 0.0, 0.0};
     for (auto ii = 10; ii < 13; ii++)
         for (auto jj = 9; jj < 12; jj++) {
             sim_out->body_[0][ii][jj] = 0.2;
@@ -662,8 +667,8 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 11, 9, {0.0, 0.0, 0.0}, 0.1);
     // Resetting values
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     body_pos = {
         {0, 10, 9}, {0, 10, 10}, {0, 10, 11}, {0, 11, 9}, {0, 11, 10},
         {0, 11, 11}, {0, 12, 9}, {0, 12, 10}, {0, 12, 11}};

--- a/test/unit_tests/test_bucket_pos.cpp
+++ b/test/unit_tests/test_bucket_pos.cpp
@@ -116,6 +116,9 @@ TEST(UnitTestBucketPos, CalcLinePos) {
 }
 
 TEST(UnitTestBucketPos, DecomposeVectorRectangle) {
+    // Setting up the environment
+    float tol = 1.e-5;
+
     // Declaring variables
     std::vector<float> ab_ind;
     std::vector<float> ad_ind;
@@ -124,7 +127,6 @@ TEST(UnitTestBucketPos, DecomposeVectorRectangle) {
     int area_min_y;
     int area_length_x;
     int area_length_y;
-    float tol = 1.e-5;
     std::vector<std::vector<float>> c_ab;
     std::vector<std::vector<float>> c_ad;
     std::vector<std::vector<bool>> in_rec;
@@ -296,6 +298,9 @@ TEST(UnitTestBucketPos, DecomposeVectorRectangle) {
 }
 
 TEST(UnitTestBucketPos, DecomposeVectorTriangle) {
+    // Setting up the environment
+    float tol = 1.e-5;
+
     // Declaring variables
     std::vector<float> ab_ind;
     std::vector<float> ac_ind;
@@ -304,7 +309,6 @@ TEST(UnitTestBucketPos, DecomposeVectorTriangle) {
     int area_min_y;
     int area_length_x;
     int area_length_y;
-    float tol = 1.e-5;
     std::vector<std::vector<float>> c_ab;
     std::vector<std::vector<float>> c_ac;
     std::vector<std::vector<bool>> in_tri;
@@ -562,13 +566,13 @@ TEST(UnitTestBucketPos, DecomposeVectorTriangle) {
 TEST(UnitTestBucketPos, CalcRectanglePos) {
     // Setting up the environment
     soil_simulator::Grid grid(1.0, 1.0, 1.0, 0.1, 0.1);
+    float tol = 1e-5;
 
     // Declaring variables
     std::vector<float> a;
     std::vector<float> b;
     std::vector<float> c;
     std::vector<float> d;
-    float tol = 1e-5;
     std::vector<std::vector<int>> rect_pos;
 
     // Test: BP-CR-1
@@ -931,12 +935,12 @@ TEST(UnitTestBucketPos, CalcRectanglePos) {
 TEST(UnitTestBucketPos, CalcTrianglePos) {
     // Setting up the environment
     soil_simulator::Grid grid(1.0, 1.0, 1.0, 0.1, 0.1);
+    float tol = 1e-5;
 
     // Declaring variables
     std::vector<float> a;
     std::vector<float> b;
     std::vector<float> c;
-    float tol = 1e-5;
     std::vector<std::vector<int>> tri_pos;
 
     // Test: BP-CT-1

--- a/test/unit_tests/test_bucket_pos.cpp
+++ b/test/unit_tests/test_bucket_pos.cpp
@@ -8,12 +8,18 @@ Copyright, 2023, Vilella Kenny.
 #include "test/unit_tests/utility.hpp"
 
 TEST(UnitTestBucketPos, CalcLinePos) {
+    // Setting up the environment
     soil_simulator::Grid grid(1.0, 1.0, 1.0, 0.1, 0.1);
 
+    // Declaring variables
+    std::vector<float> a;
+    std::vector<float> b;
+    std::vector<std::vector<int>> line_pos;
+
     // Test: BP-CL-1
-    std::vector<float> a = {0.0 + 1e-5, 0.0 - 1e-5, -0.06 + 1e-5};
-    std::vector<float> b = {1.0 - 1e-5, 0.0 - 1e-5,  0.0  - 1e-5};
-    std::vector<std::vector<int>> line_pos = soil_simulator::CalcLinePos(
+    a = {0.0 + 1e-5, 0.0 - 1e-5, -0.06 + 1e-5};
+    b = {1.0 - 1e-5, 0.0 - 1e-5,  0.0  - 1e-5};
+    line_pos = soil_simulator::CalcLinePos(
         a, b, grid);
     EXPECT_EQ(line_pos.size(), 11);
     EXPECT_TRUE((line_pos[0] == std::vector<int> {10, 10, 9}));
@@ -110,6 +116,7 @@ TEST(UnitTestBucketPos, CalcLinePos) {
 }
 
 TEST(UnitTestBucketPos, DecomposeVectorRectangle) {
+    // Declaring variables
     std::vector<float> ab_ind;
     std::vector<float> ad_ind;
     std::vector<float> a_ind;
@@ -118,6 +125,10 @@ TEST(UnitTestBucketPos, DecomposeVectorRectangle) {
     int area_length_x;
     int area_length_y;
     float tol = 1.e-5;
+    std::vector<std::vector<float>> c_ab;
+    std::vector<std::vector<float>> c_ad;
+    std::vector<std::vector<bool>> in_rec;
+    int nn;
 
     // Test: BP-DVR-1
     a_ind = {10.0, 10.0, 10.0};
@@ -127,7 +138,7 @@ TEST(UnitTestBucketPos, DecomposeVectorRectangle) {
     area_min_y = 8;
     area_length_x = 8;
     area_length_y = 8;
-    auto [c_ab, c_ad, in_rec, nn] = soil_simulator::DecomposeVectorRectangle(
+    std::tie(c_ab, c_ad, in_rec, nn) = soil_simulator::DecomposeVectorRectangle(
         ab_ind, ad_ind, a_ind, area_min_x, area_min_y, area_length_x,
         area_length_y, tol);
     EXPECT_EQ(nn, 25 * 4);
@@ -285,6 +296,7 @@ TEST(UnitTestBucketPos, DecomposeVectorRectangle) {
 }
 
 TEST(UnitTestBucketPos, DecomposeVectorTriangle) {
+    // Declaring variables
     std::vector<float> ab_ind;
     std::vector<float> ac_ind;
     std::vector<float> a_ind;
@@ -293,6 +305,10 @@ TEST(UnitTestBucketPos, DecomposeVectorTriangle) {
     int area_length_x;
     int area_length_y;
     float tol = 1.e-5;
+    std::vector<std::vector<float>> c_ab;
+    std::vector<std::vector<float>> c_ac;
+    std::vector<std::vector<bool>> in_tri;
+    int nn;
 
     // Test: BP-DVT-1
     a_ind = {10.0, 10.0, 10.0};
@@ -302,7 +318,7 @@ TEST(UnitTestBucketPos, DecomposeVectorTriangle) {
     area_min_y = 8;
     area_length_x = 15;
     area_length_y = 15;
-    auto [c_ab, c_ac, in_tri, nn] = soil_simulator::DecomposeVectorTriangle(
+    std::tie(c_ab, c_ac, in_tri, nn) = soil_simulator::DecomposeVectorTriangle(
         ab_ind, ac_ind, a_ind, area_min_x, area_min_y, area_length_x,
         area_length_y, tol);
     EXPECT_EQ(nn, 45 * 4);
@@ -544,19 +560,23 @@ TEST(UnitTestBucketPos, DecomposeVectorTriangle) {
 }
 
 TEST(UnitTestBucketPos, CalcRectanglePos) {
+    // Setting up the environment
+    soil_simulator::Grid grid(1.0, 1.0, 1.0, 0.1, 0.1);
+
+    // Declaring variables
     std::vector<float> a;
     std::vector<float> b;
     std::vector<float> c;
     std::vector<float> d;
-    soil_simulator::Grid grid(1.0, 1.0, 1.0, 0.1, 0.1);
     float tol = 1e-5;
+    std::vector<std::vector<int>> rect_pos;
 
     // Test: BP-CR-1
     a = {0.0 + 1e-5, 0.0 + 1e-5, 0.0 - 1e-5};
     b = {0.5 - 1e-5, 0.0 + 1e-5, 0.0 - 1e-5};
     c = {0.5 - 1e-5, 0.5 - 1e-5, 0.0 - 1e-5};
     d = {0.0 + 1e-5, 0.5 - 1e-5, 0.0 - 1e-5};
-    auto rect_pos = soil_simulator::CalcRectanglePos(
+    rect_pos = soil_simulator::CalcRectanglePos(
         a, b, c, d, grid, tol);
     sort(rect_pos.begin(), rect_pos.end());
     rect_pos.erase(unique(rect_pos.begin(), rect_pos.end()), rect_pos.end());
@@ -909,17 +929,21 @@ TEST(UnitTestBucketPos, CalcRectanglePos) {
 }
 
 TEST(UnitTestBucketPos, CalcTrianglePos) {
+    // Setting up the environment
+    soil_simulator::Grid grid(1.0, 1.0, 1.0, 0.1, 0.1);
+
+    // Declaring variables
     std::vector<float> a;
     std::vector<float> b;
     std::vector<float> c;
-    soil_simulator::Grid grid(1.0, 1.0, 1.0, 0.1, 0.1);
     float tol = 1e-5;
+    std::vector<std::vector<int>> tri_pos;
 
     // Test: BP-CT-1
     a = {0.0 + 1e-5, 0.0 + 1e-5, 0.0 - 1e-5};
     b = {1.0 - 1e-5, 0.0 + 1e-5, 0.0 - 1e-5};
     c = {0.0 + 1e-5, 1.0 - 1e-5, 0.0 - 1e-5};
-    auto tri_pos = soil_simulator::CalcTrianglePos(a, b, c, grid, tol);
+    tri_pos = soil_simulator::CalcTrianglePos(a, b, c, grid, tol);
     sort(tri_pos.begin(), tri_pos.end());
     tri_pos.erase(unique(tri_pos.begin(), tri_pos.end()), tri_pos.end());
     EXPECT_EQ(tri_pos.size(), 76);
@@ -1313,7 +1337,7 @@ TEST(UnitTestBucketPos, CalcTrianglePos) {
 }
 
 TEST(UnitTestBucketPos, IncludeNewBodyPos) {
-    // Setting a dummy body
+    // Setting up the environment
     soil_simulator::Grid grid(1.0, 1.0, 1.0, 0.1, 0.1);
     soil_simulator::SimOut *sim_out = new soil_simulator::SimOut(grid);
     sim_out->body_[0][6][9] = 1.0;
@@ -1413,21 +1437,17 @@ TEST(UnitTestBucketPos, IncludeNewBodyPos) {
 }
 
 TEST(UnitTestBucketPos, UpdateBody) {
-    // Setting up
+    // Setting up the environment
     soil_simulator::Grid grid(1.0, 1.0, 1.0, 0.1, 0.1);
     soil_simulator::SimOut *sim_out = new soil_simulator::SimOut(grid);
 
+    // Declaring variables
+    std::vector<std::vector<int>> area_pos;
+
     // Test: BP-UB-1
-    std::vector<std::vector<int>> area_pos(9);
-    area_pos[0] = std::vector<int> {5, 5, 9};
-    area_pos[1] = std::vector<int> {5, 5, 13};
-    area_pos[2] = std::vector<int> {6, 6, 15};
-    area_pos[3] = std::vector<int> {7, 11, 9};
-    area_pos[4] = std::vector<int> {7, 11, 10};
-    area_pos[5] = std::vector<int> {7, 12, 10};
-    area_pos[6] = std::vector<int> {7, 12, 11};
-    area_pos[7] = std::vector<int> {7, 13, 9};
-    area_pos[8] = std::vector<int> {10, 10, 9};
+    area_pos = {
+        {5, 5, 9}, {5, 5, 13}, {6, 6, 15}, {7, 11, 9}, {7, 11, 10}, {7, 12, 10},
+        {7, 12, 11}, {7, 13, 9}, {10, 10, 9}};
     soil_simulator::UpdateBody(area_pos, sim_out, grid, 1e-5);
     EXPECT_NEAR(sim_out->body_[0][5][5], -0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_[1][5][5], 0.4, 1.e-5);
@@ -1443,18 +1463,10 @@ TEST(UnitTestBucketPos, UpdateBody) {
     EXPECT_NEAR(sim_out->body_[1][10][10], 0.0, 1.e-5);
 
     // Test: BP-UB-2
-    std::vector<std::vector<int>> area_pos_2(10);
-    area_pos_2[0] = std::vector<int> {4, 4, 9};
-    area_pos_2[1] = std::vector<int> {5, 5, 13};
-    area_pos_2[2] = std::vector<int> {6, 6, 8};
-    area_pos_2[3] = std::vector<int> {7, 11, 10};
-    area_pos_2[4] = std::vector<int> {7, 11, 13};
-    area_pos_2[5] = std::vector<int> {7, 12, 7};
-    area_pos_2[6] = std::vector<int> {7, 12, 10};
-    area_pos_2[7] = std::vector<int> {7, 13, 7};
-    area_pos_2[8] = std::vector<int> {7, 13, 12};
-    area_pos_2[9] = std::vector<int> {10, 10, 11};
-    soil_simulator::UpdateBody(area_pos_2, sim_out, grid, 1e-5);
+    area_pos = {
+        {4, 4, 9}, {5, 5, 13}, {6, 6, 8}, {7, 11, 10}, {7, 11, 13}, {7, 12, 7},
+        {7, 12, 10}, {7, 13, 7}, {7, 13, 12}, {10, 10, 11}};
+    soil_simulator::UpdateBody(area_pos, sim_out, grid, 1e-5);
     EXPECT_NEAR(sim_out->body_[0][4][4], -0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_[1][4][4], 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_[0][5][5], -0.1, 1.e-5);
@@ -1475,19 +1487,16 @@ TEST(UnitTestBucketPos, UpdateBody) {
     EXPECT_NEAR(sim_out->body_[3][10][10], 0.2, 1.e-5);
 
     // Test: BP-UB-3
-    std::vector<std::vector<int>> area_pos_3(2);
-    area_pos_3[0] = std::vector<int> {6, 6, 6};
-    area_pos_3[1] = std::vector<int> {6, 6, 17};
-    soil_simulator::UpdateBody(area_pos_3, sim_out, grid, 1e-5);
+    area_pos = {{6, 6, 6}, {6, 6, 17}};
+    soil_simulator::UpdateBody(area_pos, sim_out, grid, 1e-5);
     EXPECT_NEAR(sim_out->body_[0][6][6], -0.4, 1.e-5);
     EXPECT_NEAR(sim_out->body_[1][6][6], 0.8, 1.e-5);
     EXPECT_NEAR(sim_out->body_[2][6][6], 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_[3][6][6], 0.0, 1.e-5);
 
     // Test: BP-UB-4
-    std::vector<std::vector<int>> area_pos_4(1);
-    area_pos_4[0] = std::vector<int> {10, 10, 13};
-    soil_simulator::UpdateBody(area_pos_4, sim_out, grid, 1e-5);
+    area_pos = {{{10, 10, 13}}};
+    soil_simulator::UpdateBody(area_pos, sim_out, grid, 1e-5);
     EXPECT_NEAR(sim_out->body_[0][10][10], -0.1, 1.e-5);
     EXPECT_NEAR(sim_out->body_[1][10][10], 0.0, 1.e-5);
     EXPECT_NEAR(sim_out->body_[2][10][10], 0.1, 1.e-5);
@@ -1497,20 +1506,29 @@ TEST(UnitTestBucketPos, UpdateBody) {
 }
 
 TEST(UnitTestBucketPos, CalcBucketPos) {
-    // Setting up
+    // Setting up the environment
     soil_simulator::Grid grid(1.0, 1.0, 1.0, 0.1, 0.1);
     soil_simulator::SimParam sim_param(0.785, 4, 4);
     soil_simulator::SimOut *sim_out = new soil_simulator::SimOut(grid);
 
+    // Declaring variables
+    std::vector<float> o_pos;
+    std::vector<float> j_pos;
+    std::vector<float> b_pos;
+    std::vector<float> t_pos;
+    std::vector<float> ori;
+    std::vector<float> pos;
+    std::vector<std::vector<int>> body_pos;
+
     // Test: BP-CB-1
-    std::vector<float> o_pos = {0.0, 0.0, 0.0};
-    std::vector<float> j_pos = {0.0, 0.0, 0.0};
-    std::vector<float> b_pos = {0.5, 0.01, 0.0};
-    std::vector<float> t_pos = {0.5, 0.0, 0.0};
+    o_pos = {0.0, 0.0, 0.0};
+    j_pos = {0.0, 0.0, 0.0};
+    b_pos = {0.5, 0.01, 0.0};
+    t_pos = {0.5, 0.0, 0.0};
     soil_simulator::Bucket *bucket = new soil_simulator::Bucket(
         o_pos, j_pos, b_pos, t_pos, 0.5);
-    std::vector<float> ori = {1.0, 0.0, 0.0, 0.0};
-    std::vector<float> pos = {0.0, 0.0, 0.0};
+    ori = {1.0, 0.0, 0.0, 0.0};
+    pos = {0.0, 0.0, 0.0};
     soil_simulator::CalcBucketPos(
         sim_out, pos, ori, grid, bucket, sim_param, 1.e-5);
     EXPECT_NEAR(sim_out->body_[0][10][10], -0.3, 1.e-5);
@@ -1530,7 +1548,7 @@ TEST(UnitTestBucketPos, CalcBucketPos) {
     EXPECT_EQ(sim_out->bucket_area_[1][0], 6);
     EXPECT_EQ(sim_out->bucket_area_[1][1], 14);
     // Resetting values
-    std::vector<std::vector<int>> body_pos = {
+    body_pos = {
         {0, 10, 10}, {0, 11, 10}, {0, 12, 10}, {0, 13, 10}, {0, 14, 10},
         {0, 15, 10}};
     test_soil_simulator::ResetValueAndTest(

--- a/test/unit_tests/test_intersecting_cells.cpp
+++ b/test/unit_tests/test_intersecting_cells.cpp
@@ -19,8 +19,8 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     soil_simulator::Bucket *bucket = new soil_simulator::Bucket(
         o_pos, j_pos, b_pos, t_pos, 0.5);
     soil_simulator::SimOut *sim_out = new soil_simulator::SimOut(grid);
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     auto pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.7, grid, bucket);
     auto pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.0, grid, bucket);
 
@@ -472,8 +472,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     soil_simulator::Bucket *bucket = new soil_simulator::Bucket(
         o_pos, j_pos, b_pos, t_pos, 0.5);
     soil_simulator::SimOut *sim_out = new soil_simulator::SimOut(grid);
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
 
     // Declaring variables
     std::vector<float> pos0;
@@ -489,6 +489,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     std::vector<float> posI;
     std::vector<float> posJ;
     std::vector<float> posK;
+    std::vector<std::vector<int>> body_pos;
+    std::vector<std::vector<int>> body_soil_pos;
 
     // Test: IC-MIBS-1
     soil_simulator::rng.seed(1234);
@@ -2707,12 +2709,12 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
         sim_out->body_soil_pos_[11], 2, 12, 17, posE, 0.2);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 12);
     // Resetting values
-    std::vector<std::vector<int>> body_pos = {
+    body_pos = {
         {0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 11, 15}, {0, 12, 15},
         {0, 10, 16}, {2, 10, 16}, {2, 10, 17}, {0, 11, 14}, {2, 11, 14},
         {2, 12, 13}, {0, 9, 14}, {2, 9, 14}, {2, 8, 13}, {0, 11, 16},
         {2, 11, 16}, {0, 12, 17}, {2, 12, 17}};
-    std::vector<std::vector<int>> body_soil_pos = {
+    body_soil_pos = {
         {0, 10, 15}, {2, 10, 15}, {0, 11, 15}, {2, 10, 16}, {0, 11, 14},
         {2, 9, 14}, {0, 11, 16}, {2, 12, 17}};
     test_soil_simulator::ResetValueAndTest(

--- a/test/unit_tests/test_intersecting_cells.cpp
+++ b/test/unit_tests/test_intersecting_cells.cpp
@@ -24,6 +24,14 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     auto pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.7, grid, bucket);
     auto pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.0, grid, bucket);
 
+    // Declaring variables
+    int ind;
+    int ii;
+    int jj;
+    float h_soil;
+    bool wall_presence;
+    std::vector<float> posA;
+
     // Creating a lambda function to set the initial state
     auto SetInitState = [&]() {
         sim_out->body_[0][10][15] = 0.3;
@@ -42,7 +50,7 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
 
     // Test: IC-MBS-1
     SetInitState();
-    auto [ind, ii, jj, h_soil, wall_presence] = soil_simulator::MoveBodySoil(
+    std::tie(ind, ii, jj, h_soil, wall_presence) = soil_simulator::MoveBodySoil(
         sim_out, 2, 10, 15, 0.3, 5, 7, 0.6, false, grid, bucket, 1e-5);
     EXPECT_EQ(wall_presence, false);
     EXPECT_NEAR(h_soil, 0.0, 1e-5);
@@ -86,7 +94,7 @@ TEST(UnitTestIntersectingCells, MoveBodySoil) {
     SetInitState();
     sim_out->body_[0][5][7] = 0.0;
     sim_out->body_[1][5][7] = 0.2;
-    auto posA = soil_simulator::CalcBucketFramePos(5, 7, 0.2, grid, bucket);
+    posA = soil_simulator::CalcBucketFramePos(5, 7, 0.2, grid, bucket);
     std::tie(ind, ii, jj, h_soil, wall_presence) = soil_simulator::MoveBodySoil(
         sim_out, 2, 10, 15, 0.3, 5, 7, 0.6, false, grid, bucket, 1e-5);
     EXPECT_EQ(wall_presence, false);
@@ -467,6 +475,21 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
 
+    // Declaring variables
+    std::vector<float> pos0;
+    std::vector<float> pos2;
+    std::vector<float> posA;
+    std::vector<float> posB;
+    std::vector<float> posC;
+    std::vector<float> posD;
+    std::vector<float> posE;
+    std::vector<float> posF;
+    std::vector<float> posG;
+    std::vector<float> posH;
+    std::vector<float> posI;
+    std::vector<float> posJ;
+    std::vector<float> posK;
+
     // Test: IC-MIBS-1
     soil_simulator::rng.seed(1234);
     sim_out->body_[0][10][15] = 0.0;
@@ -477,8 +500,8 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     sim_out->body_soil_[1][10][15] = 0.8;
     sim_out->body_soil_[2][10][15] = 0.6;
     sim_out->body_soil_[3][10][15] = 0.7;
-    auto pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
-    auto pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
     sim_out->body_soil_pos_.push_back(
@@ -738,7 +761,7 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
         soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
-    auto posA = soil_simulator::CalcBucketFramePos(11, 15, 0.2, grid, bucket);
+    posA = soil_simulator::CalcBucketFramePos(11, 15, 0.2, grid, bucket);
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -2382,7 +2405,7 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
         soil_simulator::body_soil {0, 11, 15, posA[0], posA[1], posA[2], 0.1});
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {2, 11, 15, pos2[0], pos2[1], pos2[2], 0.1});
-    auto posB = soil_simulator::CalcBucketFramePos(12, 15, 0.3, grid, bucket);
+    posB = soil_simulator::CalcBucketFramePos(12, 15, 0.3, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 12, 15, posB[0], posB[1], posB[2], 0.1});
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
@@ -2644,16 +2667,16 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     posB = soil_simulator::CalcBucketFramePos(10, 16, 0.1, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {2, 10, 16, posB[0], posB[1], posB[2], 0.3});
-    auto posC = soil_simulator::CalcBucketFramePos(11, 14, 0.1, grid, bucket);
+    posC = soil_simulator::CalcBucketFramePos(11, 14, 0.1, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 11, 14, posC[0], posC[1], posC[2], 0.1});
-    auto posD = soil_simulator::CalcBucketFramePos(9, 14, 0.3, grid, bucket);
+    posD = soil_simulator::CalcBucketFramePos(9, 14, 0.3, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {2, 9, 14, posD[0], posD[1], posD[2], 0.1});
     pos0 = soil_simulator::CalcBucketFramePos(11, 16, 0.1, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 11, 16, pos0[0], pos0[1], pos0[2], 0.7});
-    auto posE = soil_simulator::CalcBucketFramePos(12, 17, 0.3, grid, bucket);
+    posE = soil_simulator::CalcBucketFramePos(12, 17, 0.3, grid, bucket);
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -3028,15 +3051,15 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     posE = soil_simulator::CalcBucketFramePos(15, 15, 0.2, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 15, 15, posE[0], posE[1], posE[2], 0.2});
-    auto posG = soil_simulator::CalcBucketFramePos(17, 15, 0.6, grid, bucket);
+    posG = soil_simulator::CalcBucketFramePos(17, 15, 0.6, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {2, 17, 15, posG[0], posG[1], posG[2], 0.2});
     posA = soil_simulator::CalcBucketFramePos(11, 15, 0.2, grid, bucket);
     posD = soil_simulator::CalcBucketFramePos(14, 15, 0.2, grid, bucket);
-    auto posF = soil_simulator::CalcBucketFramePos(16, 15, 0.5, grid, bucket);
-    auto posH = soil_simulator::CalcBucketFramePos(18, 15, 0.8, grid, bucket);
-    auto posI = soil_simulator::CalcBucketFramePos(19, 15, 0.4, grid, bucket);
-    auto posJ = soil_simulator::CalcBucketFramePos(20, 15, 0.1, grid, bucket);
+    posF = soil_simulator::CalcBucketFramePos(16, 15, 0.5, grid, bucket);
+    posH = soil_simulator::CalcBucketFramePos(18, 15, 0.8, grid, bucket);
+    posI = soil_simulator::CalcBucketFramePos(19, 15, 0.4, grid, bucket);
+    posJ = soil_simulator::CalcBucketFramePos(20, 15, 0.1, grid, bucket);
     soil_simulator::MoveIntersectingBodySoil(sim_out, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[0][10][15], 0.3, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_[1][10][15], 0.5, 1e-5);
@@ -3190,7 +3213,7 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBodySoil) {
     posJ = soil_simulator::CalcBucketFramePos(19, 15, 0.9, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {2, 19, 15, posJ[0], posJ[1], posJ[2], 0.3});
-    auto posK = soil_simulator::CalcBucketFramePos(20, 15, 0.1, grid, bucket);
+    posK = soil_simulator::CalcBucketFramePos(20, 15, 0.1, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 20, 15, posK[0], posK[1], posK[2], 0.2});
     posC = soil_simulator::CalcBucketFramePos(12, 15, 0.2, grid, bucket);
@@ -3977,8 +4000,11 @@ TEST(UnitTestIntersectingCells, LocateIntersectingCells) {
     sim_out->body_[2][10][16] = -0.6;
     sim_out->body_[3][10][16] = -0.4;
 
+    // Declaring variables
+    std::vector<std::vector<int>> intersecting_cells;
+
     // -- Testing that intersecting cells are properly located --
-    auto intersecting_cells = soil_simulator::LocateIntersectingCells(
+    intersecting_cells = soil_simulator::LocateIntersectingCells(
         sim_out, 1e-5);
     EXPECT_TRUE((intersecting_cells[0] == std::vector<int> {0, 10, 11}));
     EXPECT_TRUE((intersecting_cells[1] == std::vector<int> {2, 10, 12}));
@@ -4002,6 +4028,10 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
     sim_out->bucket_area_[1][0] = 1;
     sim_out->bucket_area_[1][1] = 20;
 
+    // Declaring variables
+    std::vector<std::vector<int>> body_pos;
+    std::vector<std::vector<int>> terrain_pos;
+
     // Test: IC-MIB-1
     for (auto ii = 11; ii < 13; ii++)
         for (auto jj = 16; jj < 19; jj++) {
@@ -4016,7 +4046,7 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
     soil_simulator::MoveIntersectingBody(sim_out, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[10][17], 0.1, 1e-5);
     // Resetting values
-    std::vector<std::vector<int>> body_pos = {
+    body_pos = {
         {0, 10, 16}, {0, 10, 18}, {0, 11, 16}, {0, 11, 17}, {0, 11, 18},
         {0, 12, 16}, {0, 12, 17}, {0, 12, 18}};
     test_soil_simulator::ResetValueAndTest(
@@ -4348,7 +4378,7 @@ TEST(UnitTestIntersectingCells, MoveIntersectingBody) {
     EXPECT_NEAR(sim_out->terrain_[14][20], 0.2, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[15][17], 0.2, 1e-5);
     // Resetting values
-    std::vector<std::vector<int>> terrain_pos = {
+    terrain_pos = {
         {11, 17}, {10, 17}, {8, 17}, {12, 17}, {13, 17}, {13, 19}, {14, 20},
         {15, 17}};
     body_pos = {

--- a/test/unit_tests/test_relax.cpp
+++ b/test/unit_tests/test_relax.cpp
@@ -25,8 +25,11 @@ TEST(UnitTestRelax, LocateUnstableTerrainCell) {
     sim_out->terrain_[15][5] = -0.4;
     sim_out->terrain_[15][6] = -0.2;
 
+    // Declaring variables
+    std::vector<std::vector<int>> unstable_cells;
+
     // -- Testing that all unstable cells are properly located --
-    auto unstable_cells = soil_simulator::LocateUnstableTerrainCell(
+    unstable_cells = soil_simulator::LocateUnstableTerrainCell(
         sim_out, 0.1, 1e-5);
     EXPECT_TRUE((unstable_cells[0] == std::vector<int> {4, 2}));
     EXPECT_TRUE((unstable_cells[1] == std::vector<int> {5, 3}));
@@ -52,6 +55,8 @@ TEST(UnitTestRelax, CheckUnstableTerrainCell) {
     // Setting up the environment
     soil_simulator::Grid grid(1.0, 1.0, 1.0, 0.1, 0.1);
     soil_simulator::SimOut *sim_out = new soil_simulator::SimOut(grid);
+
+    // Declaring variables
     int status;
 
     // Test: RE-CUT-1
@@ -821,6 +826,11 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
 
+    // Declaring variables
+    std::vector<float> pos0;
+    std::vector<float> pos2;
+    std::vector<float> posA;
+
     // Test: RE-RUT-1
     sim_out->terrain_[10][14] = 0.4;
     sim_out->terrain_[10][15] = 0.1;
@@ -863,7 +873,7 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     sim_out->terrain_[10][15] = -0.4;
     sim_out->body_[0][10][15] = -0.4;
     sim_out->body_[1][10][15] = -0.2;
-    auto posA = soil_simulator::CalcBucketFramePos(10, 15, -0.2, grid, bucket);
+    posA = soil_simulator::CalcBucketFramePos(10, 15, -0.2, grid, bucket);
     soil_simulator::RelaxUnstableTerrainCell(
         sim_out, 14, 0.1, 10, 14, 10, 15, grid, bucket, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[10][14], -0.1, 1e-5);
@@ -883,7 +893,7 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     sim_out->body_[1][10][15] = -0.5;
     sim_out->body_soil_[0][10][15] = -0.5;
     sim_out->body_soil_[1][10][15] = -0.3;
-    auto  pos0 = soil_simulator::CalcBucketFramePos(10, 15, -0.5, grid, bucket);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, -0.5, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.2});
     soil_simulator::RelaxUnstableTerrainCell(
@@ -989,7 +999,7 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     sim_out->body_[3][10][15] = -0.5;
     sim_out->body_soil_[2][10][15] = -0.5;
     sim_out->body_soil_[3][10][15] = -0.3;
-    auto pos2 = soil_simulator::CalcBucketFramePos(10, 15, -0.5, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, -0.5, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.2});
     soil_simulator::RelaxUnstableTerrainCell(
@@ -1459,6 +1469,12 @@ TEST(UnitTestRelax, RelaxTerrain) {
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
 
+    // Declaring variables
+    std::vector<float> pos0;
+    std::vector<float> pos2;
+    std::vector<float> posA;
+    std::vector<float> posB;
+
     // Test: RE-RT-1
     soil_simulator::rng.seed(200);
     sim_out->terrain_[10][15] = -0.1;
@@ -1527,7 +1543,7 @@ TEST(UnitTestRelax, RelaxTerrain) {
     sim_out->relax_area_[0][1] = 15;
     sim_out->relax_area_[1][0] = 10;
     sim_out->relax_area_[1][1] = 15;
-    auto posA = soil_simulator::CalcBucketFramePos(10, 15, -0.2, grid, bucket);
+    posA = soil_simulator::CalcBucketFramePos(10, 15, -0.2, grid, bucket);
     soil_simulator::RelaxTerrain(sim_out, grid, bucket, sim_param, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[10][15], -0.4, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[10][16], -0.1, 1e-5);
@@ -1575,7 +1591,7 @@ TEST(UnitTestRelax, RelaxTerrain) {
     sim_out->relax_area_[0][1] = 15;
     sim_out->relax_area_[1][0] = 10;
     sim_out->relax_area_[1][1] = 15;
-    auto pos0 = soil_simulator::CalcBucketFramePos(10, 15, -0.5, grid, bucket);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, -0.5, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 10, 15, pos0[0], pos0[1], pos0[2], 0.5});
     soil_simulator::RelaxTerrain(sim_out, grid, bucket, sim_param, 1e-5);
@@ -1730,7 +1746,7 @@ TEST(UnitTestRelax, RelaxTerrain) {
     sim_out->relax_area_[0][1] = 15;
     sim_out->relax_area_[1][0] = 10;
     sim_out->relax_area_[1][1] = 15;
-    auto pos2 = soil_simulator::CalcBucketFramePos(10, 15, -0.5, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, -0.5, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.4});
     soil_simulator::RelaxTerrain(sim_out, grid, bucket, sim_param, 1e-5);
@@ -1868,7 +1884,7 @@ TEST(UnitTestRelax, RelaxTerrain) {
     sim_out->relax_area_[1][0] = 10;
     sim_out->relax_area_[1][1] = 15;
     posA = soil_simulator::CalcBucketFramePos(10, 15, -0.6, grid, bucket);
-    auto posB = soil_simulator::CalcBucketFramePos(10, 15, -0.2, grid, bucket);
+    posB = soil_simulator::CalcBucketFramePos(10, 15, -0.2, grid, bucket);
     soil_simulator::RelaxTerrain(sim_out, grid, bucket, sim_param, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[10][15], -0.8, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[10][16], -0.2, 1e-5);
@@ -2718,6 +2734,8 @@ TEST(UnitTestRelax, CheckUnstableBodyCell) {
     // Setting up the environment
     soil_simulator::Grid grid(1.0, 1.0, 1.0, 0.1, 0.1);
     soil_simulator::SimOut *sim_out = new soil_simulator::SimOut(grid);
+
+    // Declaring variables
     int status;
 
     // Test: RE-CUB-1
@@ -3576,6 +3594,11 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
 
+    // Declaring variables
+    std::vector<float> pos0;
+    std::vector<float> pos2;
+    std::vector<float> posA;
+
     // Test: RE-RUB-1
     sim_out->terrain_[10][14] = -0.2;
     sim_out->body_[0][10][14] = -0.2;
@@ -3583,7 +3606,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     sim_out->body_soil_[0][10][14] = 0.0;
     sim_out->body_soil_[1][10][14] = 0.2;
     sim_out->terrain_[10][15] = 0.0;
-    auto pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 10, 14, pos0[0], pos0[1], pos0[2], 0.2});
     soil_simulator::RelaxUnstableBodyCell(
@@ -3750,7 +3773,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 10, 14, pos0[0], pos0[1], pos0[2], 0.2});
-    auto posA = soil_simulator::CalcBucketFramePos(10, 15, 0.0, grid, bucket);
+    posA = soil_simulator::CalcBucketFramePos(10, 15, 0.0, grid, bucket);
     soil_simulator::RelaxUnstableBodyCell(
         sim_out, 14, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
         1e-5);
@@ -3995,7 +4018,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.1, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 10, 14, pos0[0], pos0[1], pos0[2], 0.2});
-    auto pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
     soil_simulator::RelaxUnstableBodyCell(
@@ -5527,6 +5550,11 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
     bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
 
+    // Declaring variables
+    std::vector<float> pos0;
+    std::vector<float> pos2;
+    std::vector<float> posA;
+
     // Test: RE-RBS-1
     soil_simulator::rng.seed(1234);
     sim_out->terrain_[10][14] = -0.3;
@@ -5535,7 +5563,7 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     sim_out->body_soil_[0][10][14] = -0.2;
     sim_out->body_soil_[1][10][14] = 0.0;
     sim_out->terrain_[10][15] = -0.2;
-    auto pos0 = soil_simulator::CalcBucketFramePos(10, 14, -0.2, grid, bucket);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 14, -0.2, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 10, 14, pos0[0], pos0[1], pos0[2], 0.2});
     soil_simulator::RelaxBodySoil(sim_out, grid, bucket, sim_param, 1e-5);
@@ -5693,7 +5721,7 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, -0.3, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 10, 14, pos0[0], pos0[1], pos0[2], 0.2});
-    auto posA = soil_simulator::CalcBucketFramePos(10, 15, -0.3, grid, bucket);
+    posA = soil_simulator::CalcBucketFramePos(10, 15, -0.3, grid, bucket);
     soil_simulator::RelaxBodySoil(sim_out, grid, bucket, sim_param, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[10][14], -0.4, 1e-5);
     EXPECT_NEAR(sim_out->terrain_[10][15], -0.4, 1e-5);
@@ -6454,7 +6482,7 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, -0.2, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 10, 14, pos0[0], pos0[1], pos0[2], 0.2});
-    auto pos2 = soil_simulator::CalcBucketFramePos(10, 15, -0.7, grid, bucket);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, -0.7, grid, bucket);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {2, 10, 15, pos2[0], pos2[1], pos2[2], 0.1});
     posA = soil_simulator::CalcBucketFramePos(10, 15, -0.2, grid, bucket);

--- a/test/unit_tests/test_relax.cpp
+++ b/test/unit_tests/test_relax.cpp
@@ -823,8 +823,8 @@ TEST(UnitTestRelax, RelaxUnstableTerrainCell) {
     soil_simulator::Bucket *bucket = new soil_simulator::Bucket(
         o_pos, j_pos, b_pos, t_pos, 0.5);
     soil_simulator::SimOut *sim_out = new soil_simulator::SimOut(grid);
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
 
     // Declaring variables
     std::vector<float> pos0;
@@ -1466,8 +1466,8 @@ TEST(UnitTestRelax, RelaxTerrain) {
     sim_out->impact_area_[0][1] = 16;
     sim_out->impact_area_[1][0] = 9;
     sim_out->impact_area_[1][1] = 20;
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
 
     // Declaring variables
     std::vector<float> pos0;
@@ -3591,8 +3591,8 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     soil_simulator::SimOut *sim_out = new soil_simulator::SimOut(grid);
     std::vector<soil_simulator::body_soil> *body_soil_pos = (
         new std::vector<soil_simulator::body_soil>);
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
 
     // Declaring variables
     std::vector<float> pos0;
@@ -5547,13 +5547,14 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     sim_out->impact_area_[0][1] = 20;
     sim_out->impact_area_[1][0] = 2;
     sim_out->impact_area_[1][1] = 20;
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
 
     // Declaring variables
     std::vector<float> pos0;
     std::vector<float> pos2;
     std::vector<float> posA;
+    std::vector<std::vector<int>> terrain_pos;
 
     // Test: RE-RBS-1
     soil_simulator::rng.seed(1234);
@@ -8174,7 +8175,7 @@ TEST(UnitTestRelax, RelaxBodySoil) {
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.7, 1.e-5);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 3);
     // Resetting values
-    std::vector<std::vector<int>> terrain_pos = {
+    terrain_pos = {
         {9, 13}, {9, 14}, {9, 15}, {10, 13}, {10, 14}, {10, 15}, {11, 13},
         {11, 14}, {11, 15}};
     test_soil_simulator::ResetValueAndTest(

--- a/test/unit_tests/test_types.cpp
+++ b/test/unit_tests/test_types.cpp
@@ -92,11 +92,16 @@ TEST(UnitTestTypes, Grid) {
 }
 
 TEST(UnitTestTypes, Bucket) {
-    // Test: TY-B-1
+    // Setting up the environment
+    std::vector<float> vect_1 = {0.0};
+    std::vector<float> vect_2 = {0.0, 0.1};
+    std::vector<float> vect_4 = {0.0, 0.1, 0.0, 0.3};
     std::vector<float> o_pos = {0.0, 0.1, 0.0};
     std::vector<float> j_pos = {0.0, 0.5, 0.0};
     std::vector<float> b_pos = {0.0, 0.5, 0.5};
     std::vector<float> t_pos = {0.5, 0.5, 0.0};
+
+    // Test: TY-B-1
     soil_simulator::Bucket bucket(o_pos, j_pos, b_pos, t_pos, 0.5);
     EXPECT_NEAR(bucket.j_pos_init_[0], 0.0, 1e-8);
     EXPECT_NEAR(bucket.j_pos_init_[1], 0.4, 1e-8);
@@ -112,11 +117,6 @@ TEST(UnitTestTypes, Bucket) {
         EXPECT_EQ(bucket.pos_[ii], 0.0);
     for (auto ii = 0 ; ii < 4 ; ii++)
         EXPECT_EQ(bucket.ori_[ii], 0.0);
-
-    // Setting up some dummy vect
-    std::vector<float> vect_1 = {0.0};
-    std::vector<float> vect_2 = {0.0, 0.1};
-    std::vector<float> vect_4 = {0.0, 0.1, 0.0, 0.3};
 
     // Test: TY-B-2
     EXPECT_THROW(

--- a/test/unit_tests/test_utils.cpp
+++ b/test/unit_tests/test_utils.cpp
@@ -16,9 +16,13 @@ TEST(UnitTestUtils, CalcBucketCornerPos) {
     soil_simulator::Bucket *bucket = new soil_simulator::Bucket(
         o_pos, j_pos, b_pos, t_pos, 0.5);
 
+    // Declaring variables
+    std::vector<float> pos;
+    std::vector<float> ori;
+
     // Test: UT-CBC-1
-    auto pos = std::vector<float> {0.0, 0.0, 0.0};
-    auto ori = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    pos = {0.0, 0.0, 0.0};
+    ori = {1.0, 0.0, 0.0, 0.0};
     auto [j_r_pos, j_l_pos, b_r_pos, b_l_pos, t_r_pos, t_l_pos] =
         soil_simulator::CalcBucketCornerPos(pos, ori, bucket);
     EXPECT_TRUE((j_r_pos == std::vector<float> {0.0, -0.25, 0.0}));
@@ -29,8 +33,8 @@ TEST(UnitTestUtils, CalcBucketCornerPos) {
     EXPECT_TRUE((t_l_pos == std::vector<float> {0.7, 0.25, -0.5}));
 
     // Test: UT-CBC-2
-    pos = std::vector<float> {0.1, -0.1, 0.2};
-    ori = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    pos = {0.1, -0.1, 0.2};
+    ori = {1.0, 0.0, 0.0, 0.0};
     std::tie(j_r_pos, j_l_pos, b_r_pos, b_l_pos, t_r_pos, t_l_pos) =
         soil_simulator::CalcBucketCornerPos(pos, ori, bucket);
     EXPECT_TRUE((j_r_pos == std::vector<float> {0.1, -0.35, 0.2}));
@@ -41,8 +45,8 @@ TEST(UnitTestUtils, CalcBucketCornerPos) {
     EXPECT_TRUE((t_l_pos == std::vector<float> {0.8, 0.15, -0.3}));
 
     // Test: UT-CBC-3
-    pos = std::vector<float> {0.0, 0.0, 0.0};
-    ori = std::vector<float> {0.707107, 0.0, 0.0, -0.707107};
+    pos = {0.0, 0.0, 0.0};
+    ori = {0.707107, 0.0, 0.0, -0.707107};
     std::tie(j_r_pos, j_l_pos, b_r_pos, b_l_pos, t_r_pos, t_l_pos) =
         soil_simulator::CalcBucketCornerPos(pos, ori, bucket);
     EXPECT_TRUE((j_r_pos == std::vector<float> {0.25, 0.0, 0.0}));
@@ -58,8 +62,8 @@ TEST(UnitTestUtils, CalcBucketCornerPos) {
     EXPECT_NEAR(t_l_pos[2], -0.5, 1e-5);
 
     // Test: UT-CBC-4
-    pos = std::vector<float> {0.1, -0.1, 0.2};
-    ori = std::vector<float> {0.707107, 0.0, 0.0, -0.707107};
+    pos = {0.1, -0.1, 0.2};
+    ori = {0.707107, 0.0, 0.0, -0.707107};
     std::tie(j_r_pos, j_l_pos, b_r_pos, b_l_pos, t_r_pos, t_l_pos) =
         soil_simulator::CalcBucketCornerPos(pos, ori, bucket);
     EXPECT_TRUE((j_r_pos == std::vector<float> {0.35, -0.1, 0.2}));
@@ -81,54 +85,59 @@ TEST(UnitTestUtils, CheckBucketMovement) {
     std::vector<float> t_pos = {0.7, 0.0, -0.5};
     soil_simulator::Bucket *bucket = new soil_simulator::Bucket(
         o_pos, j_pos, b_pos, t_pos, 0.5);
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+
+    // Declaring variables
+    std::vector<float> pos;
+    std::vector<float> ori;
+    bool status;
 
     // Test: UT-CBM-1
-    auto pos = std::vector<float> {0.1, 0.0, 0.0};
-    auto ori = std::vector<float> {1.0, 0.0, 0.0, 0.0};
-    bool status = soil_simulator::CheckBucketMovement(pos, ori, grid, bucket);
+    pos = {0.1, 0.0, 0.0};
+    ori = {1.0, 0.0, 0.0, 0.0};
+    status = soil_simulator::CheckBucketMovement(pos, ori, grid, bucket);
     EXPECT_TRUE(status);
 
     // Test: UT-CBM-2
-    pos = std::vector<float> {0.05, 0.02, -0.05};
-    ori = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    pos = {0.05, 0.02, -0.05};
+    ori = {1.0, 0.0, 0.0, 0.0};
     status = soil_simulator::CheckBucketMovement(pos, ori, grid, bucket);
     EXPECT_TRUE(status);
 
     // Test: UT-CBM-3
-    pos = std::vector<float> {0.0, 0.0, 0.0};
-    ori = std::vector<float> {0.997, 0.0, 0.07, 0.0};
+    pos = {0.0, 0.0, 0.0};
+    ori = {0.997, 0.0, 0.07, 0.0};
     status = soil_simulator::CheckBucketMovement(pos, ori, grid, bucket);
     EXPECT_TRUE(status);
 
     // Test: UT-CBM-4
-    pos = std::vector<float> {0.05, 0.0, 0.0};
-    ori = std::vector<float> {0.997, 0.0, 0.07, 0.0};
+    pos = {0.05, 0.0, 0.0};
+    ori = {0.997, 0.0, 0.07, 0.0};
     status = soil_simulator::CheckBucketMovement(pos, ori, grid, bucket);
     EXPECT_TRUE(status);
 
     // Test: UT-CBM-5
-    pos = std::vector<float> {0.005, 0.0, 0.0};
-    ori = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    pos = {0.005, 0.0, 0.0};
+    ori = {1.0, 0.0, 0.0, 0.0};
     status = soil_simulator::CheckBucketMovement(pos, ori, grid, bucket);
     EXPECT_FALSE(status);
 
     // Test: UT-CBM-6
-    pos = std::vector<float> {0.001, 0.002, -0.003};
-    ori = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    pos = {0.001, 0.002, -0.003};
+    ori = {1.0, 0.0, 0.0, 0.0};
     status = soil_simulator::CheckBucketMovement(pos, ori, grid, bucket);
     EXPECT_FALSE(status);
 
     // Test: UT-CBM-7
-    pos = std::vector<float> {0.0, 0.0, 0.0};
-    ori = std::vector<float> {0.999, 0.0, 0.0029, 0.0};
+    pos = {0.0, 0.0, 0.0};
+    ori = {0.999, 0.0, 0.0029, 0.0};
     status = soil_simulator::CheckBucketMovement(pos, ori, grid, bucket);
     EXPECT_FALSE(status);
 
     // Test: UT-CBM-8
-    pos = std::vector<float> {0.001, 0.0, 0.0};
-    ori = std::vector<float> {0.999, 0.0, 0.0029, 0.0};
+    pos = {0.001, 0.0, 0.0};
+    ori = {0.999, 0.0, 0.0029, 0.0};
     status = soil_simulator::CheckBucketMovement(pos, ori, grid, bucket);
     EXPECT_FALSE(status);
 
@@ -136,11 +145,18 @@ TEST(UnitTestUtils, CheckBucketMovement) {
 }
 
 TEST(UnitTestUtils, CalcNormal) {
+    // Declaring variables
+    std::vector<float> a;
+    std::vector<float> b;
+    std::vector<float> c;
+    std::vector<float> normal;
+    float cc;
+
     // Test: UT-CN-1
-    std::vector<float> a = {0.0, 0.0, 0.0};
-    std::vector<float> b = {2.3, 0.0, 0.0};
-    std::vector<float> c = {2.3, 2.45, 0.0};
-    auto normal = soil_simulator::CalcNormal(a, b, c);
+    a = {0.0, 0.0, 0.0};
+    b = {2.3, 0.0, 0.0};
+    c = {2.3, 2.45, 0.0};
+    normal = soil_simulator::CalcNormal(a, b, c);
     EXPECT_TRUE((normal == std::vector<float> {0.0, 0.0, 1.0}));
     normal = soil_simulator::CalcNormal(a, c, b);
     EXPECT_TRUE((normal == std::vector<float> {0.0, 0.0, -1.0}));
@@ -167,7 +183,7 @@ TEST(UnitTestUtils, CalcNormal) {
     a = {1.0, 0.0, 0.0};
     b = {0.0, 1.0, 0.0};
     c = {0.0, 0.0, 1.0};
-    float cc = std::sqrt(1.0 / 3.0);
+    cc = std::sqrt(1.0 / 3.0);
     normal = soil_simulator::CalcNormal(a, b, c);
     EXPECT_TRUE((normal == std::vector<float> {cc, cc, cc}));
     normal = soil_simulator::CalcNormal(a, c, b);
@@ -175,9 +191,14 @@ TEST(UnitTestUtils, CalcNormal) {
 }
 
 TEST(UnitTestUtils, MultiplyQuaternion) {
+    // Declaring variables
+    std::vector<float> q1;
+    std::vector<float> q2;
+    std::vector<float> quat;
+
     // Test: UT-MQ-1
-    std::vector<float> q1 = {0.707107, 0.0, 0.0, -0.707107};
-    std::vector<float> quat = soil_simulator::MultiplyQuaternion(q1, q1);
+    q1 = {0.707107, 0.0, 0.0, -0.707107};
+    quat = soil_simulator::MultiplyQuaternion(q1, q1);
     EXPECT_NEAR(quat[0], 0.0, 1e-5);
     EXPECT_NEAR(quat[1], 0.0, 1e-5);
     EXPECT_NEAR(quat[2], 0.0, 1e-5);
@@ -201,7 +222,7 @@ TEST(UnitTestUtils, MultiplyQuaternion) {
 
     // Test: UT-MQ-4
     q1 = {0.8, -0.4, 0.2, 0.7};
-    std::vector<float> q2 = {0.2, 0.5, -0.7, -0.8};
+    q2 = {0.2, 0.5, -0.7, -0.8};
     quat = soil_simulator::MultiplyQuaternion(q1, q2);
     EXPECT_NEAR(quat[0], 1.06, 1e-5);
     EXPECT_NEAR(quat[1], 0.65, 1e-5);
@@ -210,10 +231,15 @@ TEST(UnitTestUtils, MultiplyQuaternion) {
 }
 
 TEST(UnitTestUtils, CalcRotationQuaternion) {
+    // Declaring variables
+    std::vector<float> pos;
+    std::vector<float> ori;
+    std::vector<float> new_pos;
+
     // Test: UT-CRQ-1
-    std::vector<float> ori = {0.707107, 0.0, 0.0, -0.707107};
-    std::vector<float> pos = {0.1, 0.1, 0.3};
-    auto new_pos = soil_simulator::CalcRotationQuaternion(ori, pos);
+    ori = {0.707107, 0.0, 0.0, -0.707107};
+    pos = {0.1, 0.1, 0.3};
+    new_pos = soil_simulator::CalcRotationQuaternion(ori, pos);
     EXPECT_NEAR(new_pos[0], -0.1, 1e-5);
     EXPECT_NEAR(new_pos[1], 0.1, 1e-5);
     EXPECT_NEAR(new_pos[2], 0.3, 1e-5);
@@ -244,9 +270,13 @@ TEST(UnitTestUtils, CalcRotationQuaternion) {
 }
 
 TEST(UnitTestUtils, AngleToQuat) {
+    // Declaring variables
+    std::vector<float> ori;
+    std::vector<float> quat;
+
     // Test: UT-AQ-1
-    std::vector<float> ori = {-1.570796327, 0.0, 0.0};
-    auto quat = soil_simulator::AngleToQuat(ori);
+    ori = {-1.570796327, 0.0, 0.0};
+    quat = soil_simulator::AngleToQuat(ori);
     EXPECT_NEAR(quat[0], 0.707107, 1e-5);
     EXPECT_NEAR(quat[1], 0.0, 1e-5);
     EXPECT_NEAR(quat[2], 0.0, 1e-5);
@@ -286,70 +316,76 @@ TEST(UnitTestUtils, CalcBucketFramePos) {
     std::vector<float> t_pos = {0.7, 0.0, -0.5};
     soil_simulator::Bucket *bucket = new soil_simulator::Bucket(
         o_pos, j_pos, b_pos, t_pos, 0.5);
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+
+    // Declaring variables
+    std::vector<float> pos;
 
     // Test: UT-CBF-1
-    auto pos = soil_simulator::CalcBucketFramePos(
+    pos = soil_simulator::CalcBucketFramePos(
         11, 11, 0.2, grid, bucket);
     EXPECT_NEAR(pos[0], 0.1, 1e-5);
     EXPECT_NEAR(pos[1], 0.1, 1e-5);
     EXPECT_NEAR(pos[2], 0.2, 1e-5);
 
     // Test: UT-CBF-2
-    bucket->pos_ = std::vector<float> {-0.1, 0.2, 0.3};
+    bucket->pos_ = {-0.1, 0.2, 0.3};
     pos = soil_simulator::CalcBucketFramePos(
         10, 12, -0.2, grid, bucket);
     EXPECT_NEAR(pos[0], 0.1, 1e-5);
     EXPECT_NEAR(pos[1], 0.0, 1e-5);
     EXPECT_NEAR(pos[2], -0.5, 1e-5);
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
 
     // Test: UT-CBF-3
-    bucket->ori_ = std::vector<float> {0.707107, 0.0, 0.0, -0.707107};
+    bucket->ori_ = {0.707107, 0.0, 0.0, -0.707107};
     pos = soil_simulator::CalcBucketFramePos(
         11, 12, 0.3, grid, bucket);
     EXPECT_NEAR(pos[0], 0.2, 1e-5);
     EXPECT_NEAR(pos[1], -0.1, 1e-5);
     EXPECT_NEAR(pos[2], 0.3, 1e-5);
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
 
     // Test: UT-CBF-4
-    bucket->ori_ = std::vector<float> {0.707107, 0.0, -0.707107, 0.0};
+    bucket->ori_ = {0.707107, 0.0, -0.707107, 0.0};
     pos = soil_simulator::CalcBucketFramePos(
         11, 12, 0.3, grid, bucket);
     EXPECT_NEAR(pos[0], -0.3, 1e-5);
     EXPECT_NEAR(pos[1], 0.2, 1e-5);
     EXPECT_NEAR(pos[2], 0.1, 1e-5);
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
 
     // Test: UT-CBF-5
-    bucket->ori_ = std::vector<float> {0.707107, 0.707107, 0.0, 0.0};
+    bucket->ori_ = {0.707107, 0.707107, 0.0, 0.0};
     pos = soil_simulator::CalcBucketFramePos(
         11, 12, 0.3, grid, bucket);
     EXPECT_NEAR(pos[0], 0.1, 1e-5);
     EXPECT_NEAR(pos[1], -0.3, 1e-5);
     EXPECT_NEAR(pos[2], 0.2, 1e-5);
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
 
     // Test: UT-CBF-6
-    bucket->pos_ = std::vector<float> {-0.1, 0.2, 0.3};
-    bucket->ori_ = std::vector<float> {0.707107, 0.0, 0.0, -0.707107};
+    bucket->pos_ = {-0.1, 0.2, 0.3};
+    bucket->ori_ = {0.707107, 0.0, 0.0, -0.707107};
     pos = soil_simulator::CalcBucketFramePos(
         10, 12, -0.2, grid, bucket);
     EXPECT_NEAR(pos[0], 0.0, 1e-5);
     EXPECT_NEAR(pos[1], -0.1, 1e-5);
     EXPECT_NEAR(pos[2], -0.5, 1e-5);
-    bucket->pos_ = std::vector<float> {0.0, 0.0, 0.0};
-    bucket->ori_ = std::vector<float> {1.0, 0.0, 0.0, 0.0};
+    bucket->pos_ = {0.0, 0.0, 0.0};
+    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
 
     delete bucket;
 }
 
 TEST(UnitTestUtils, CheckVolume) {
-    // Setting dummy classes
+    // Setting up the environment
     soil_simulator::Grid grid(1.0, 1.0, 1.0, 0.1, 0.1);
     soil_simulator::SimOut *sim_out = new soil_simulator::SimOut(grid);
+
+    // Declaring variables
+    float init_volume;
 
     // Test: UT-CV-1
     EXPECT_TRUE(soil_simulator::CheckVolume(sim_out, 0.0, grid, 1e-5));
@@ -361,7 +397,7 @@ TEST(UnitTestUtils, CheckVolume) {
 
     // Test: UT-CV-2
     sim_out->terrain_[1][2] = 0.2;
-    float init_volume =  0.2 * grid.cell_area_;
+    init_volume =  0.2 * grid.cell_area_;
     EXPECT_TRUE(soil_simulator::CheckVolume(sim_out, init_volume, grid, 1e-5));
     EXPECT_FALSE(soil_simulator::CheckVolume(sim_out, 0.0, grid, 1e-5));
     EXPECT_FALSE(soil_simulator::CheckVolume(
@@ -409,7 +445,7 @@ TEST(UnitTestUtils, CheckVolume) {
 }
 
 TEST(UnitTestUtils, CheckSoil) {
-    // Setting dummy classes
+    // Setting up the environment
     soil_simulator::Grid grid(1.0, 1.0, 1.0, 0.1, 0.1);
     soil_simulator::SimOut *sim_out = new soil_simulator::SimOut(grid);
 


### PR DESCRIPTION
# Description
- Removed unnecessary types declaration
- Added type declaration at start of unit test
- Improved a bit vector definition in bucket pos unit tests

# Note
The advantage of declaring variables at the start of the unit tests is that unit tests can be moved around easily without broking anything. They are all independent from each other.