### PR TITLE
Bugfix: all tags are not fetched during CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Get all git tags
-        run: git fetch --all
+        run: git fetch --prune --unshallow --tags
 
       - name: Setup Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
# Description
- Changed command to fetch tags in CI

# Note
This branch will be tested during PR.
The issue is that versioned documentation does not work as some tags are not detected.