### PR TITLE
Bugfix: Improved CheckVolume function to avoid false negative

### DIFF
--- a/soil_simulator/soil_dynamics.cpp
+++ b/soil_simulator/soil_dynamics.cpp
@@ -114,6 +114,7 @@ bool soil_simulator::SoilDynamics::Step(
         // Relaxing the soil resting on the body
         RelaxBodySoil(sim_out, grid, body, sim_param, tol);
     }
+
     return true;
 }
 template bool soil_simulator::SoilDynamics::Step(
@@ -124,7 +125,7 @@ template bool soil_simulator::SoilDynamics::Step(
     Grid grid, Blade* body, SimParam sim_param, float tol);
 
 void soil_simulator::SoilDynamics::Check(
-    SimOut* sim_out, float init_volume, Grid grid, float tol
+    SimOut* sim_out, int init_volume, Grid grid, float tol
 ) {
     // Checking mass conservation
     soil_simulator::CheckVolume(sim_out, init_volume, grid, tol);

--- a/soil_simulator/soil_dynamics.hpp
+++ b/soil_simulator/soil_dynamics.hpp
@@ -46,11 +46,11 @@ class SoilDynamics {
      /// \brief Check the validity of the simulation outputs.
      ///
      /// \param sim_out: Class that stores simulation outputs.
-     /// \param init_volume: Initial volume of soil in the terrain. [m^3]
+     /// \param init_volume: Initial number of soil cells.
      /// \param grid: Class that stores information related to the
      ///              simulation grid.
      /// \param tol: Small number used to handle numerical approximation errors.
-     void Check(SimOut* sim_out, float init_volume, Grid grid, float tol);
+     void Check(SimOut* sim_out, int init_volume, Grid grid, float tol);
 
      /// \brief Write the simulation outputs into files.
      ///

--- a/soil_simulator/utils.hpp
+++ b/soil_simulator/utils.hpp
@@ -102,12 +102,12 @@ std::vector<float> MultiplyQuaternion(
 ///        the content of `body_soil_pos_` and `body_soil_` is consistent.
 ///
 /// \param sim_out: Class that stores simulation outputs.
-/// \param init_volume: Initial volume of soil in the terrain. [m^3]
+/// \param init_volume: Initial number of soil cells.
 /// \param grid: Class that stores information related to the simulation grid.
 /// \param tol: Small number used to handle numerical approximation errors.
 ///
 /// \return Boolean indicating whether soil is conserved or not.
-bool CheckVolume(SimOut* sim_out, float init_volume, Grid grid, float tol);
+bool CheckVolume(SimOut* sim_out, int init_volume, Grid grid, float tol);
 
 /// \brief This function checks that all the simulation outputs follow the
 ///        conventions of the simulator.

--- a/test/example/soil_evolution.cpp
+++ b/test/example/soil_evolution.cpp
@@ -305,12 +305,12 @@ void soil_simulator::SoilEvolution(
     // Initializing the terrain
     sim.Init(sim_out, grid, 32.0);
 
-    float init_volume = 0.0;
+    int init_volume = 0;
     if (check_outputs) {
         for (auto ii = 0; ii < sim_out->terrain_.size(); ii++)
             for (auto jj = 0; jj < sim_out->terrain_[0].size(); jj++)
-                init_volume += sim_out->terrain_[ii][jj];
-        init_volume = grid.cell_area_ * init_volume;
+                init_volume += round(
+                    sim_out->terrain_[ii][jj] / grid.cell_size_z_);
     }
 
     // Simulation loop

--- a/test/unit_tests/test_utils.cpp
+++ b/test/unit_tests/test_utils.cpp
@@ -404,7 +404,7 @@ TEST(UnitTestUtils, CheckVolume) {
     soil_simulator::SimOut *sim_out = new soil_simulator::SimOut(grid);
 
     // Declaring variables
-    float init_volume;
+    int init_volume;
     std::string warning_msg;
     std::string exp_msg;
     size_t string_loc;
@@ -421,33 +421,32 @@ TEST(UnitTestUtils, CheckVolume) {
 
     // Test: UT-CV-1
     exp_msg = "Volume is not conserved!";
-    EXPECT_TRUE(soil_simulator::CheckVolume(sim_out, 0.0, grid, 1e-5));
-    CheckVolumeWarning(1.0);
-    CheckVolumeWarning(-0.6 * grid.cell_volume_);
-    CheckVolumeWarning(0.6 * grid.cell_volume_);
+    EXPECT_TRUE(soil_simulator::CheckVolume(sim_out, 0, grid, 1e-5));
+    CheckVolumeWarning(1);
+    CheckVolumeWarning(-1);
 
     // Test: UT-CV-2
     exp_msg = "Volume is not conserved!";
     sim_out->terrain_[1][2] = 0.2;
-    init_volume =  0.2 * grid.cell_area_;
+    init_volume =  round(0.2 / grid.cell_size_z_);
     EXPECT_TRUE(soil_simulator::CheckVolume(sim_out, init_volume, grid, 1e-5));
-    CheckVolumeWarning(0.0);
-    CheckVolumeWarning(init_volume - 0.6 * grid.cell_volume_);
-    CheckVolumeWarning(init_volume + 0.6 * grid.cell_volume_);
+    CheckVolumeWarning(0);
+    CheckVolumeWarning(init_volume - 1);
+    CheckVolumeWarning(init_volume + 1);
+    sim_out->terrain_[1][2] = 0.0;
 
     // Test: UT-CV-3
     exp_msg = "Volume is not conserved!";
-    sim_out->terrain_[1][2] = 0.0;
-    SetHeight(sim_out, 1, 1, NAN, NAN, NAN, 0.0, 0.08, NAN, NAN, NAN, NAN);
-    SetHeight(sim_out, 2, 1, NAN, NAN, NAN, NAN, NAN, NAN, NAN, 0.0, 0.15);
-    SetHeight(sim_out, 2, 2, NAN, NAN, NAN, -0.1, 0.0, NAN, NAN, 0.2, 0.27);
-    PushBodySoilPos(sim_out, 0, 1, 1, {0.0, 0.0, 0.0}, 0.08);
-    PushBodySoilPos(sim_out, 2, 2, 1, {0.0, 0.0, 0.0}, 0.15);
+    SetHeight(sim_out, 1, 1, NAN, NAN, NAN, 0.0, 0.1, NAN, NAN, NAN, NAN);
+    SetHeight(sim_out, 2, 1, NAN, NAN, NAN, NAN, NAN, NAN, NAN, 0.0, 0.2);
+    SetHeight(sim_out, 2, 2, NAN, NAN, NAN, -0.1, 0.0, NAN, NAN, 0.2, 0.3);
+    PushBodySoilPos(sim_out, 0, 1, 1, {0.0, 0.0, 0.0}, 0.1);
+    PushBodySoilPos(sim_out, 2, 2, 1, {0.0, 0.0, 0.0}, 0.2);
     PushBodySoilPos(sim_out, 0, 2, 2, {0.0, 0.0, 0.0}, 0.1);
-    PushBodySoilPos(sim_out, 2, 2, 2, {0.0, 0.0, 0.0}, 0.07);
-    init_volume =  0.4 * grid.cell_area_;
+    PushBodySoilPos(sim_out, 2, 2, 2, {0.0, 0.0, 0.0}, 0.1);
+    init_volume = round(0.5 / grid.cell_size_z_);
     EXPECT_TRUE(soil_simulator::CheckVolume(sim_out, init_volume, grid, 1e-5));
-    CheckVolumeWarning(0.0);
+    CheckVolumeWarning(0);
 
     // Test: UT-CV-4
     exp_msg = "Volume of soil in body_soil_pos_ is not consistent";
@@ -457,8 +456,6 @@ TEST(UnitTestUtils, CheckVolume) {
     PushBodySoilPos(sim_out, 0, 2, 2, {0.0, 0.0, 0.0}, 0.05);
     CheckVolumeWarning(init_volume);
     sim_out->body_soil_[1][2][2] = 0.05;
-    init_volume += 0.05 * grid.cell_area_;
-    EXPECT_TRUE(soil_simulator::CheckVolume(sim_out, init_volume, grid, 1e-5));
     PushBodySoilPos(sim_out, 0, 5, 5, {0.0, 0.0, 0.0}, 0.05);
     CheckVolumeWarning(init_volume);
 


### PR DESCRIPTION
# Description
- Changed the `CheckVolume` function to count number of soil cells instead of soil volume. This is to avoid false negative due to accumulating floating number error
- Changed the unit tests accordingly