### PR TITLE
Refactor unit tests: Improve unit tests for the RelaxUnstableBodyCell function (19)

### DIFF
--- a/test/unit_tests/README.md
+++ b/test/unit_tests/README.md
@@ -875,6 +875,7 @@ In this table,
 Unit test for the `RelaxUnstableBodyCell` function.
 
 The tested function moves the soil following the status code provided assuming that it corresponds to the actual configuration.
+It is thus required to have avalanching soil.
 The purpose of these tests is to check all possible configurations.
 The description of the unit tests can therefore be done with a simple table describing the configuration.
 
@@ -885,63 +886,81 @@ The configuration of the inital position should not impact the result of this fu
 | --------- | ------------ | ------- | --------- | ------------ | ------- | ------------ | ----------- | ------------ | ------------ |
 | RE-RUB-1  | &cross;      | &cross; | &cross;   | &cross;      | &cross; | terrain      | &check;     | &check;      | Partial      |
 | RE-RUB-2  | &cross;      | &cross; | &cross;   | &cross;      | &cross; | terrain      | &check;     | &check;      | Full         |
-| RE-RUB-3  | &cross;      | &cross; | &cross;   | &cross;      | &cross; | terrain      | &cross;     | &check;      | Full         |
+| RE-RUB-3  | &cross;      | &cross; | &cross;   | &cross;      | &cross; | terrain      | &cross;     | &check;      | Partial      |
 | RE-RUB-4  | First layer  | &cross; | &cross;   | &cross;      | &cross; | terrain      | &check;     | &check;      | Partial      |
 | RE-RUB-5  | First layer  | &cross; | &cross;   | &cross;      | &cross; | terrain      | &check;     | &check;      | Full         |
-| RE-RUB-6  | First layer  | &cross; | &cross;   | &cross;      | &cross; | terrain      | &cross;     | &check;      | Partial      |
-| RE-RUB-7  | First layer  | &cross; | &cross;   | &cross;      | &cross; | First layer  | &check;     | &check;      | Partial      |
-| RE-RUB-8  | First layer  | &cross; | &cross;   | &cross;      | &cross; | First layer  | &check;     | &check;      | Full         |
-| RE-RUB-9  | First layer  | &cross; | &cross;   | &cross;      | &cross; | First layer  | &cross;     | &check;      | Full         |
-| RE-RUB-10 | First layer  | &check; | &cross;   | &cross;      | &cross; | First layer  | &check;     | &check;      | Partial      |
-| RE-RUB-11 | First layer  | &check; | &cross;   | &cross;      | &cross; | First layer  | &check;     | &check;      | Full         |
-| RE-RUB-12 | First layer  | &check; | &cross;   | &cross;      | &cross; | First layer  | &cross;     | &check;      | Full         |
-| RE-RUB-13 | Second layer | &cross; | &cross;   | &cross;      | &cross; | terrain      | &check;     | &check;      | Partial      |
-| RE-RUB-14 | Second layer | &cross; | &cross;   | &cross;      | &cross; | terrain      | &check;     | &check;      | Full         |
-| RE-RUB-15 | Second layer | &cross; | &cross;   | &cross;      | &cross; | Second layer | &check;     | &check;      | Partial      |
-| RE-RUB-16 | Second layer | &cross; | &cross;   | &cross;      | &cross; | Second layer | &check;     | &check;      | Full         |
-| RE-RUB-17 | Second layer | &cross; | &cross;   | &cross;      | &cross; | Second layer | &cross;     | &check;      | Full         |
-| RE-RUB-18 | Second layer | &check; | &cross;   | &cross;      | &cross; | Second layer | &check;     | &check;      | Partial      |
-| RE-RUB-19 | Second layer | &check; | &cross;   | &cross;      | &cross; | Second layer | &check;     | &check;      | Full         |
-| RE-RUB-20 | Second layer | &check; | &cross;   | &cross;      | &cross; | Second layer | &cross;     | &check;      | Full         |
-| RE-RUB-21 | First layer  | &cross; | &cross;   | Second layer | &cross; | First layer  | &check;     | &check;      | Partial      |
-| RE-RUB-22 | First layer  | &cross; | &cross;   | Second layer | &cross; | First layer  | &check;     | &check;      | Full         |
-| RE-RUB-23 | First layer  | &cross; | &cross;   | Second layer | &cross; | First layer  | &cross;     | &check;      | Full         |
-| RE-RUB-24 | First layer  | &cross; | &cross;   | Second layer | &cross; | First layer  | &check;     | &cross;      | Partial      |
-| RE-RUB-25 | First layer  | &cross; | &cross;   | Second layer | &cross; | Second layer | &check;     | &check;      | Partial      |
-| RE-RUB-26 | First layer  | &cross; | &cross;   | Second layer | &cross; | Second layer | &check;     | &check;      | Full         |
-| RE-RUB-27 | First layer  | &check; | &cross;   | Second layer | &check; | First layer  | &check;     | &check;      | Partial      |
-| RE-RUB-28 | First layer  | &check; | &cross;   | Second layer | &check; | First layer  | &check;     | &check;      | Full         |  
-| RE-RUB-29 | First layer  | &check; | &cross;   | Second layer | &check; | First layer  | &cross;     | &check;      | Full         |
-| RE-RUB-30 | First layer  | &check; | &cross;   | Second layer | &check; | First layer  | &check;     | &cross;      | Partial      |
-| RE-RUB-31 | First layer  | &check; | &cross;   | Second layer | &check; | Second layer | &check;     | &check;      | Partial      |  
-| RE-RUB-32 | First layer  | &check; | &cross;   | Second layer | &check; | Second layer | &check;     | &check;      | Fulll        | 
-| RE-RUB-33 | Second layer | &cross; | &cross;   | First layer  | &cross; | Second layer | &check;     | &check;      | Partial      |
-| RE-RUB-34 | Second layer | &cross; | &cross;   | First layer  | &cross; | Second layer | &check;     | &check;      | Full         |
-| RE-RUB-35 | Second layer | &cross; | &cross;   | First layer  | &cross; | Second layer | &cross;     | &check;      | Full         |
-| RE-RUB-36 | Second layer | &cross; | &cross;   | First layer  | &cross; | Second layer | &check;     | &cross;      | Partial      |
-| RE-RUB-37 | Second layer | &cross; | &cross;   | First layer  | &cross; | First layer  | &check;     | &check;      | Partial      |
-| RE-RUB-38 | Second layer | &cross; | &cross;   | First layer  | &cross; | First layer  | &check;     | &check;      | Full         |
-| RE-RUB-39 | Second layer | &check; | &cross;   | First layer  | &check; | Second layer | &check;     | &check;      | Partial      |
-| RE-RUB-40 | Second layer | &check; | &cross;   | First layer  | &check; | Second layer | &check;     | &check;      | Full         | 
-| RE-RUB-41 | Second layer | &check; | &cross;   | First layer  | &check; | Second layer | &cross;     | &check;      | Full         |
-| RE-RUB-42 | Second layer | &check; | &cross;   | First layer  | &check; | Second layer | &check;     | &cross;      | Partial      |
-| RE-RUB-43 | Second layer | &check; | &cross;   | First layer  | &check; | First layer  | &check;     | &check;      | Partial      | 
-| RE-RUB-44 | Second layer | &check; | &cross;   | First layer  | &check; | First layer  | &check;     | &check;      | Fulll        | 
-| RE-RUB-45 | First layer  | &check; | &check;   | Second layer | &check; | &cross;      | &check;     | &cross;      | &cross;      |
-| RE-RUB-46 | Second layer | &check; | &check;   | First layer  | &check; | &cross;      | &check;     | &cross;      | &cross;      | 
-| RE-RUB-47 | First layer  | &check; | &check;   | Second layer | &cross; | Second layer | &check;     | &check;      | Partial      |
-| RE-RUB-48 | First layer  | &check; | &check;   | Second layer | &check; | Second layer | &check;     | &check;      | Partial      |
-| RE-RUB-49 | Second layer | &check; | &check;   | First layer  | &cross; | First layer  | &check;     | &check;      | Partial      |
-| RE-RUB-50 | Second layer | &check; | &check;   | First layer  | &check; | First layer  | &check;     | &check;      | Partial      |
-| RE-RUB-51 | Second layer | &check; | &cross;   | &cross;      | &cross; | terrain      | &check;     | &cross;      | Partial      |
+| RE-RUB-6  | First layer  | &cross; | &cross;   | &cross;      | &cross; | terrain      | &check;     | &cross;      | Partial      |
+| RE-RUB-7  | First layer  | &cross; | &cross;   | &cross;      | &cross; | terrain      | &cross;     | &check;      | Partial      |
+| RE-RUB-8  | First layer  | &cross; | &cross;   | &cross;      | &cross; | terrain      | &cross;     | &cross;      | Partial      |
+| RE-RUB-9  | First layer  | &cross; | &cross;   | &cross;      | &cross; | First layer  | &check;     | &check;      | Partial      |
+| RE-RUB-10 | First layer  | &cross; | &cross;   | &cross;      | &cross; | First layer  | &check;     | &check;      | Full         |
+| RE-RUB-11 | First layer  | &cross; | &cross;   | &cross;      | &cross; | First layer  | &cross;     | &check;      | Partial      |
+| RE-RUB-12 | First layer  | &check; | &cross;   | &cross;      | &cross; | First layer  | &check;     | &check;      | Partial      |
+| RE-RUB-13 | First layer  | &check; | &cross;   | &cross;      | &cross; | First layer  | &check;     | &check;      | Full         |
+| RE-RUB-14 | First layer  | &check; | &cross;   | &cross;      | &cross; | First layer  | &cross;     | &check;      | Partial      |
+| RE-RUB-15 | Second layer | &cross; | &cross;   | &cross;      | &cross; | terrain      | &check;     | &check;      | Partial      |
+| RE-RUB-16 | Second layer | &cross; | &cross;   | &cross;      | &cross; | terrain      | &check;     | &check;      | Full         |
+| RE-RUB-17 | Second layer | &cross; | &cross;   | &cross;      | &cross; | terrain      | &check;     | &cross;      | Partial      |
+| RE-RUB-18 | Second layer | &cross; | &cross;   | &cross;      | &cross; | terrain      | &cross;     | &check;      | Partial      |
+| RE-RUB-19 | Second layer | &cross; | &cross;   | &cross;      | &cross; | terrain      | &cross;     | &cross;      | Partial      |
+| RE-RUB-20 | Second layer | &cross; | &cross;   | &cross;      | &cross; | Second layer | &check;     | &check;      | Partial      |
+| RE-RUB-21 | Second layer | &cross; | &cross;   | &cross;      | &cross; | Second layer | &check;     | &check;      | Full         |
+| RE-RUB-22 | Second layer | &cross; | &cross;   | &cross;      | &cross; | Second layer | &cross;     | &check;      | Partial      |
+| RE-RUB-23 | Second layer | &check; | &cross;   | &cross;      | &cross; | Second layer | &check;     | &check;      | Partial      |
+| RE-RUB-24 | Second layer | &check; | &cross;   | &cross;      | &cross; | Second layer | &check;     | &check;      | Full         |
+| RE-RUB-25 | Second layer | &check; | &cross;   | &cross;      | &cross; | Second layer | &cross;     | &check;      | Partial      |
+| RE-RUB-26 | First layer  | &cross; | &cross;   | Second layer | &cross; | First layer  | &check;     | &check;      | Partial      |
+| RE-RUB-27 | First layer  | &cross; | &cross;   | Second layer | &cross; | First layer  | &check;     | &check;      | Full         |
+| RE-RUB-28 | First layer  | &cross; | &cross;   | Second layer | &cross; | First layer  | &cross;     | &check;      | Partial      |
+| RE-RUB-29 | First layer  | &cross; | &cross;   | Second layer | &cross; | First layer  | &check;     | &cross;      | Partial      |
+| RE-RUB-30 | First layer  | &cross; | &cross;   | Second layer | &cross; | First layer  | &cross;     | &cross;      | Partial      |
+| RE-RUB-31 | First layer  | &cross; | &cross;   | Second layer | &cross; | Second layer | &check;     | &check;      | Partial      |
+| RE-RUB-32 | First layer  | &cross; | &cross;   | Second layer | &cross; | Second layer | &check;     | &check;      | Full         |
+| RE-RUB-33 | First layer  | &cross; | &cross;   | Second layer | &cross; | Second layer | &cross;     | &check;      | Partial      |
+| RE-RUB-34 | First layer  | &check; | &cross;   | Second layer | &check; | First layer  | &check;     | &check;      | Partial      |
+| RE-RUB-35 | First layer  | &check; | &cross;   | Second layer | &check; | First layer  | &check;     | &check;      | Full         |
+| RE-RUB-36 | First layer  | &check; | &cross;   | Second layer | &check; | First layer  | &cross;     | &check;      | Partial      |
+| RE-RUB-37 | First layer  | &check; | &cross;   | Second layer | &check; | First layer  | &check;     | &cross;      | Partial      |
+| RE-RUB-38 | First layer  | &check; | &cross;   | Second layer | &check; | First layer  | &cross;     | &cross;      | Partial      |
+| RE-RUB-39 | First layer  | &check; | &cross;   | Second layer | &check; | Second layer | &check;     | &check;      | Partial      |
+| RE-RUB-40 | First layer  | &check; | &cross;   | Second layer | &check; | Second layer | &check;     | &check;      | Full         |
+| RE-RUB-41 | First layer  | &check; | &cross;   | Second layer | &check; | Second layer | &cross;     | &check;      | Partial      |
+| RE-RUB-42 | First layer  | &check; | &check;   | Second layer | &cross; | Second layer | &check;     | &check;      | Partial      |
+| RE-RUB-43 | First layer  | &check; | &check;   | Second layer | &cross; | Second layer | &check;     | &check;      | Full         |
+| RE-RUB-44 | First layer  | &check; | &check;   | Second layer | &cross; | Second layer | &cross;     | &check;      | Partial      |
+| RE-RUB-45 | First layer  | &check; | &check;   | Second layer | &check; | Second layer | &check;     | &check;      | Partial      |
+| RE-RUB-46 | First layer  | &check; | &check;   | Second layer | &check; | Second layer | &check;     | &check;      | Full         |
+| RE-RUB-47 | First layer  | &check; | &check;   | Second layer | &check; | Second layer | &cross;     | &check;      | Partial      |
+| RE-RUB-48 | Second layer | &cross; | &cross;   | First layer  | &cross; | Second layer | &check;     | &check;      | Partial      |
+| RE-RUB-49 | Second layer | &cross; | &cross;   | First layer  | &cross; | Second layer | &check;     | &check;      | Full         |
+| RE-RUB-50 | Second layer | &cross; | &cross;   | First layer  | &cross; | Second layer | &cross;     | &check;      | Partial      |
+| RE-RUB-51 | Second layer | &cross; | &cross;   | First layer  | &cross; | Second layer | &check;     | &cross;      | Partial      |
+| RE-RUB-52 | Second layer | &cross; | &cross;   | First layer  | &cross; | Second layer | &cross;     | &cross;      | Partial      |
+| RE-RUB-53 | Second layer | &cross; | &cross;   | First layer  | &cross; | First layer  | &check;     | &check;      | Partial      |
+| RE-RUB-54 | Second layer | &cross; | &cross;   | First layer  | &cross; | First layer  | &check;     | &check;      | Full         |
+| RE-RUB-55 | Second layer | &cross; | &cross;   | First layer  | &cross; | First layer  | &cross;     | &check;      | Partial      |
+| RE-RUB-56 | Second layer | &check; | &cross;   | First layer  | &check; | Second layer | &check;     | &check;      | Partial      |
+| RE-RUB-57 | Second layer | &check; | &cross;   | First layer  | &check; | Second layer | &check;     | &check;      | Full         | 
+| RE-RUB-58 | Second layer | &check; | &cross;   | First layer  | &check; | Second layer | &cross;     | &check;      | Partial      |
+| RE-RUB-59 | Second layer | &check; | &cross;   | First layer  | &check; | Second layer | &check;     | &cross;      | Partial      |
+| RE-RUB-60 | Second layer | &check; | &cross;   | First layer  | &check; | Second layer | &cross;     | &cross;      | Partial      |
+| RE-RUB-61 | Second layer | &check; | &cross;   | First layer  | &check; | First layer  | &check;     | &check;      | Partial      | 
+| RE-RUB-62 | Second layer | &check; | &cross;   | First layer  | &check; | First layer  | &check;     | &check;      | Full         |
+| RE-RUB-63 | Second layer | &check; | &cross;   | First layer  | &check; | First layer  | &cross;     | &check;      | Partial      |
+| RE-RUB-64 | Second layer | &check; | &check;   | First layer  | &cross; | First layer  | &check;     | &check;      | Partial      |
+| RE-RUB-65 | Second layer | &check; | &check;   | First layer  | &cross; | First layer  | &check;     | &check;      | Full         |
+| RE-RUB-66 | Second layer | &check; | &check;   | First layer  | &cross; | First layer  | &cross;     | &check;      | Partial      |
+| RE-RUB-67 | Second layer | &check; | &check;   | First layer  | &check; | First layer  | &check;     | &check;      | Partial      |
+| RE-RUB-68 | Second layer | &check; | &check;   | First layer  | &check; | First layer  | &check;     | &check;      | Full         |
+| RE-RUB-69 | Second layer | &check; | &check;   | First layer  | &check; | First layer  | &cross;     | &check;      | Partial      |
 
 In this table,
 - `Soil` indicates whether soil is present on the corresponding layer.
 - `Until top` indicates whether the soil fully fill the gap between the two layers.
 - `Avalanche` indicates where the soil should avalanche.
-- `Enough soil` indicates whether there is enough soil in the considered soil column to reach the stable configuration.
+- `Enough soil` indicates whether all the soil is located in one `body_soil` or several has to be moved.
 - `Enough space` indicates whether there is enough space on the layer where the soil should avalanche to accommodate all the avalanching soil.
-- `Status` indicates the type of soil avalanche.
+- `Status` indicates the type of soil avalanche. `Partial` when some soil remained from the original location, `Full` when all soil avalanche, and `&cross;` when there is no avalanche.
 
 ### `RelaxBodySoil`
 

--- a/test/unit_tests/README.md
+++ b/test/unit_tests/README.md
@@ -673,6 +673,12 @@ The description of the unit tests can therefore be done with a simple table desc
 | RE-CUT-49 | Second layer | &check; | &check;   | &check; | First layer  | &check; | &check; | &cross;      |
 | RE-CUT-50 | Second layer | &check; | &check;   | &check; | First layer  | &check; | &cross; | First layer  |
 
+In this table,
+- `Soil` indicates whether soil is present on the corresponding layer.
+- `Until top` indicates whether the soil fully fill the gap between the two layers.
+- `Stable` indicates whether the corresponding soil layer is unstable considering the configuration.
+- `Avalanche` indicates where the soil should avalanche.
+
 In addition to these basic unit tests, a few extra edge cases are checked.
 
 | Test name | Description of the unit test                                               |
@@ -720,6 +726,11 @@ The description of the unit tests can therefore be done with a simple table desc
 | RE-RUT-27 | Second layer | &check; | First layer  | &check; | Second layer | &check;      | 
 | RE-RUT-28 | Second layer | &check; | First layer  | &check; | Second layer | &cross;      |
 | RE-RUT-29 | Second layer | &check; | First layer  | &check; | First layer  | &check;      |
+
+In this table,
+- `Soil` indicates whether soil is present on the corresponding layer.
+- `Avalanche` indicates where the soil should avalanche.
+- `Enough space` indicates whether there is enough space on the layer where the soil should avalanche to accommodate all the avalanching soil.
 
 ### `RelaxTerrain`
 
@@ -780,6 +791,12 @@ Each unit test is constructed such that soil is only avalanching to a single pos
 | RE-RT-37  | Second layer | &check; | &cross;   | &cross; | First layer  | &check; | &check; | Second layer |
 | RE-RT-38  | Second layer | &check; | &cross;   | &cross; | First layer  | &check; | &cross; | Second layer |
 |           | Second layer | &check; | &check;   | &check; | First layer  | &check; | &cross; | First layer  |
+
+In this table,
+- `Soil` indicates whether soil is present on the corresponding layer.
+- `Until top` indicates whether the soil fully fill the gap between the two layers.
+- `Stable` indicates whether the corresponding soil layer is unstable considering the configuration.
+- `Avalanche` indicates where the soil should avalanche.
 
 In addition to these basic unit tests, a few extra edge cases are checked.
 
@@ -846,6 +863,13 @@ The configuration of the inital position should not impact the result of this fu
 | RE-CUB-41 | First layer  | &cross; | &cross;   | &cross;    | Second layer | &check; | &check;    | &cross;      |
 | RE-CUB-42 | First layer  | &cross; | &cross;   | &check;    | Second layer | &cross; | &check;    | &cross;      |
 
+In this table,
+- `Soil` indicates whether soil is present on the corresponding layer.
+- `Until top` indicates whether the soil fully fill the gap between the two layers.
+- `Accessible` indicates whether the soil could potentially avalanche on this layer.
+  The layer is not accessible if a wall blocked the movement or if the soil column in the corresponding layer is higher than the considered soil column.
+- `Avalanche` indicates where the soil should avalanche.
+
 ### `RelaxUnstableBodyCell`
 
 Unit test for the `RelaxUnstableBodyCell` function.
@@ -910,6 +934,14 @@ The configuration of the inital position should not impact the result of this fu
 | RE-RUB-49 | Second layer | &check; | &check;   | First layer  | &cross; | First layer  | &check;     | &check;      | Partial      |
 | RE-RUB-50 | Second layer | &check; | &check;   | First layer  | &check; | First layer  | &check;     | &check;      | Partial      |
 | RE-RUB-51 | Second layer | &check; | &cross;   | &cross;      | &cross; | terrain      | &check;     | &cross;      | Partial      |
+
+In this table,
+- `Soil` indicates whether soil is present on the corresponding layer.
+- `Until top` indicates whether the soil fully fill the gap between the two layers.
+- `Avalanche` indicates where the soil should avalanche.
+- `Enough soil` indicates whether there is enough soil in the considered soil column to reach the stable configuration.
+- `Enough space` indicates whether there is enough space on the layer where the soil should avalanche to accommodate all the avalanching soil.
+- `Status` indicates the type of soil avalanche.
 
 ### `RelaxBodySoil`
 
@@ -1014,6 +1046,13 @@ The configuration of the inital position should not impact the result of this fu
 | RE-RBS-76 | Second layer | &cross; | &cross;   | First layer  | &cross; | &cross;      | &check;      | &cross;      |    
 | RE-RBS-77 | Second layer | &check; | &check;   | First layer  | &cross; | &cross;      | &check;      | &cross;      |
 | RE-RBS-78 | Second layer | &check; | &check;   | First layer  | &check; | &cross;      | &check;      | &cross;      |
+
+In this table,
+- `Soil` indicates whether soil is present on the corresponding layer.
+- `Until top` indicates whether the soil fully fill the gap between the two layers.
+- `Avalanche` indicates where the soil should avalanche.
+- `Enough space` indicates whether there is enough space on the layer where the soil should avalanche to accommodate all the avalanching soil.
+- `Status` indicates the type of soil avalanche.
 
 In addition to these basic unit tests, a few extra edge cases are checked.
 

--- a/test/unit_tests/test_relax.cpp
+++ b/test/unit_tests/test_relax.cpp
@@ -2032,7 +2032,6 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->terrain_[10][15], 0.1, 1e-5);
     EXPECT_EQ(body_soil_pos->size(), 0);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
     ResetValueAndTest(
         sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}}, {{0, 10, 14}});
 
@@ -2048,25 +2047,23 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->terrain_[10][15], 0.0, 1e-5);
     EXPECT_EQ(body_soil_pos->size(), 0);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
     ResetValueAndTest(
         sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}}, {{0, 10, 14}});
 
     // Test: RE-RUB-3
-    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.2, NAN, NAN, NAN, NAN);
-    sim_out->terrain_[10][15] = -0.2;
+    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.4, NAN, NAN, NAN, NAN);
+    sim_out->terrain_[10][15] = 0.0;
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
     PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.1);
-    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.1);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.3);
     soil_simulator::RelaxUnstableBodyCell(
         sim_out, 40, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
         1e-5);
-    CheckHeight(sim_out, 10, 14, -0.2, 0.0, 0.1, NAN, NAN);
-    EXPECT_NEAR(sim_out->terrain_[10][15], -0.1, 1e-5);
+    CheckHeight(sim_out, 10, 14, -0.2, 0.0, 0.3, NAN, NAN);
+    EXPECT_NEAR(sim_out->terrain_[10][15], 0.1, 1e-5);
     EXPECT_EQ(body_soil_pos->size(), 0);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.3, 1.e-5);
     ResetValueAndTest(
         sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}}, {{0, 10, 14}});
 
@@ -2082,40 +2079,36 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
     EXPECT_NEAR(sim_out->terrain_[10][15], 0.1, 1e-5);
     EXPECT_EQ(body_soil_pos->size(), 0);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_.size(), 1);
     ResetValueAndTest(
         sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}},
         {{0, 10, 14}});
 
     // Test: RE-RUB-5
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.2, NAN, NAN, NAN, NAN);
-    SetHeight(sim_out, 10, 15, -0.4, 0.1, 0.4, 0.4, 0.5, NAN, NAN, NAN, NAN);
+    SetHeight(sim_out, 10, 15, -0.4, 0.1, 0.4, NAN, NAN, NAN, NAN, NAN, NAN);
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
     PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.2);
-    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.4, grid, bucket);
-    PushBodySoilPos(sim_out, 0, 10, 15, pos0, 0.1);
     soil_simulator::RelaxUnstableBodyCell(
         sim_out, 10, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
         1e-5);
     CheckHeight(sim_out, 10, 14, -0.2, 0.0, 0.0, NAN, NAN);
-    CheckHeight(sim_out, 10, 15, -0.2, 0.4, 0.5, NAN, NAN);
+    CheckHeight(sim_out, 10, 15, -0.2, NAN, NAN, NAN, NAN);
     EXPECT_EQ(body_soil_pos->size(), 0);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
-    EXPECT_EQ(sim_out->body_soil_pos_.size(), 2);
     ResetValueAndTest(
         sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}},
         {{0, 10, 14}, {0, 10, 15}});
 
     // Test: RE-RUB-6
-    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.5, NAN, NAN, NAN, NAN);
-    SetHeight(sim_out, 10, 15, 0.0, 0.2, 0.4, NAN, NAN, NAN, NAN, NAN, NAN);
+    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.4, NAN, NAN, NAN, NAN);
+    SetHeight(sim_out, 10, 15, 0.0, 0.1, 0.2, NAN, NAN, NAN, NAN, NAN, NAN);
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
-    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.5);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.4);
     soil_simulator::RelaxUnstableBodyCell(
         sim_out, 10, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
         1e-5);
     CheckHeight(sim_out, 10, 14, -0.2, 0.0, 0.3, NAN, NAN);
-    EXPECT_NEAR(sim_out->terrain_[10][15], 0.2, 1e-5);
+    EXPECT_NEAR(sim_out->terrain_[10][15], 0.1, 1e-5);
     EXPECT_EQ(body_soil_pos->size(), 0);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.3, 1.e-5);
     ResetValueAndTest(
@@ -2123,6 +2116,42 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}});
 
     // Test: RE-RUB-7
+    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.4, NAN, NAN, NAN, NAN);
+    SetHeight(sim_out, 10, 15, 0.0, 0.3, 0.4, NAN, NAN, NAN, NAN, NAN, NAN);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.1);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.3);
+    soil_simulator::RelaxUnstableBodyCell(
+        sim_out, 10, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
+        1e-5);
+    CheckHeight(sim_out, 10, 14, -0.2, 0.0, 0.3, NAN, NAN);
+    EXPECT_NEAR(sim_out->terrain_[10][15], 0.1, 1e-5);
+    EXPECT_EQ(body_soil_pos->size(), 0);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.3, 1.e-5);
+    ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}},
+        {{0, 10, 14}});
+
+    // Test: RE-RUB-8
+    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.6, NAN, NAN, NAN, NAN);
+    SetHeight(sim_out, 10, 15, 0.0, 0.1, 0.4, NAN, NAN, NAN, NAN, NAN, NAN);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.3);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.3);
+    soil_simulator::RelaxUnstableBodyCell(
+        sim_out, 10, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
+        1e-5);
+    CheckHeight(sim_out, 10, 14, -0.2, 0.0, 0.5, NAN, NAN);
+    EXPECT_NEAR(sim_out->terrain_[10][15], 0.1, 1e-5);
+    EXPECT_EQ(body_soil_pos->size(), 0);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.2, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.3, 1.e-5);
+    ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}},
+        {{0, 10, 14}});
+
+    // Test: RE-RUB-9
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.2, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 15, -0.2, -0.2, 0.0, NAN, NAN, NAN, NAN, NAN, NAN);
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
@@ -2141,7 +2170,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {0, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-8
+    // Test: RE-RUB-10
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.2, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 15, -0.3, -0.3, -0.2, NAN, NAN, NAN, NAN, NAN, NAN);
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
@@ -2160,7 +2189,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {0, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-9
+    // Test: RE-RUB-11
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.2, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 15, -0.3, -0.3, -0.2, NAN, NAN, NAN, NAN, NAN, NAN);
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
@@ -2181,7 +2210,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {0, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-10
+    // Test: RE-RUB-12
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.2, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 15, -0.3, -0.3, -0.2, -0.2, 0.0, NAN, NAN, NAN, NAN);
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
@@ -2202,7 +2231,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {0, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-11
+    // Test: RE-RUB-13
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.1, 0.1, 0.2, NAN, NAN, NAN, NAN);
     SetHeight(
         sim_out, 10, 15, -0.3, -0.3, -0.2, -0.2, -0.1, NAN, NAN, NAN, NAN);
@@ -2224,7 +2253,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {0, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-12
+    // Test: RE-RUB-14
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.2, 0.2, 0.4, NAN, NAN, NAN, NAN);
     SetHeight(
         sim_out, 10, 15, -0.3, -0.3, -0.2, -0.2, -0.1, NAN, NAN, NAN, NAN);
@@ -2248,26 +2277,23 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {0, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-13
+    // Test: RE-RUB-15
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.2, NAN, NAN, NAN, NAN);
-    SetHeight(sim_out, 10, 15, 0.0, NAN, NAN, NAN, NAN, 0.5, 0.6, 0.6, 0.7);
+    SetHeight(sim_out, 10, 15, 0.0, NAN, NAN, NAN, NAN, 0.5, 0.6, NAN, NAN);
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.1, grid, bucket);
     PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.2);
-    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.6, grid, bucket);
-    PushBodySoilPos(sim_out, 2, 10, 15, pos2, 0.1);
     soil_simulator::RelaxUnstableBodyCell(
         sim_out, 20, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
         1e-5);
     CheckHeight(sim_out, 10, 14, -0.2, 0.0, 0.1, NAN, NAN);
-    CheckHeight(sim_out, 10, 15, 0.1, NAN, NAN, 0.6, 0.7);
+    EXPECT_NEAR(sim_out->terrain_[10][15], 0.1, 1e-5);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 0);
     ResetValueAndTest(
         sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
         {{0, 10, 14}, {2, 10, 15}});
 
-    // Test: RE-RUB-14
+    // Test: RE-RUB-16
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.2, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 15, -0.4, NAN, NAN, NAN, NAN, 0.5, 0.6, NAN, NAN);
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
@@ -2283,7 +2309,59 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
         {{0, 10, 14}});
 
-    // Test: RE-RUB-15
+    // Test: RE-RUB-17
+    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.4, NAN, NAN, NAN, NAN);
+    SetHeight(sim_out, 10, 15, 0.0, NAN, NAN, NAN, NAN, 0.1, 0.6, NAN, NAN);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.4);
+    soil_simulator::RelaxUnstableBodyCell(
+        sim_out, 20, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
+        1e-5);
+    CheckHeight(sim_out, 10, 14, -0.2, 0.0, 0.3, NAN, NAN);
+    EXPECT_NEAR(sim_out->terrain_[10][15], 0.1, 1e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.3, 1.e-5);
+    EXPECT_EQ(body_soil_pos->size(), 0);
+    ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
+
+    // Test: RE-RUB-18
+    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.2, NAN, NAN, NAN, NAN);
+    SetHeight(sim_out, 10, 15, -0.4, NAN, NAN, NAN, NAN, 0.5, 0.6, NAN, NAN);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.1);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.1);
+    soil_simulator::RelaxUnstableBodyCell(
+        sim_out, 20, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
+        1e-5);
+    CheckHeight(sim_out, 10, 14, -0.2, 0.0, 0.1, NAN, NAN);
+    EXPECT_NEAR(sim_out->terrain_[10][15], -0.3, 1e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.1, 1.e-5);
+    EXPECT_EQ(body_soil_pos->size(), 0);
+    ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
+        {{0, 10, 14}});
+
+    // Test: RE-RUB-19
+    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.6, NAN, NAN, NAN, NAN);
+    SetHeight(sim_out, 10, 15, 0.0, NAN, NAN, NAN, NAN, 0.1, 0.6, NAN, NAN);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.2);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.4);
+    soil_simulator::RelaxUnstableBodyCell(
+        sim_out, 20, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
+        1e-5);
+    CheckHeight(sim_out, 10, 14, -0.2, 0.0, 0.5, NAN, NAN);
+    EXPECT_NEAR(sim_out->terrain_[10][15], 0.1, 1e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.4, 1.e-5);
+    EXPECT_EQ(body_soil_pos->size(), 0);
+    ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
+        {{0, 10, 14}});
+
+    // Test: RE-RUB-20
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.2, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 15, -0.2, NAN, NAN, NAN, NAN, -0.2, 0.0, NAN, NAN);
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
@@ -2302,7 +2380,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-16
+    // Test: RE-RUB-21
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.1, 0.1, 0.2, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 15, -0.2, NAN, NAN, NAN, NAN, -0.2, -0.1, NAN, NAN);
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.1, grid, bucket);
@@ -2321,7 +2399,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-17
+    // Test: RE-RUB-22
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.1, 0.1, 0.3, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 15, -0.3, NAN, NAN, NAN, NAN, -0.3, -0.2, NAN, NAN);
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.1, grid, bucket);
@@ -2342,7 +2420,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-18
+    // Test: RE-RUB-23
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.2, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 15, -0.2, NAN, NAN, NAN, NAN, -0.2, -0.1, -0.1, 0.0);
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
@@ -2363,7 +2441,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-19
+    // Test: RE-RUB-24
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.1, 0.1, 0.2, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 15, -0.2, NAN, NAN, NAN, NAN, -0.2, -0.1, -0.1, 0.0);
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.1, grid, bucket);
@@ -2384,7 +2462,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-20
+    // Test: RE-RUB-25
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.1, 0.1, 0.3, NAN, NAN, NAN, NAN);
     SetHeight(
         sim_out, 10, 15, -0.3, NAN, NAN, NAN, NAN, -0.3, -0.2, -0.2, -0.1);
@@ -2408,7 +2486,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-21
+    // Test: RE-RUB-26
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.3, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 15, -0.2, -0.2, -0.1, NAN, NAN, 0.1, 0.3, NAN, NAN);
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
@@ -2427,7 +2505,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {0, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-22
+    // Test: RE-RUB-27
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.1, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 15, -0.2, -0.2, -0.1, NAN, NAN, 0.1, 0.3, NAN, NAN);
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
@@ -2446,7 +2524,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {0, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-23
+    // Test: RE-RUB-28
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.2, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 15, -0.3, -0.3, -0.2, NAN, NAN, 0.1, 0.3, NAN, NAN);
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
@@ -2467,7 +2545,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {0, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-24
+    // Test: RE-RUB-29
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.5, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 15, -0.2, -0.2, -0.1, NAN, NAN, 0.1, 0.3, NAN, NAN);
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
@@ -2486,7 +2564,28 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {0, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-25
+    // Test: RE-RUB-30
+    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.9, NAN, NAN, NAN, NAN);
+    SetHeight(sim_out, 10, 15, -0.2, -0.2, -0.1, NAN, NAN, 0.0, 0.3, NAN, NAN);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.2);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.7);
+    posA = soil_simulator::CalcBucketFramePos(10, 15, -0.1, grid, bucket);
+    soil_simulator::RelaxUnstableBodyCell(
+        sim_out, 34, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
+        1e-5);
+    CheckHeight(sim_out, 10, 14, -0.2, 0.0, 0.8, NAN, NAN);
+    CheckHeight(sim_out, 10, 15, -0.2, -0.1, 0.0, NAN, NAN);
+    CheckBodySoilPos((*body_soil_pos)[0], 0, 10, 15, posA, 0.1);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.7, 1.e-5);
+    EXPECT_EQ(body_soil_pos->size(), 1);
+    ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
+    body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
+
+    // Test: RE-RUB-31
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.5, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 15, -0.2, -0.2, -0.1, NAN, NAN, 0.0, 0.3, NAN, NAN);
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
@@ -2505,7 +2604,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-26
+    // Test: RE-RUB-32
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.5, 0.5, 0.8, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 15, -0.2, -0.2, -0.1, NAN, NAN, 0.0, 0.2, NAN, NAN);
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.5, grid, bucket);
@@ -2524,7 +2623,28 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-27
+    // Test: RE-RUB-33
+    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.5, 0.5, 0.8, NAN, NAN, NAN, NAN);
+    SetHeight(sim_out, 10, 15, -0.2, -0.2, -0.1, NAN, NAN, 0.0, 0.2, NAN, NAN);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.5, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.1);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.2);
+    posA = soil_simulator::CalcBucketFramePos(10, 15, 0.2, grid, bucket);
+    soil_simulator::RelaxUnstableBodyCell(
+        sim_out, 32, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
+        1e-5);
+    CheckHeight(sim_out, 10, 14, -0.2, 0.5, 0.7, NAN, NAN);
+    CheckHeight(sim_out, 10, 15, -0.2, NAN, NAN, 0.2, 0.3);
+    CheckBodySoilPos((*body_soil_pos)[0], 2, 10, 15, posA, 0.1);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.2, 1.e-5);
+    EXPECT_EQ(body_soil_pos->size(), 1);
+    ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
+    body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
+
+    // Test: RE-RUB-34
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.3, NAN, NAN, NAN, NAN);
     SetHeight(
         sim_out, 10, 15, -0.3, -0.3, -0.2, -0.2, -0.1, 0.1, 0.3, 0.3, 0.5);
@@ -2547,7 +2667,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-28
+    // Test: RE-RUB-35
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.1, 0.1, 0.3, NAN, NAN, NAN, NAN);
     SetHeight(
         sim_out, 10, 15, -0.3, -0.3, -0.2, -0.2, -0.1, 0.2, 0.3, 0.3, 0.5);
@@ -2570,7 +2690,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-29
+    // Test: RE-RUB-36
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.1, 0.1, 0.3, NAN, NAN, NAN, NAN);
     SetHeight(
         sim_out, 10, 15, -0.3, -0.3, -0.2, -0.2, -0.1, 0.2, 0.3, 0.3, 0.5);
@@ -2595,7 +2715,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-30
+    // Test: RE-RUB-37
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.1, 0.1, 0.9, NAN, NAN, NAN, NAN);
     SetHeight(
         sim_out, 10, 15, -0.3, -0.3, -0.2, -0.2, -0.1, 0.2, 0.3, 0.3, 0.5);
@@ -2618,7 +2738,32 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-31
+    // Test: RE-RUB-38
+    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.1, 0.1, 0.9, NAN, NAN, NAN, NAN);
+    SetHeight(
+        sim_out, 10, 15, -0.3, -0.3, -0.2, -0.2, -0.1, 0.0, 0.3, 0.3, 0.5);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.1, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.2);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.6);
+    posA = soil_simulator::CalcBucketFramePos(10, 15, -0.2, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 15, posA, 0.1);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    PushBodySoilPos(sim_out, 2, 10, 15, pos2, 0.2);
+    soil_simulator::RelaxUnstableBodyCell(
+        sim_out, 33, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
+        1e-5);
+    CheckHeight(sim_out, 10, 14, -0.2, 0.1, 0.8, NAN, NAN);
+    CheckHeight(sim_out, 10, 15, -0.3, -0.2, 0.0, 0.3, 0.5);
+    CheckBodySoilPos((*body_soil_pos)[0], 0, 10, 15, posA, 0.1);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.6, 1.e-5);
+    EXPECT_EQ(body_soil_pos->size(), 1);
+    ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
+    body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
+
+    // Test: RE-RUB-39
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.1, 0.1, 0.9, NAN, NAN, NAN, NAN);
     SetHeight(
         sim_out, 10, 15, -0.3, -0.3, -0.2, -0.2, -0.1, 0.1, 0.3, 0.3, 0.5);
@@ -2641,7 +2786,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-32
+    // Test: RE-RUB-40
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.7, 0.7, 0.9, NAN, NAN, NAN, NAN);
     SetHeight(
         sim_out, 10, 15, -0.3, -0.3, -0.2, -0.2, -0.1, 0.1, 0.3, 0.3, 0.5);
@@ -2664,7 +2809,165 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-33
+    // Test: RE-RUB-41
+    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.1, 0.1, 0.9, NAN, NAN, NAN, NAN);
+    SetHeight(
+        sim_out, 10, 15, -0.3, -0.3, -0.2, -0.2, -0.1, 0.1, 0.3, 0.3, 0.5);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.1, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.1);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.8);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, -0.2, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 15, pos0, 0.1);
+    posA = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    PushBodySoilPos(sim_out, 2, 10, 15, posA, 0.2);
+    soil_simulator::RelaxUnstableBodyCell(
+        sim_out, 31, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
+        1e-5);
+    CheckHeight(sim_out, 10, 14, -0.2, 0.1, 0.8, NAN, NAN);
+    CheckHeight(sim_out, 10, 15, -0.3, -0.2, -0.1, 0.3, 0.6);
+    CheckBodySoilPos((*body_soil_pos)[0], 2, 10, 15, posA, 0.1);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.8, 1.e-5);
+    EXPECT_EQ(body_soil_pos->size(), 1);
+    ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
+    body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
+
+    // Test: RE-RUB-42
+    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.8, NAN, NAN, NAN, NAN);
+    SetHeight(sim_out, 10, 15, -0.3, -0.3, -0.2, -0.2, 0.1, 0.1, 0.2, NAN, NAN);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.8);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, -0.2, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 15, pos0, 0.3);
+    posA = soil_simulator::CalcBucketFramePos(10, 15, 0.2, grid, bucket);
+    soil_simulator::RelaxUnstableBodyCell(
+        sim_out, 32, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
+        1e-5);
+    CheckHeight(sim_out, 10, 14, -0.2, 0.0, 0.5, NAN, NAN);
+    CheckHeight(sim_out, 10, 15, -0.3, -0.2, 0.1, 0.2, 0.5);
+    CheckBodySoilPos((*body_soil_pos)[0], 2, 10, 15, posA, 0.3);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.5, 1.e-5);
+    EXPECT_EQ(body_soil_pos->size(), 1);
+    ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
+    body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
+
+    // Test: RE-RUB-43
+    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.6, 0.6, 0.8, NAN, NAN, NAN, NAN);
+    SetHeight(sim_out, 10, 15, -0.3, -0.3, -0.2, -0.2, 0.1, 0.1, 0.2, NAN, NAN);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.6, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.2);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, -0.2, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 15, pos0, 0.3);
+    posA = soil_simulator::CalcBucketFramePos(10, 15, 0.2, grid, bucket);
+    soil_simulator::RelaxUnstableBodyCell(
+        sim_out, 32, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
+        1e-5);
+    CheckHeight(sim_out, 10, 14, -0.2, 0.0, 0.0, NAN, NAN);
+    CheckHeight(sim_out, 10, 15, -0.3, -0.2, 0.1, 0.2, 0.4);
+    CheckBodySoilPos((*body_soil_pos)[0], 2, 10, 15, posA, 0.2);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
+    EXPECT_EQ(body_soil_pos->size(), 1);
+    ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
+    body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
+
+    // Test: RE-RUB-44
+    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.8, NAN, NAN, NAN, NAN);
+    SetHeight(sim_out, 10, 15, -0.3, -0.3, -0.2, -0.2, 0.1, 0.1, 0.2, NAN, NAN);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.1);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.7);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, -0.2, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 15, pos0, 0.3);
+    posA = soil_simulator::CalcBucketFramePos(10, 15, 0.2, grid, bucket);
+    soil_simulator::RelaxUnstableBodyCell(
+        sim_out, 32, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
+        1e-5);
+    CheckHeight(sim_out, 10, 14, -0.2, 0.0, 0.7, NAN, NAN);
+    CheckHeight(sim_out, 10, 15, -0.3, -0.2, 0.1, 0.2, 0.3);
+    CheckBodySoilPos((*body_soil_pos)[0], 2, 10, 15, posA, 0.1);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.7, 1.e-5);
+    EXPECT_EQ(body_soil_pos->size(), 1);
+    ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
+    body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
+
+    // Test: RE-RUB-45
+    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.8, NAN, NAN, NAN, NAN);
+    SetHeight(sim_out, 10, 15, -0.3, -0.3, -0.2, -0.2, 0.1, 0.1, 0.2, 0.2, 0.4);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.8);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, -0.2, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 15, pos0, 0.3);
+    posA = soil_simulator::CalcBucketFramePos(10, 15, 0.2, grid, bucket);
+    PushBodySoilPos(sim_out, 2, 10, 15, posA, 0.2);
+    soil_simulator::RelaxUnstableBodyCell(
+        sim_out, 31, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
+        1e-5);
+    CheckHeight(sim_out, 10, 14, -0.2, 0.0, 0.6, NAN, NAN);
+    CheckHeight(sim_out, 10, 15, -0.3, -0.2, 0.1, 0.2, 0.6);
+    CheckBodySoilPos((*body_soil_pos)[0], 2, 10, 15, posA, 0.2);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.6, 1.e-5);
+    EXPECT_EQ(body_soil_pos->size(), 1);
+    ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
+    body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
+
+    // Test: RE-RUB-46
+    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.7, 0.7, 0.8, NAN, NAN, NAN, NAN);
+    SetHeight(sim_out, 10, 15, -0.3, -0.3, -0.2, -0.2, 0.1, 0.1, 0.2, 0.2, 0.4);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.7, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.1);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, -0.2, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 15, pos0, 0.3);
+    posA = soil_simulator::CalcBucketFramePos(10, 15, 0.2, grid, bucket);
+    PushBodySoilPos(sim_out, 2, 10, 15, posA, 0.2);
+    soil_simulator::RelaxUnstableBodyCell(
+        sim_out, 31, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
+        1e-5);
+    CheckHeight(sim_out, 10, 14, -0.2, 0.0, 0.0, NAN, NAN);
+    CheckHeight(sim_out, 10, 15, -0.3, -0.2, 0.1, 0.2, 0.5);
+    CheckBodySoilPos((*body_soil_pos)[0], 2, 10, 15, posA, 0.1);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
+    EXPECT_EQ(body_soil_pos->size(), 1);
+    ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
+    body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
+
+    // Test: RE-RUB-47
+    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.8, NAN, NAN, NAN, NAN);
+    SetHeight(sim_out, 10, 15, -0.3, -0.3, -0.2, -0.2, 0.1, 0.1, 0.2, 0.2, 0.4);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.1);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.7);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, -0.2, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 15, pos0, 0.3);
+    posA = soil_simulator::CalcBucketFramePos(10, 15, 0.2, grid, bucket);
+    PushBodySoilPos(sim_out, 2, 10, 15, posA, 0.2);
+    soil_simulator::RelaxUnstableBodyCell(
+        sim_out, 31, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
+        1e-5);
+    CheckHeight(sim_out, 10, 14, -0.2, 0.0, 0.7, NAN, NAN);
+    CheckHeight(sim_out, 10, 15, -0.3, -0.2, 0.1, 0.2, 0.5);
+    CheckBodySoilPos((*body_soil_pos)[0], 2, 10, 15, posA, 0.1);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.7, 1.e-5);
+    EXPECT_EQ(body_soil_pos->size(), 1);
+    ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
+    body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
+
+    // Test: RE-RUB-48
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.3, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 15, -0.2, 0.1, 0.3, NAN, NAN, -0.2, -0.1, NAN, NAN);
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
@@ -2683,7 +2986,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-34
+    // Test: RE-RUB-49
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.1, 0.1, 0.3, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 15, -0.2, 0.2, 0.4, NAN, NAN, -0.2, 0.0, NAN, NAN);
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.1, grid, bucket);
@@ -2702,7 +3005,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-35
+    // Test: RE-RUB-50
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.1, 0.1, 0.3, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 15, -0.2, 0.2, 0.4, NAN, NAN, -0.2, 0.0, NAN, NAN);
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.1, grid, bucket);
@@ -2723,7 +3026,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-36
+    // Test: RE-RUB-51
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.1, 0.1, 0.8, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 15, -0.2, 0.2, 0.4, NAN, NAN, -0.2, 0.0, NAN, NAN);
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.1, grid, bucket);
@@ -2742,7 +3045,31 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-37
+    // Test: RE-RUB-52
+    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.1, 0.1, 1.0, NAN, NAN, NAN, NAN);
+    SetHeight(sim_out, 10, 15, -0.2, 0.1, 0.4, NAN, NAN, -0.2, 0.0, NAN, NAN);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.1, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.2);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.7);
+    posA = soil_simulator::CalcBucketFramePos(10, 15, 0.0, grid, bucket);
+    soil_simulator::RelaxUnstableBodyCell(
+        sim_out, 32, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
+        1e-5);
+    CheckHeight(sim_out, 10, 14, -0.2, 0.1, 0.9, NAN, NAN);
+    CheckHeight(sim_out, 10, 15, -0.2, NAN, NAN, 0.0, 0.1);
+    CheckBodySoilPos((*body_soil_pos)[0], 2, 10, 15, posA, 0.1);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.7, 1.e-5);
+    EXPECT_EQ(body_soil_pos->size(), 1);
+    ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {2, 10, 15}});
+    body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
+
+
+
+
+    // Test: RE-RUB-53
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.1, 0.1, 0.8, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 15, -0.2, 0.1, 0.4, NAN, NAN, -0.2, 0.0, NAN, NAN);
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.1, grid, bucket);
@@ -2761,7 +3088,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {0, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-38
+    // Test: RE-RUB-54
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.6, 0.6, 0.8, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 15, -0.2, 0.1, 0.2, NAN, NAN, -0.2, 0.0, NAN, NAN);
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.6, grid, bucket);
@@ -2780,7 +3107,28 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {0, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-39
+    // Test: RE-RUB-55
+    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.1, 0.1, 0.8, NAN, NAN, NAN, NAN);
+    SetHeight(sim_out, 10, 15, -0.2, 0.1, 0.4, NAN, NAN, -0.2, 0.0, NAN, NAN);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.1, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.1);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.6);
+    posA = soil_simulator::CalcBucketFramePos(10, 15, 0.4, grid, bucket);
+    soil_simulator::RelaxUnstableBodyCell(
+        sim_out, 34, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
+        1e-5);
+    CheckHeight(sim_out, 10, 14, -0.2, 0.1, 0.7, NAN, NAN);
+    CheckHeight(sim_out, 10, 15, -0.2, 0.4, 0.5, NAN, NAN);
+    CheckBodySoilPos((*body_soil_pos)[0], 0, 10, 15, posA, 0.1);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.6, 1.e-5);
+    EXPECT_EQ(body_soil_pos->size(), 1);
+    ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}});
+    body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
+
+    // Test: RE-RUB-56
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.3, NAN, NAN, NAN, NAN);
     SetHeight(
         sim_out, 10, 15, -0.3, 0.1, 0.3, 0.3, 0.8, -0.3, -0.2, -0.2, -0.1);
@@ -2803,7 +3151,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-40
+    // Test: RE-RUB-57
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.1, NAN, NAN, NAN, NAN);
     SetHeight(
         sim_out, 10, 15, -0.3, 0.1, 0.3, 0.3, 0.8, -0.3, -0.2, -0.2, -0.1);
@@ -2826,7 +3174,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-41
+    // Test: RE-RUB-58
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.2, NAN, NAN, NAN, NAN);
     SetHeight(
         sim_out, 10, 15, -0.4, 0.1, 0.3, 0.3, 0.8, -0.4, -0.3, -0.3, -0.2);
@@ -2851,7 +3199,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-42
+    // Test: RE-RUB-59
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.8, NAN, NAN, NAN, NAN);
     SetHeight(
         sim_out, 10, 15, -0.3, 0.1, 0.3, 0.3, 0.8, -0.3, -0.2, -0.2, -0.1);
@@ -2874,7 +3222,32 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-43
+    // Test: RE-RUB-60
+    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 1.0, NAN, NAN, NAN, NAN);
+    SetHeight(
+        sim_out, 10, 15, -0.3, 0.0, 0.3, 0.3, 0.8, -0.3, -0.2, -0.2, -0.1);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.2);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.8);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 15, pos0, 0.5);
+    posA = soil_simulator::CalcBucketFramePos(10, 15, -0.2, grid, bucket);
+    PushBodySoilPos(sim_out, 2, 10, 15, posA, 0.1);
+    soil_simulator::RelaxUnstableBodyCell(
+        sim_out, 31, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
+        1e-5);
+    CheckHeight(sim_out, 10, 14, -0.2, 0.0, 0.9, NAN, NAN);
+    CheckHeight(sim_out, 10, 15, -0.3, 0.3, 0.8, -0.2, 0.0);
+    CheckBodySoilPos((*body_soil_pos)[0], 2, 10, 15, posA, 0.1);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.1, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.8, 1.e-5);
+    EXPECT_EQ(body_soil_pos->size(), 1);
+    ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
+    body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
+
+    // Test: RE-RUB-61
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.1, 0.1, 0.8, NAN, NAN, NAN, NAN);
     SetHeight(
         sim_out, 10, 15, -0.3, 0.1, 0.3, 0.3, 0.5, -0.3, -0.2, -0.2, -0.1);
@@ -2897,7 +3270,7 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-44
+    // Test: RE-RUB-62
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.6, 0.6, 0.8, NAN, NAN, NAN, NAN);
     SetHeight(
         sim_out, 10, 15, -0.3, 0.1, 0.3, 0.3, 0.4, -0.3, -0.2, -0.2, -0.1);
@@ -2920,90 +3293,32 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-45
-    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.8, NAN, NAN, NAN, NAN);
-    SetHeight(sim_out, 10, 15, -0.3, -0.3, -0.2, -0.2, 0.1, 0.1, 0.3, 0.3, 0.8);
-    pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
-    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.8);
-    pos0 = soil_simulator::CalcBucketFramePos(10, 15, -0.2, grid, bucket);
-    PushBodySoilPos(sim_out, 0, 10, 15, pos0, 0.3);
-    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
-    PushBodySoilPos(sim_out, 2, 10, 15, pos2, 0.5);
-    soil_simulator::RelaxUnstableBodyCell(
-        sim_out, 33, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
-        1e-5);
-    CheckHeight(sim_out, 10, 14, -0.2, 0.0, 0.8, NAN, NAN);
-    CheckHeight(sim_out, 10, 15, -0.3, -0.2, 0.1, 0.3, 0.8);
-    EXPECT_EQ(body_soil_pos->size(), 0);
-    ResetValueAndTest(
-        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
-        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
-    body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-
-    // Test: RE-RUB-46
-    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.8, NAN, NAN, NAN, NAN);
-    SetHeight(sim_out, 10, 15, -0.3, 0.1, 0.3, 0.3, 0.8, -0.3, -0.2, -0.2, 0.1);
-    pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
-    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.8);
-    pos0 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
-    PushBodySoilPos(sim_out, 0, 10, 15, pos0, 0.5);
+    // Test: RE-RUB-63
+    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.1, 0.1, 0.8, NAN, NAN, NAN, NAN);
+    SetHeight(
+        sim_out, 10, 15, -0.3, 0.1, 0.3, 0.3, 0.4, -0.3, -0.2, -0.2, -0.1);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.1, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.6);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.1);
+    posA = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 15, posA, 0.1);
     pos2 = soil_simulator::CalcBucketFramePos(10, 15, -0.2, grid, bucket);
-    PushBodySoilPos(sim_out, 2, 10, 15, pos2, 0.3);
+    PushBodySoilPos(sim_out, 2, 10, 15, pos2, 0.1);
     soil_simulator::RelaxUnstableBodyCell(
-        sim_out, 31, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
+        sim_out, 33, body_soil_pos, 0.1, 1, 10, 14, 0, 10, 15, grid, bucket,
         1e-5);
-    CheckHeight(sim_out, 10, 14, -0.2, 0.0, 0.8, NAN, NAN);
-    CheckHeight(sim_out, 10, 15, -0.3, 0.3, 0.8, -0.2, 0.1);
-    EXPECT_EQ(body_soil_pos->size(), 0);
-    ResetValueAndTest(
-        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
-        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
-    body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-
-    // Test: RE-RUB-47
-    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.8, NAN, NAN, NAN, NAN);
-    SetHeight(sim_out, 10, 15, -0.3, -0.3, -0.2, -0.2, 0.1, 0.1, 0.2, NAN, NAN);
-    pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
-    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.8);
-    pos0 = soil_simulator::CalcBucketFramePos(10, 15, -0.2, grid, bucket);
-    PushBodySoilPos(sim_out, 0, 10, 15, pos0, 0.3);
-    posA = soil_simulator::CalcBucketFramePos(10, 15, 0.2, grid, bucket);
-    soil_simulator::RelaxUnstableBodyCell(
-        sim_out, 32, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
-        1e-5);
-    CheckHeight(sim_out, 10, 14, -0.2, 0.0, 0.5, NAN, NAN);
-    CheckHeight(sim_out, 10, 15, -0.3, -0.2, 0.1, 0.2, 0.5);
-    CheckBodySoilPos((*body_soil_pos)[0], 2, 10, 15, posA, 0.3);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.5, 1.e-5);
-    EXPECT_EQ(body_soil_pos->size(), 1);
-    ResetValueAndTest(
-        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
-        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
-    body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
-
-    // Test: RE-RUB-48
-    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.8, NAN, NAN, NAN, NAN);
-    SetHeight(sim_out, 10, 15, -0.3, -0.3, -0.2, -0.2, 0.1, 0.1, 0.2, 0.2, 0.4);
-    pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
-    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.8);
-    pos0 = soil_simulator::CalcBucketFramePos(10, 15, -0.2, grid, bucket);
-    PushBodySoilPos(sim_out, 0, 10, 15, pos0, 0.3);
-    posA = soil_simulator::CalcBucketFramePos(10, 15, 0.2, grid, bucket);
-    PushBodySoilPos(sim_out, 2, 10, 15, posA, 0.2);
-    soil_simulator::RelaxUnstableBodyCell(
-        sim_out, 31, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
-        1e-5);
-    CheckHeight(sim_out, 10, 14, -0.2, 0.0, 0.6, NAN, NAN);
-    CheckHeight(sim_out, 10, 15, -0.3, -0.2, 0.1, 0.2, 0.6);
-    CheckBodySoilPos((*body_soil_pos)[0], 2, 10, 15, posA, 0.2);
+    CheckHeight(sim_out, 10, 14, -0.2, 0.1, 0.7, NAN, NAN);
+    CheckHeight(sim_out, 10, 15, -0.3, 0.3, 0.5, -0.2, -0.1);
+    CheckBodySoilPos((*body_soil_pos)[0], 0, 10, 15, posA, 0.1);
     EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.6, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.0, 1.e-5);
     EXPECT_EQ(body_soil_pos->size(), 1);
     ResetValueAndTest(
         sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
         {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-49
+    // Test: RE-RUB-64
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.8, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 15, -0.3, 0.4, 0.5, NAN, NAN, -0.3, -0.2, -0.2, 0.4);
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
@@ -3024,7 +3339,51 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-50
+    // Test: RE-RUB-65
+    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.7, 0.7, 0.8, NAN, NAN, NAN, NAN);
+    SetHeight(sim_out, 10, 15, -0.3, 0.4, 0.5, NAN, NAN, -0.3, -0.2, -0.2, 0.4);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.7, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.1);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, -0.2, grid, bucket);
+    PushBodySoilPos(sim_out, 2, 10, 15, pos2, 0.6);
+    posA = soil_simulator::CalcBucketFramePos(10, 15, 0.5, grid, bucket);
+    soil_simulator::RelaxUnstableBodyCell(
+        sim_out, 34, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
+        1e-5);
+    CheckHeight(sim_out, 10, 14, -0.2, 0.0, 0.0, NAN, NAN);
+    CheckHeight(sim_out, 10, 15, -0.3, 0.5, 0.6, -0.2, 0.4);
+    CheckBodySoilPos((*body_soil_pos)[0], 0, 10, 15, posA, 0.1);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
+    EXPECT_EQ(body_soil_pos->size(), 1);
+    ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
+    body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
+
+    // Test: RE-RUB-66
+    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.9, NAN, NAN, NAN, NAN);
+    SetHeight(sim_out, 10, 15, -0.3, 0.4, 0.5, NAN, NAN, -0.3, -0.2, -0.2, 0.4);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.1);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.8);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, -0.2, grid, bucket);
+    PushBodySoilPos(sim_out, 2, 10, 15, pos2, 0.6);
+    posA = soil_simulator::CalcBucketFramePos(10, 15, 0.5, grid, bucket);
+    soil_simulator::RelaxUnstableBodyCell(
+        sim_out, 34, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
+        1e-5);
+    CheckHeight(sim_out, 10, 14, -0.2, 0.0, 0.8, NAN, NAN);
+    CheckHeight(sim_out, 10, 15, -0.3, 0.5, 0.6, -0.2, 0.4);
+    CheckBodySoilPos((*body_soil_pos)[0], 0, 10, 15, posA, 0.1);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.8, 1.e-5);
+    EXPECT_EQ(body_soil_pos->size(), 1);
+    ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
+    body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
+
+    // Test: RE-RUB-67
     SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.8, NAN, NAN, NAN, NAN);
     SetHeight(sim_out, 10, 15, -0.3, 0.4, 0.5, 0.5, 0.6, -0.3, -0.2, -0.2, 0.4);
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
@@ -3046,24 +3405,51 @@ TEST(UnitTestRelax, RelaxUnstableBodyCell) {
         {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
     body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
-    // Test: RE-RUB-51
-    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 0.5, NAN, NAN, NAN, NAN);
-    SetHeight(sim_out, 10, 15, 0.0, NAN, NAN, NAN, NAN, 0.2, 0.3, 0.3, 0.7);
+    // Test: RE-RUB-68
+    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.7, 0.7, 0.8, NAN, NAN, NAN, NAN);
+    SetHeight(sim_out, 10, 15, -0.3, 0.4, 0.5, 0.5, 0.6, -0.3, -0.2, -0.2, 0.4);
     pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
-    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.5);
-    pos2 = soil_simulator::CalcBucketFramePos(10, 15, 0.3, grid, bucket);
-    PushBodySoilPos(sim_out, 2, 10, 15, pos2, 0.4);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.1);
+    posA = soil_simulator::CalcBucketFramePos(10, 15, 0.5, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 15, posA, 0.1);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, -0.2, grid, bucket);
+    PushBodySoilPos(sim_out, 2, 10, 15, pos2, 0.6);
     soil_simulator::RelaxUnstableBodyCell(
-        sim_out, 20, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
+        sim_out, 33, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
         1e-5);
-    CheckHeight(sim_out, 10, 14, -0.2, 0.0, 0.3, NAN, NAN);
-    CheckHeight(sim_out, 10, 15, 0.2, NAN, NAN, 0.3, 0.7);
-    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.3, 1.e-5);
-    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.4, 1.e-5);
-    EXPECT_EQ(body_soil_pos->size(), 0);
+    CheckHeight(sim_out, 10, 14, -0.2, 0.0, 0.0, NAN, NAN);
+    CheckHeight(sim_out, 10, 15, -0.3, 0.5, 0.7, -0.2, 0.4);
+    CheckBodySoilPos((*body_soil_pos)[0], 0, 10, 15, posA, 0.1);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
+    EXPECT_EQ(body_soil_pos->size(), 1);
     ResetValueAndTest(
-        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {2, 10, 15}},
-        {{0, 10, 14}, {2, 10, 15}});
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
+    body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
+
+    // Test: RE-RUB-69
+    SetHeight(sim_out, 10, 14, -0.2, -0.2, 0.0, 0.0, 1.0, NAN, NAN, NAN, NAN);
+    SetHeight(sim_out, 10, 15, -0.3, 0.4, 0.5, 0.5, 0.6, -0.3, -0.2, -0.2, 0.4);
+    pos0 = soil_simulator::CalcBucketFramePos(10, 14, 0.0, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.1);
+    PushBodySoilPos(sim_out, 0, 10, 14, pos0, 0.9);
+    posA = soil_simulator::CalcBucketFramePos(10, 15, 0.5, grid, bucket);
+    PushBodySoilPos(sim_out, 0, 10, 15, posA, 0.1);
+    pos2 = soil_simulator::CalcBucketFramePos(10, 15, -0.2, grid, bucket);
+    PushBodySoilPos(sim_out, 2, 10, 15, pos2, 0.6);
+    soil_simulator::RelaxUnstableBodyCell(
+        sim_out, 33, body_soil_pos, 0.1, 0, 10, 14, 0, 10, 15, grid, bucket,
+        1e-5);
+    CheckHeight(sim_out, 10, 14, -0.2, 0.0, 0.9, NAN, NAN);
+    CheckHeight(sim_out, 10, 15, -0.3, 0.5, 0.7, -0.2, 0.4);
+    CheckBodySoilPos((*body_soil_pos)[0], 0, 10, 15, posA, 0.1);
+    EXPECT_NEAR(sim_out->body_soil_pos_[0].h_soil, 0.0, 1.e-5);
+    EXPECT_NEAR(sim_out->body_soil_pos_[1].h_soil, 0.9, 1.e-5);
+    EXPECT_EQ(body_soil_pos->size(), 1);
+    ResetValueAndTest(
+        sim_out, {{10, 14}, {10, 15}}, {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}},
+        {{0, 10, 14}, {0, 10, 15}, {2, 10, 15}});
+    body_soil_pos->erase(body_soil_pos->begin(), body_soil_pos->end());
 
     delete bucket;
     delete sim_out;


### PR DESCRIPTION
# Description
- Improved descriptions of unit tests
- Added missing unit tests for the `RelaxUnstableBodyCell` function
- Refactored unit tests for the  `RelaxUnstableBodyCell` function