### PR TITLE
Refactor unit tests: Improve unit tests in test_body_soil.cpp (11)

### DIFF
--- a/soil_simulator/body_soil.cpp
+++ b/soil_simulator/body_soil.cpp
@@ -37,7 +37,6 @@ void soil_simulator::UpdateBodySoil(
     Bucket* bucket, float tol
 ) {
     // Copying previous body_soil locations
-    auto old_body_soil = sim_out->body_soil_;
     auto old_body_soil_pos = sim_out->body_soil_pos_;
 
     // Resetting body_soil

--- a/test/unit_tests/test_body_soil.cpp
+++ b/test/unit_tests/test_body_soil.cpp
@@ -12,6 +12,7 @@ Copyright, 2023, Vilella Kenny.
 // It greatly improves readability.
 using test_soil_simulator::SetHeight;
 using test_soil_simulator::CheckHeight;
+using soil_simulator::UpdateBodySoil;
 
 TEST(UnitTestBodySoil, UpdateBodySoil) {
     // Setting up the environment
@@ -38,8 +39,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 10, 10, 0.0, 0.0, 0.0, 0.1});
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 11, 10, NAN, 0.1, 0.2, NAN, NAN);
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 11, 10, {0.0, 0.0, 0.0}, 0.1);
@@ -56,8 +56,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, NAN, NAN, NAN, NAN, 0.1, 0.2);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {2, 10, 10, 0.0, 0.0, 0.0, 0.1});
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 11, 10, NAN, 0.1, 0.2, NAN, NAN);
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 11, 10, {0.0, 0.0, 0.0}, 0.1);
@@ -74,8 +73,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 10, 10, 0.0, 0.0, 0.0, 0.1});
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 11, 10, NAN, NAN, NAN, 0.1, 0.2);
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 2, 11, 10, {0.0, 0.0, 0.0}, 0.1);
@@ -92,8 +90,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, NAN, NAN, NAN, NAN, 0.1, 0.2);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {2, 10, 10, 0.0, 0.0, 0.0, 0.1});
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 11, 10, NAN, NAN, NAN, 0.1, 0.2);
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 2, 11, 10, {0.0, 0.0, 0.0}, 0.1);
@@ -110,8 +107,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     SetHeight(sim_out, 11, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 11, 10, 0.1, 0.0, 0.0, 0.1});
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 10, 11, NAN, 0.1, 0.2, NAN, NAN);
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 10, 11, {0.1, 0.0, 0.0}, 0.1);
@@ -128,8 +124,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     SetHeight(sim_out, 11, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 11, 10, 0.1, 0.0, 0.0, 0.1});
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 11, 11, NAN, 0.1, 0.2, NAN, NAN);
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 11, 11, {0.1, 0.0, 0.0}, 0.1);
@@ -146,8 +141,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     SetHeight(sim_out, 11, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 11, 10, 0.1, 0.0, 0.0, 0.1});
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 12, 11, NAN, 0.1, 0.2, NAN, NAN);
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 12, 11, {0.1, 0.0, 0.0}, 0.1);
@@ -163,8 +157,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     SetHeight(sim_out, 11, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 11, 10, 0.1, 0.0, 0.0, 0.1});
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->terrain_[9][10], 0.1, 1.e-5);
     // Resetting values
     bucket->pos_ = {0.0, 0.0, 0.0};
@@ -182,8 +175,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         soil_simulator::body_soil {0, 11, 10, 0.1, 0.0, 0.0, 0.1});
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {1, 12, 10, 0.2, 0.0, 0.0, 0.2});
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 10, 10, NAN, 0.1, 0.4, NAN, NAN);
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 10, 10, {0.1, 0.0, 0.0}, 0.1);
@@ -205,8 +197,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         soil_simulator::body_soil {0, 11, 10, 0.1, 0.0, 0.0, 0.1});
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {2, 12, 10, 0.2, 0.0, 0.0, 0.2});
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 10, 10, NAN, 0.1, 0.4, NAN, NAN);
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 10, 10, {0.1, 0.0, 0.0}, 0.1);
@@ -228,8 +219,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         soil_simulator::body_soil {0, 11, 10, 0.1, 0.0, 0.0, 0.1});
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {2, 12, 10, 0.2, 0.0, 0.0, 0.2});
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.4);
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 2, 10, 10, {0.1, 0.0, 0.0}, 0.1);
@@ -251,8 +241,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.15, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 10, 10, 0.0, 0.0, 0.0, 0.05});
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 10, 10, NAN, 0.0, 0.0, NAN, NAN);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 0);
     // Resetting values
@@ -264,8 +253,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.195, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 10, 10, 0.0, 0.0, 0.0, 0.095});
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 10, 10, NAN, 0.1, 0.2, NAN, NAN);
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 10, 10, {0.0, 0.0, 0.0}, 0.1);
@@ -284,8 +272,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 10, 10, 0.0, 0.0, 0.0, 0.1});
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 11, 10, NAN, 0.1, 0.2, NAN, NAN);
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 11, 10, {0.0, 0.0, 0.0}, 0.1);
@@ -295,8 +282,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     SetHeight(sim_out, 11, 10, NAN, 0.2, 0.3, 0.0, 0.0, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 12, 10, NAN, 0.1, 0.2, NAN, NAN);
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 12, 10, {0.0, 0.0, 0.0}, 0.1);
@@ -306,8 +292,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     SetHeight(sim_out, 12, 10, NAN, 0.2, 0.3, 0.0, 0.0, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 12, 11, NAN, 0.1, 0.2, NAN, NAN);
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 12, 11, {0.0, 0.0, 0.0}, 0.1);
@@ -317,8 +302,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     SetHeight(sim_out, 12, 11, NAN, 0.2, 0.3, 0.0, 0.0, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 11, 11, NAN, 0.1, 0.2, NAN, NAN);
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 11, 11, {0.0, 0.0, 0.0}, 0.1);
@@ -328,8 +312,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     SetHeight(sim_out, 11, 11, NAN, 0.2, 0.3, 0.0, 0.0, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 12, 9, NAN, 0.1, 0.2, NAN, NAN);
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 12, 9, {0.0, 0.0, 0.0}, 0.1);
@@ -339,8 +322,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     SetHeight(sim_out, 12, 9, NAN, 0.2, 0.3, 0.0, 0.0, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 11, 9, NAN, 0.1, 0.2, NAN, NAN);
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 11, 9, {0.0, 0.0, 0.0}, 0.1);
@@ -350,8 +332,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     SetHeight(sim_out, 11, 9, NAN, 0.2, 0.3, 0.0, 0.0, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 10, 11, NAN, 0.1, 0.2, NAN, NAN);
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 10, 11, {0.0, 0.0, 0.0}, 0.1);
@@ -361,8 +342,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     SetHeight(sim_out, 10, 11, NAN, 0.2, 0.3, 0.0, 0.0, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 10, 10, NAN, 0.1, 0.2, NAN, NAN);
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 10, 10, {0.0, 0.0, 0.0}, 0.1);
@@ -371,8 +351,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     SetHeight(sim_out, 10, 10, NAN, 0.2, 0.3, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 10, 9, NAN, 0.1, 0.2, NAN, NAN);
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 10, 9, {0.0, 0.0, 0.0}, 0.1);
@@ -396,8 +375,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 10, 10, 0.0, 0.0, 0.0, 0.1});
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 10, 9, NAN, 0.1, 0.2, NAN, NAN);
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 10, 9, {0.0, 0.0, 0.0}, 0.1);
@@ -407,8 +385,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     SetHeight(sim_out, 10, 9, NAN, 0.2, 0.3, 0.0, 0.0, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 10, 8, NAN, 0.1, 0.2, NAN, NAN);
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 10, 8, {0.0, 0.0, 0.0}, 0.1);
@@ -418,8 +395,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     SetHeight(sim_out, 10, 8, NAN, 0.2, 0.3, 0.0, 0.0, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 9, 8, NAN, 0.1, 0.2, NAN, NAN);
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 9, 8, {0.0, 0.0, 0.0}, 0.1);
@@ -429,8 +405,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     SetHeight(sim_out, 9, 8, NAN, 0.2, 0.3, 0.0, 0.0, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 9, 9, NAN, 0.1, 0.2, NAN, NAN);
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 9, 9, {0.0, 0.0, 0.0}, 0.1);
@@ -440,8 +415,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     SetHeight(sim_out, 9, 9, NAN, 0.2, 0.3, 0.0, 0.0, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 11, 8, NAN, 0.1, 0.2, NAN, NAN);
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 11, 8, {0.0, 0.0, 0.0}, 0.1);
@@ -451,8 +425,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     SetHeight(sim_out, 11, 8, NAN, 0.2, 0.3, 0.0, 0.0, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 11, 9, NAN, 0.1, 0.2, NAN, NAN);
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 11, 9, {0.0, 0.0, 0.0}, 0.1);
@@ -462,8 +435,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     SetHeight(sim_out, 11, 9, NAN, 0.2, 0.3, 0.0, 0.0, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 9, 10, NAN, 0.1, 0.2, NAN, NAN);
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 9, 10, {0.0, 0.0, 0.0}, 0.1);
@@ -473,8 +445,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     SetHeight(sim_out, 9, 10, NAN, 0.2, 0.3, 0.0, 0.0, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 10, 10, NAN, 0.1, 0.2, NAN, NAN);
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 10, 10, {0.0, 0.0, 0.0}, 0.1);
@@ -483,8 +454,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
     SetHeight(sim_out, 10, 10, NAN, 0.2, 0.3, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 11, 10, NAN, 0.1, 0.2, NAN, NAN);
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 11, 10, {0.0, 0.0, 0.0}, 0.1);
@@ -509,8 +479,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     SetHeight(sim_out, 10, 9, NAN, 0.0, 0.1, NAN, NAN, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 10, 10, 0.0, 0.0, 0.0, 0.1});
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 10, 9, NAN, 0.1, 0.2, NAN, NAN);
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 10, 9, {0.0, 0.0, 0.0}, 0.1);
@@ -535,8 +504,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     SetHeight(sim_out, 11, 9, NAN, -0.2, -0.1, NAN, NAN, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_.push_back(
         soil_simulator::body_soil {0, 10, 10, 0.0, 0.0, 0.0, 0.1});
-    soil_simulator::UpdateBodySoil(
-        sim_out, pos, ori, grid, bucket, 1.e-5);
+    UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     CheckHeight(sim_out, 11, 9, NAN, -0.1, 0.0, NAN, NAN);
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 11, 9, {0.0, 0.0, 0.0}, 0.1);

--- a/test/unit_tests/test_body_soil.cpp
+++ b/test/unit_tests/test_body_soil.cpp
@@ -32,6 +32,12 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     std::vector<float> ori;
     std::vector<std::vector<int>> body_pos;
 
+    // Creating a lambda function to set reset the bucket pose
+    auto ResetBucketPose = [&]() {
+        bucket->pos_ = {0.0, 0.0, 0.0};
+        bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    };
+
     // Test: BS-UBS-1
     pos = {grid.cell_size_xy_, 0.0, 0.0};
     ori = {1.0, 0.0, 0.0, 0.0};
@@ -44,8 +50,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 11, 10, {0.0, 0.0, 0.0}, 0.1);
     // Resetting values
-    bucket->pos_ = {0.0, 0.0, 0.0};
-    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    ResetBucketPose();
     test_soil_simulator::ResetValueAndTest(
         sim_out, {}, {{0, 11, 10}}, {{0, 11, 10}});
 
@@ -61,8 +66,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 11, 10, {0.0, 0.0, 0.0}, 0.1);
     // Resetting values
-    bucket->pos_ = {0.0, 0.0, 0.0};
-    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    ResetBucketPose();
     test_soil_simulator::ResetValueAndTest(
         sim_out, {}, {{0, 11, 10}}, {{0, 11, 10}});
 
@@ -78,8 +82,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 2, 11, 10, {0.0, 0.0, 0.0}, 0.1);
     // Resetting values
-    bucket->pos_ = {0.0, 0.0, 0.0};
-    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    ResetBucketPose();
     test_soil_simulator::ResetValueAndTest(
         sim_out, {}, {{2, 11, 10}}, {{2, 11, 10}});
 
@@ -95,8 +98,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 2, 11, 10, {0.0, 0.0, 0.0}, 0.1);
     // Resetting values
-    bucket->pos_ = {0.0, 0.0, 0.0};
-    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    ResetBucketPose();
     test_soil_simulator::ResetValueAndTest(
         sim_out, {}, {{2, 11, 10}}, {{2, 11, 10}});
 
@@ -112,8 +114,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 10, 11, {0.1, 0.0, 0.0}, 0.1);
     // Resetting values
-    bucket->pos_ = {0.0, 0.0, 0.0};
-    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    ResetBucketPose();
     test_soil_simulator::ResetValueAndTest(
         sim_out, {}, {{0, 10, 11}}, {{0, 10, 11}});
 
@@ -129,8 +130,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 11, 11, {0.1, 0.0, 0.0}, 0.1);
     // Resetting values
-    bucket->pos_ = {0.0, 0.0, 0.0};
-    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    ResetBucketPose();
     test_soil_simulator::ResetValueAndTest(
         sim_out, {}, {{0, 11, 11}}, {{0, 11, 11}});
 
@@ -146,8 +146,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 12, 11, {0.1, 0.0, 0.0}, 0.1);
     // Resetting values
-    bucket->pos_ = {0.0, 0.0, 0.0};
-    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    ResetBucketPose();
     test_soil_simulator::ResetValueAndTest(
         sim_out, {}, {{0, 12, 11}}, {{0, 12, 11}});
 
@@ -160,8 +159,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
     EXPECT_NEAR(sim_out->terrain_[9][10], 0.1, 1.e-5);
     // Resetting values
-    bucket->pos_ = {0.0, 0.0, 0.0};
-    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    ResetBucketPose();
     test_soil_simulator::ResetValueAndTest(
         sim_out, {{9, 10}}, {}, {});
 
@@ -182,8 +180,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[1], 0, 10, 10, {0.2, 0.0, 0.0}, 0.2);
     // Resetting values
-    bucket->pos_ = {0.0, 0.0, 0.0};
-    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    ResetBucketPose();
     test_soil_simulator::ResetValueAndTest(
         sim_out, {}, {{0, 10, 10}}, {{0, 10, 10}});
 
@@ -204,8 +201,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[1], 0, 10, 10, {0.2, 0.0, 0.0}, 0.2);
     // Resetting values
-    bucket->pos_ = {0.0, 0.0, 0.0};
-    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    ResetBucketPose();
     test_soil_simulator::ResetValueAndTest(
         sim_out, {}, {{0, 10, 10}}, {{0, 10, 10}});
 
@@ -226,8 +222,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[1], 2, 10, 10, {0.2, 0.0, 0.0}, 0.2);
     // Resetting values
-    bucket->pos_ = {0.0, 0.0, 0.0};
-    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    ResetBucketPose();
     test_soil_simulator::ResetValueAndTest(
         sim_out, {}, {{2, 10, 10}}, {{2, 10, 10}});
 
@@ -245,6 +240,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     CheckHeight(sim_out, 10, 10, NAN, 0.0, 0.0, NAN, NAN);
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 0);
     // Resetting values
+    ResetBucketPose();
     test_soil_simulator::ResetValueAndTest(
         sim_out, {}, {{0, 10, 10}}, {{0, 10, 10}});
 
@@ -258,6 +254,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 10, 10, {0.0, 0.0, 0.0}, 0.1);
     // Resetting values
+    ResetBucketPose();
     test_soil_simulator::ResetValueAndTest(
         sim_out, {}, {{0, 10, 10}}, {{0, 10, 10}});
 
@@ -277,8 +274,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 11, 10, {0.0, 0.0, 0.0}, 0.1);
     // Testing for second direction
-    bucket->pos_ = {0.0, 0.0, 0.0};
-    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    ResetBucketPose();
     SetHeight(sim_out, 11, 10, NAN, 0.2, 0.3, 0.0, 0.0, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
@@ -287,8 +283,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 12, 10, {0.0, 0.0, 0.0}, 0.1);
     // Testing for third direction
-    bucket->pos_ = {0.0, 0.0, 0.0};
-    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    ResetBucketPose();
     SetHeight(sim_out, 12, 10, NAN, 0.2, 0.3, 0.0, 0.0, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
@@ -297,8 +292,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 12, 11, {0.0, 0.0, 0.0}, 0.1);
     // Testing for fouth direction
-    bucket->pos_ = {0.0, 0.0, 0.0};
-    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    ResetBucketPose();
     SetHeight(sim_out, 12, 11, NAN, 0.2, 0.3, 0.0, 0.0, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
@@ -307,8 +301,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 11, 11, {0.0, 0.0, 0.0}, 0.1);
     // Testing for fifth direction
-    bucket->pos_ = {0.0, 0.0, 0.0};
-    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    ResetBucketPose();
     SetHeight(sim_out, 11, 11, NAN, 0.2, 0.3, 0.0, 0.0, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
@@ -317,8 +310,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 12, 9, {0.0, 0.0, 0.0}, 0.1);
     // Testing for sixth direction
-    bucket->pos_ = {0.0, 0.0, 0.0};
-    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    ResetBucketPose();
     SetHeight(sim_out, 12, 9, NAN, 0.2, 0.3, 0.0, 0.0, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
@@ -327,8 +319,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 11, 9, {0.0, 0.0, 0.0}, 0.1);
     // Testing for seventh direction
-    bucket->pos_ = {0.0, 0.0, 0.0};
-    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    ResetBucketPose();
     SetHeight(sim_out, 11, 9, NAN, 0.2, 0.3, 0.0, 0.0, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
@@ -337,8 +328,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 10, 11, {0.0, 0.0, 0.0}, 0.1);
     // Testing for eighth direction
-    bucket->pos_ = {0.0, 0.0, 0.0};
-    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    ResetBucketPose();
     SetHeight(sim_out, 10, 11, NAN, 0.2, 0.3, 0.0, 0.0, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
@@ -347,8 +337,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 10, 10, {0.0, 0.0, 0.0}, 0.1);
     // Testing for ninth direction
-    bucket->pos_ = {0.0, 0.0, 0.0};
-    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    ResetBucketPose();
     SetHeight(sim_out, 10, 10, NAN, 0.2, 0.3, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
     UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
@@ -356,8 +345,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 10, 9, {0.0, 0.0, 0.0}, 0.1);
     // Resetting values
-    bucket->pos_ = {0.0, 0.0, 0.0};
-    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    ResetBucketPose();
     body_pos = {
         {0, 10, 9}, {0, 10, 10}, {0, 10, 11}, {0, 11, 9}, {0, 11, 10},
         {0, 11, 11}, {0, 12, 9}, {0, 12, 10}, {0, 12, 11}};
@@ -380,8 +368,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 10, 9, {0.0, 0.0, 0.0}, 0.1);
     // Testing for second direction
-    bucket->pos_ = {0.0, 0.0, 0.0};
-    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    ResetBucketPose();
     SetHeight(sim_out, 10, 9, NAN, 0.2, 0.3, 0.0, 0.0, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
@@ -390,8 +377,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 10, 8, {0.0, 0.0, 0.0}, 0.1);
     // Testing for third direction
-    bucket->pos_ = {0.0, 0.0, 0.0};
-    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    ResetBucketPose();
     SetHeight(sim_out, 10, 8, NAN, 0.2, 0.3, 0.0, 0.0, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
@@ -400,8 +386,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 9, 8, {0.0, 0.0, 0.0}, 0.1);
     // Testing for fouth direction
-    bucket->pos_ = {0.0, 0.0, 0.0};
-    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    ResetBucketPose();
     SetHeight(sim_out, 9, 8, NAN, 0.2, 0.3, 0.0, 0.0, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
@@ -410,8 +395,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 9, 9, {0.0, 0.0, 0.0}, 0.1);
     // Testing for fifth direction
-    bucket->pos_ = {0.0, 0.0, 0.0};
-    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    ResetBucketPose();
     SetHeight(sim_out, 9, 9, NAN, 0.2, 0.3, 0.0, 0.0, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
@@ -420,8 +404,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 11, 8, {0.0, 0.0, 0.0}, 0.1);
     // Testing for sixth direction
-    bucket->pos_ = {0.0, 0.0, 0.0};
-    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    ResetBucketPose();
     SetHeight(sim_out, 11, 8, NAN, 0.2, 0.3, 0.0, 0.0, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
@@ -430,8 +413,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 11, 9, {0.0, 0.0, 0.0}, 0.1);
     // Testing for seventh direction
-    bucket->pos_ = {0.0, 0.0, 0.0};
-    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    ResetBucketPose();
     SetHeight(sim_out, 11, 9, NAN, 0.2, 0.3, 0.0, 0.0, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
@@ -440,8 +422,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 9, 10, {0.0, 0.0, 0.0}, 0.1);
     // Testing for eighth direction
-    bucket->pos_ = {0.0, 0.0, 0.0};
-    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    ResetBucketPose();
     SetHeight(sim_out, 9, 10, NAN, 0.2, 0.3, 0.0, 0.0, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 10, NAN, NAN, NAN, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
@@ -450,8 +431,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 10, 10, {0.0, 0.0, 0.0}, 0.1);
     // Testing for ninth direction
-    bucket->pos_ = {0.0, 0.0, 0.0};
-    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    ResetBucketPose();
     SetHeight(sim_out, 10, 10, NAN, 0.2, 0.3, 0.1, 0.2, NAN, NAN, NAN, NAN);
     sim_out->body_soil_pos_[0].ii = 10;
     UpdateBodySoil(sim_out, pos, ori, grid, bucket, 1.e-5);
@@ -459,8 +439,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 11, 10, {0.0, 0.0, 0.0}, 0.1);
     // Resetting values
-    bucket->pos_ = {0.0, 0.0, 0.0};
-    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    ResetBucketPose();
     body_pos = {
         {0, 9, 8}, {0, 9, 9}, {0, 9, 10}, {0, 10, 8}, {0, 10, 9},
         {0, 10, 10}, {0, 11, 8}, {0, 11, 9}, {0, 11, 10}};
@@ -484,8 +463,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 10, 9, {0.0, 0.0, 0.0}, 0.1);
     // Resetting values
-    bucket->pos_ = {0.0, 0.0, 0.0};
-    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    ResetBucketPose();
     body_pos = {
         {0, 10, 9}, {0, 10, 10}, {0, 10, 11}, {0, 11, 9}, {0, 11, 10},
         {0, 11, 11}, {0, 12, 9}, {0, 12, 10}, {0, 12, 11}};
@@ -509,8 +487,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     test_soil_simulator::CheckBodySoilPos(
         sim_out->body_soil_pos_[0], 0, 11, 9, {0.0, 0.0, 0.0}, 0.1);
     // Resetting values
-    bucket->pos_ = {0.0, 0.0, 0.0};
-    bucket->ori_ = {1.0, 0.0, 0.0, 0.0};
+    ResetBucketPose();
     body_pos = {
         {0, 10, 9}, {0, 10, 10}, {0, 10, 11}, {0, 11, 9}, {0, 11, 10},
         {0, 11, 11}, {0, 12, 9}, {0, 12, 10}, {0, 12, 11}};

--- a/test/unit_tests/test_body_soil.cpp
+++ b/test/unit_tests/test_body_soil.cpp
@@ -13,6 +13,7 @@ Copyright, 2023, Vilella Kenny.
 using test_soil_simulator::SetHeight;
 using test_soil_simulator::CheckHeight;
 using soil_simulator::UpdateBodySoil;
+using test_soil_simulator::ResetValueAndTest;
 
 TEST(UnitTestBodySoil, UpdateBodySoil) {
     // Setting up the environment
@@ -51,8 +52,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out->body_soil_pos_[0], 0, 11, 10, {0.0, 0.0, 0.0}, 0.1);
     // Resetting values
     ResetBucketPose();
-    test_soil_simulator::ResetValueAndTest(
-        sim_out, {}, {{0, 11, 10}}, {{0, 11, 10}});
+    ResetValueAndTest(sim_out, {}, {{0, 11, 10}}, {{0, 11, 10}});
 
     // Test: BS-UBS-2
     pos = {grid.cell_size_xy_, 0.0, 0.0};
@@ -67,8 +67,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out->body_soil_pos_[0], 0, 11, 10, {0.0, 0.0, 0.0}, 0.1);
     // Resetting values
     ResetBucketPose();
-    test_soil_simulator::ResetValueAndTest(
-        sim_out, {}, {{0, 11, 10}}, {{0, 11, 10}});
+    ResetValueAndTest(sim_out, {}, {{0, 11, 10}}, {{0, 11, 10}});
 
     // Test: BS-UBS-3
     pos = {grid.cell_size_xy_, 0.0, 0.0};
@@ -83,8 +82,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out->body_soil_pos_[0], 2, 11, 10, {0.0, 0.0, 0.0}, 0.1);
     // Resetting values
     ResetBucketPose();
-    test_soil_simulator::ResetValueAndTest(
-        sim_out, {}, {{2, 11, 10}}, {{2, 11, 10}});
+    ResetValueAndTest(sim_out, {}, {{2, 11, 10}}, {{2, 11, 10}});
 
     // Test: BS-UBS-4
     pos = {grid.cell_size_xy_, 0.0, 0.0};
@@ -99,8 +97,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out->body_soil_pos_[0], 2, 11, 10, {0.0, 0.0, 0.0}, 0.1);
     // Resetting values
     ResetBucketPose();
-    test_soil_simulator::ResetValueAndTest(
-        sim_out, {}, {{2, 11, 10}}, {{2, 11, 10}});
+    ResetValueAndTest(sim_out, {}, {{2, 11, 10}}, {{2, 11, 10}});
 
     // Test: BS-UBS-5
     pos = {0.0, 0.0, 0.0};
@@ -115,8 +112,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out->body_soil_pos_[0], 0, 10, 11, {0.1, 0.0, 0.0}, 0.1);
     // Resetting values
     ResetBucketPose();
-    test_soil_simulator::ResetValueAndTest(
-        sim_out, {}, {{0, 10, 11}}, {{0, 10, 11}});
+    ResetValueAndTest(sim_out, {}, {{0, 10, 11}}, {{0, 10, 11}});
 
     // Test: BS-UBS-6
     pos = {0.0, 0.0, 0.0};
@@ -131,8 +127,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out->body_soil_pos_[0], 0, 11, 11, {0.1, 0.0, 0.0}, 0.1);
     // Resetting values
     ResetBucketPose();
-    test_soil_simulator::ResetValueAndTest(
-        sim_out, {}, {{0, 11, 11}}, {{0, 11, 11}});
+    ResetValueAndTest(sim_out, {}, {{0, 11, 11}}, {{0, 11, 11}});
 
     // Test: BS-UBS-7
     pos = {grid.cell_size_xy_, 0.0, 0.0};
@@ -147,8 +142,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out->body_soil_pos_[0], 0, 12, 11, {0.1, 0.0, 0.0}, 0.1);
     // Resetting values
     ResetBucketPose();
-    test_soil_simulator::ResetValueAndTest(
-        sim_out, {}, {{0, 12, 11}}, {{0, 12, 11}});
+    ResetValueAndTest(sim_out, {}, {{0, 12, 11}}, {{0, 12, 11}});
 
     // Test: BS-UBS-8
     pos = {0.0, 0.0, 0.0};
@@ -160,8 +154,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     EXPECT_NEAR(sim_out->terrain_[9][10], 0.1, 1.e-5);
     // Resetting values
     ResetBucketPose();
-    test_soil_simulator::ResetValueAndTest(
-        sim_out, {{9, 10}}, {}, {});
+    ResetValueAndTest(sim_out, {{9, 10}}, {}, {});
 
     // Test: BS-UBS-9
     pos = {0.0, 0.0, 0.0};
@@ -181,8 +174,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out->body_soil_pos_[1], 0, 10, 10, {0.2, 0.0, 0.0}, 0.2);
     // Resetting values
     ResetBucketPose();
-    test_soil_simulator::ResetValueAndTest(
-        sim_out, {}, {{0, 10, 10}}, {{0, 10, 10}});
+    ResetValueAndTest(sim_out, {}, {{0, 10, 10}}, {{0, 10, 10}});
 
     // Test: BS-UBS-10
     pos = {0.0, 0.0, 0.0};
@@ -202,8 +194,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out->body_soil_pos_[1], 0, 10, 10, {0.2, 0.0, 0.0}, 0.2);
     // Resetting values
     ResetBucketPose();
-    test_soil_simulator::ResetValueAndTest(
-        sim_out, {}, {{0, 10, 10}}, {{0, 10, 10}});
+    ResetValueAndTest(sim_out, {}, {{0, 10, 10}}, {{0, 10, 10}});
 
     // Test: BS-UBS-11
     pos = {0.0, 0.0, 0.0};
@@ -223,8 +214,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out->body_soil_pos_[1], 2, 10, 10, {0.2, 0.0, 0.0}, 0.2);
     // Resetting values
     ResetBucketPose();
-    test_soil_simulator::ResetValueAndTest(
-        sim_out, {}, {{2, 10, 10}}, {{2, 10, 10}});
+    ResetValueAndTest(sim_out, {}, {{2, 10, 10}}, {{2, 10, 10}});
 
     // ---------------------------------------------------------------------- //
     // The tests below are specific to the current implementation and may     //
@@ -241,8 +231,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     EXPECT_EQ(sim_out->body_soil_pos_.size(), 0);
     // Resetting values
     ResetBucketPose();
-    test_soil_simulator::ResetValueAndTest(
-        sim_out, {}, {{0, 10, 10}}, {{0, 10, 10}});
+    ResetValueAndTest(sim_out, {}, {{0, 10, 10}}, {{0, 10, 10}});
 
     // Test: BS-UBS-13
     SetHeight(sim_out, 10, 10, NAN, 0.0, 0.1, NAN, NAN, NAN, NAN, NAN, NAN);
@@ -255,8 +244,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
         sim_out->body_soil_pos_[0], 0, 10, 10, {0.0, 0.0, 0.0}, 0.1);
     // Resetting values
     ResetBucketPose();
-    test_soil_simulator::ResetValueAndTest(
-        sim_out, {}, {{0, 10, 10}}, {{0, 10, 10}});
+    ResetValueAndTest(sim_out, {}, {{0, 10, 10}}, {{0, 10, 10}});
 
     // Test: BS-UBS-14
     pos = {grid.cell_size_xy_, 0.01, 0.0};
@@ -349,8 +337,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     body_pos = {
         {0, 10, 9}, {0, 10, 10}, {0, 10, 11}, {0, 11, 9}, {0, 11, 10},
         {0, 11, 11}, {0, 12, 9}, {0, 12, 10}, {0, 12, 11}};
-    test_soil_simulator::ResetValueAndTest(
-        sim_out, {}, body_pos, {{0, 10, 9}});
+    ResetValueAndTest(sim_out, {}, body_pos, {{0, 10, 9}});
 
     // Test: BS-UBS-15
     pos = {-0.01, -grid.cell_size_xy_, 0.0};
@@ -443,8 +430,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     body_pos = {
         {0, 9, 8}, {0, 9, 9}, {0, 9, 10}, {0, 10, 8}, {0, 10, 9},
         {0, 10, 10}, {0, 11, 8}, {0, 11, 9}, {0, 11, 10}};
-    test_soil_simulator::ResetValueAndTest(
-        sim_out, {}, body_pos, {{0, 11, 10}});
+    ResetValueAndTest(sim_out, {}, body_pos, {{0, 11, 10}});
 
     // Test: BS-UBS-16
     pos = {grid.cell_size_xy_, 0.01, 0.0};
@@ -467,8 +453,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     body_pos = {
         {0, 10, 9}, {0, 10, 10}, {0, 10, 11}, {0, 11, 9}, {0, 11, 10},
         {0, 11, 11}, {0, 12, 9}, {0, 12, 10}, {0, 12, 11}};
-    test_soil_simulator::ResetValueAndTest(
-        sim_out, {}, body_pos, {{0, 10, 9}});
+    ResetValueAndTest(sim_out, {}, body_pos, {{0, 10, 9}});
 
     // Test: BS-UBS-17
     pos = {grid.cell_size_xy_, 0.01, 0.0};
@@ -491,8 +476,7 @@ TEST(UnitTestBodySoil, UpdateBodySoil) {
     body_pos = {
         {0, 10, 9}, {0, 10, 10}, {0, 10, 11}, {0, 11, 9}, {0, 11, 10},
         {0, 11, 11}, {0, 12, 9}, {0, 12, 10}, {0, 12, 11}};
-    test_soil_simulator::ResetValueAndTest(
-        sim_out, {}, body_pos, {{0, 11, 9}});
+    ResetValueAndTest(sim_out, {}, body_pos, {{0, 11, 9}});
 
     delete sim_out;
     delete bucket;


### PR DESCRIPTION
# Description
- Removed unnecessary copy in `UpdateBodySoil`
- Added lambda function to reset bucket pose
- Removed namespace to keep function call on one line

# Note
Two modifications are left to be done:
- Create a utility function to push into body_soil_pos
- Add a test about logging